### PR TITLE
refactor: bind SharedMaterialManager directly to setup request event …

### DIFF
--- a/client/src/core/SteamBrickAndMortarApp.ts
+++ b/client/src/core/SteamBrickAndMortarApp.ts
@@ -31,7 +31,6 @@ import type { AppConfig as DIAppConfig } from './di'
 import { StartupEventTracker, StartupPhase } from '../utils/StartupEventTracker'
 import { RenderLoopDiagnostics } from '../debug/RenderLoopDiagnostics'
 import { Logger, LogLevel } from '../utils/Logger'
-import { SharedMaterialManager } from '../utils/SharedMaterialManager'
 // Side-effect import: registers GpuMemoryEstimator to window for console debugging
 import '../debug/GpuMemoryEstimator'
 
@@ -183,13 +182,6 @@ export class SteamBrickAndMortarApp {
             await this.container.initialize()
             this.startupTracker.phaseEnd(StartupPhase.DIContainerSetup)
 
-            // Kick off procedural material pre-warming in parallel with coordinator resolution.
-            // Fire-and-forget — the scene setup pipeline is async enough that materials
-            // will be ready by the time shelves are actually built. Swallow errors gracefully
-            // (worst case: getMaterial() returns flat-colour fallback).
-            SharedMaterialManager.getInstance().prewarm().catch(err => {
-                console.warn('Material prewarm failed, using sync fallback:', err)
-            })
 
             this.startupTracker.phaseStart(StartupPhase.CoordinatorResolution, 'Resolving coordinators from DI')
             

--- a/client/src/utils/SharedMaterialManager.ts
+++ b/client/src/utils/SharedMaterialManager.ts
@@ -16,6 +16,8 @@ import * as THREE from 'three'
 import { MaterialUtils } from './MaterialUtils'
 import { Logger } from './Logger'
 import { ProceduralTextureWorker } from './textures/ProceduralTextureWorker'
+import { EventManager } from '../core/EventManager'
+import { StorePropsEventTypes } from '../scene/props/PropsEvents'
 
 export enum MaterialType {
     FallbackGameBox = 'fallbackGameBox',
@@ -51,6 +53,11 @@ export class SharedMaterialManager {
 
     private constructor() {
         // Lightweight — no sync texture generation here.
+
+        EventManager.getInstance().registerDefaultHandler(
+            StorePropsEventTypes.SetupRequest,
+            this.prewarm.bind(this)
+        )
     }
 
     public static getInstance(): SharedMaterialManager {
@@ -79,34 +86,37 @@ export class SharedMaterialManager {
      * Pre-warm all procedurally-generated materials off the main thread.
      * Call once at startup. Subsequent calls return the same Promise (idempotent).
      */
-    public async prewarm(): Promise<void> {
+﻿    public prewarm(): Promise<void> {
+        if (this.disposed) return Promise.resolve()
         if (this.prewarmPromise) return this.prewarmPromise
-        this.prewarmPromise = this.doPrewarm()
+
+        this.prewarmPromise = (async () => {
+            if (!this.materialPool) this.initialize()
+            const worker = ProceduralTextureWorker.getInstance()
+            const t0 = performance.now()
+            SharedMaterialManager.logger.debug('🚀 Starting off-thread material prewarm...')
+
+            await Promise.all([
+                this.prewarmMDFVeneer(worker),
+                this.prewarmCarpet(worker),
+                this.prewarmCeiling(worker),
+                this.prewarmWallWood(worker),
+                this.prewarmBasicWood(worker),
+            ])
+
+            SharedMaterialManager.logger.debug(
+                `✨ Material prewarm complete in ms`
+            )
+        })().catch(err => {
+            SharedMaterialManager.logger.warn('Material prewarm failed, continuing with fallback materials:', err)
+        })
+
         return this.prewarmPromise
     }
 
-    private async doPrewarm(): Promise<void> {
-        if (!this.materialPool) this.initialize()
-        const worker = ProceduralTextureWorker.getInstance()
-        const t0 = performance.now()
-        SharedMaterialManager.logger.debug('🎨 Starting off-thread material prewarm...')
 
-        await Promise.all([
-            this.prewarmMDFVeneer(worker),
-            this.prewarmCarpet(worker),
-            this.prewarmCeiling(worker),
-            this.prewarmWallWood(worker),
-            this.prewarmBasicWood(worker),
-        ])
+    // --- Public API ----------------------------------------------------------
 
-        SharedMaterialManager.logger.debug(
-            `✅ Material prewarm complete in ${(performance.now() - t0).toFixed(0)}ms`
-        )
-    }
-
-    // ─── Public API ──────────────────────────────────────────────────────────
-
-    /** Returns a material from cache (instant), or creates it synchronously as fallback. */
     public getMaterial(type: MaterialType): THREE.MeshStandardMaterial {
         if (!this.materialPool) this.initialize()
 

--- a/client/src/utils/textures/procedural-texture.worker.ts
+++ b/client/src/utils/textures/procedural-texture.worker.ts
@@ -99,11 +99,13 @@ function octaveNoise(x: number, y: number, octaves: number, persistence: number,
     return total / maxValue
 }
 
-function woodGrain(offsetX: number, offsetY: number, ringFrequency: number, grainStrength: number): number {
-    const dist = Math.sqrt(offsetX * offsetX + offsetY * offsetY)
-    const rings = Math.sin(dist * ringFrequency * Math.PI * 2) * 0.5 + 0.5
-    const grain = noise2D(offsetX * 0.02, offsetY * 0.02) * grainStrength
-    return Math.max(0, Math.min(1, rings + grain))
+function woodGrainLinear(x: number, y: number, ringFrequency: number, grainStrength: number): number {
+    // Lumber-like longitudinal grain: dominant variation across Y, subtle drift across X.
+    // This avoids tree-ring cross-section appearance (radial circles).
+    const baseLines = Math.sin(y * ringFrequency) * 0.5 + 0.5
+    const alongGrainVariation = octaveNoise(x * 0.01, y * 0.05, 2, 0.3, 1) * 0.2
+    const fineCrossGrain = octaveNoise(x * 0.08, y * 0.02, 3, 0.4, 1) * grainStrength
+    return Math.max(0, Math.min(1, baseLines + alongGrainVariation + fineCrossGrain))
 }
 
 function carpetFiber(x: number, y: number, fiberDensity: number): number {
@@ -132,13 +134,10 @@ function paintWoodEnhanced(data: Uint8ClampedArray, width: number, height: numbe
     const rgb1 = hexToRgb(color1)
     const rgb2 = hexToRgb(color2)
     const rgb3 = hexToRgb(color3)
-    const centerX = width / 2
-    const centerY = height / 2
-
     for (let y = 0; y < height; y++) {
         for (let x = 0; x < width; x++) {
             const i = (y * width + x) * 4
-            const gv = woodGrain(x - centerX, y - centerY, ringFrequency, grainStrength)
+            const gv = woodGrainLinear(x, y, ringFrequency, grainStrength)
             const c1 = octaveNoise(x * 0.03, y * 0.03, 3, 0.5, 1) * 0.12
             const c2 = octaveNoise(x * 0.08, y * 0.08, 4, 0.4, 1) * 0.08
             const c3 = octaveNoise(x * 0.15, y * 0.15, 2, 0.3, 1) * 0.05


### PR DESCRIPTION
…without handleSetupRequest wrapper

- simplifies the callback by binding 	his.prewarm.bind(this) directly to the SetupRequest event
- removes the extraneous handleSetupRequest wrapper function
- internalizes catch handling directly into the prewarm() promise chain so callers/subscribers don't need to handle it
- removes doPrewarm separation so there is only one consolidated prewarm method returning the Promise