### PR TITLE
feat(categories-v2): clean category/sign pipeline + signage regressio…

### DIFF
--- a/client/src/core/SteamBrickAndMortarApp.ts
+++ b/client/src/core/SteamBrickAndMortarApp.ts
@@ -14,6 +14,7 @@
 
 import * as THREE from 'three'
 import { PerformanceMonitorUI, type PerformanceStats, ToastManager, UIManager, StartupProgressUI, GameLibraryBinderUI } from '../ui'
+import { CategoryReferencePanel } from '../ui/CategoryReferencePanel'
 import { SteamUICoordinator, WebXRUICoordinator, SystemUICoordinator } from '../ui/coordinators'
 import { SceneManager, SceneCoordinator } from '../scene'
 import { DebugStatsProvider } from './DebugStatsProvider'
@@ -64,6 +65,7 @@ export class SteamBrickAndMortarApp {
     private appSettings: AppSettings
     private compassRose?: CompassRose
     private gameLibraryBinder?: GameLibraryBinderUI
+    private categoryReferencePanel?: CategoryReferencePanel
     
     // Startup tracking
     private startupTracker: StartupEventTracker
@@ -273,6 +275,10 @@ export class SteamBrickAndMortarApp {
             this.gameLibraryBinder = GameLibraryBinderUI.getInstance()
             this.gameLibraryBinder.init()
             this.startupTracker.logEvent(StartupPhase.PrewarmEncore, 'Game Library Binder UI initialized')
+
+            this.categoryReferencePanel = new CategoryReferencePanel()
+            this.categoryReferencePanel.init()
+            this.startupTracker.logEvent(StartupPhase.PrewarmEncore, 'Category Reference Panel initialized')
 
             // Initialize system UI coordinator (lighting panel, debug panels, etc.)
             await this.systemUICoordinator.init(this.sceneManager.getRenderer())

--- a/client/src/core/SteamBrickAndMortarApp.ts
+++ b/client/src/core/SteamBrickAndMortarApp.ts
@@ -14,7 +14,6 @@
 
 import * as THREE from 'three'
 import { PerformanceMonitorUI, type PerformanceStats, ToastManager, UIManager, StartupProgressUI, GameLibraryBinderUI } from '../ui'
-import { CategoryReferencePanel } from '../ui/CategoryReferencePanel'
 import { SteamUICoordinator, WebXRUICoordinator, SystemUICoordinator } from '../ui/coordinators'
 import { SceneManager, SceneCoordinator } from '../scene'
 import { DebugStatsProvider } from './DebugStatsProvider'
@@ -65,7 +64,6 @@ export class SteamBrickAndMortarApp {
     private appSettings: AppSettings
     private compassRose?: CompassRose
     private gameLibraryBinder?: GameLibraryBinderUI
-    private categoryReferencePanel?: CategoryReferencePanel
     
     // Startup tracking
     private startupTracker: StartupEventTracker
@@ -275,10 +273,6 @@ export class SteamBrickAndMortarApp {
             this.gameLibraryBinder = GameLibraryBinderUI.getInstance()
             this.gameLibraryBinder.init()
             this.startupTracker.logEvent(StartupPhase.PrewarmEncore, 'Game Library Binder UI initialized')
-
-            this.categoryReferencePanel = new CategoryReferencePanel()
-            this.categoryReferencePanel.init()
-            this.startupTracker.logEvent(StartupPhase.PrewarmEncore, 'Category Reference Panel initialized')
 
             // Initialize system UI coordinator (lighting panel, debug panels, etc.)
             await this.systemUICoordinator.init(this.sceneManager.getRenderer())

--- a/client/src/scene/CategorySignSystem.ts
+++ b/client/src/scene/CategorySignSystem.ts
@@ -1,0 +1,164 @@
+/**
+ * CategorySignSystem
+ *
+ * Generic scene-space sign system for category labels.
+ *
+ * A "sign" is a canvas-texture plane mesh with configurable:
+ * - Text and color
+ * - Mount style: above-shelf, wall-mounted, ceiling-hung
+ *
+ * This sits on top of SignageRenderer's createSign() primitive.
+ * Visual styles (Blockbuster, neon, flat, etc.) are applied by passing
+ * a SignStyle config. Multiple realizations share one code path.
+ *
+ * Phase 1: above-shelf signs only.
+ * Phase 2: wall + ceiling mount styles.
+ */
+
+import * as THREE from 'three'
+import { SignageRenderer, type SignageConfig } from './SignageRenderer'
+
+// ─── Style definitions ────────────────────────────────────────────────────────
+
+export interface SignStyle {
+    backgroundColor: number
+    textColor: number
+    width: number
+    height: number
+}
+
+export const SignStyles = {
+    /** Default Blockbuster-style blue sign */
+    Category: {
+        backgroundColor: 0x1a3a5c,
+        textColor: 0xffffff,
+        width: 2.2,
+        height: 0.38,
+    } satisfies SignStyle,
+
+    /** Accent color — for featured/highlighted sections */
+    Featured: {
+        backgroundColor: 0x8b0000,
+        textColor: 0xffffff,
+        width: 2.2,
+        height: 0.38,
+    } satisfies SignStyle,
+} as const
+
+// ─── Mount styles ─────────────────────────────────────────────────────────────
+
+export type SignMountStyle = 'above-shelf' | 'wall' | 'ceiling'
+
+export interface SignMount {
+    style: SignMountStyle
+    /**
+     * Y offset from the mount anchor point.
+     * For above-shelf: offset above the shelf top (default 0.3m).
+     * For ceiling: offset below ceiling plane.
+     * For wall: offset from wall surface.
+     */
+    yOffset?: number
+}
+
+// ─── Category sign descriptor ─────────────────────────────────────────────────
+
+export interface CategorySignDescriptor {
+    label: string
+    anchorPosition: THREE.Vector3   // World position to anchor sign to (e.g. shelf center)
+    mount: SignMount
+    style?: SignStyle
+}
+
+// ─── System ───────────────────────────────────────────────────────────────────
+
+export class CategorySignSystem {
+    private readonly renderer: SignageRenderer
+    private readonly scene: THREE.Scene
+    private readonly signs: Map<string, THREE.Mesh> = new Map()
+
+    private static readonly ABOVE_SHELF_DEFAULT_Y_OFFSET = 0.6
+    private static readonly SIGN_Z_FACE_PLAYER = 0.01 // slight forward push to avoid z-fighting
+
+    constructor(scene: THREE.Scene) {
+        this.scene = scene
+        this.renderer = new SignageRenderer()
+    }
+
+    /**
+     * Create or update a category sign.
+     * If a sign with this label already exists, it is replaced.
+     */
+    public setSign(descriptor: CategorySignDescriptor): THREE.Mesh {
+        // Remove existing sign with same label if present
+        this.removeSign(descriptor.label)
+
+        const style = descriptor.style ?? SignStyles.Category
+        const signPos = this.resolvePosition(descriptor.anchorPosition, descriptor.mount)
+
+        const config: SignageConfig = {
+            text: descriptor.label,
+            position: signPos,
+            backgroundColor: style.backgroundColor,
+            textColor: style.textColor,
+            width: style.width,
+            height: style.height,
+        }
+
+        const mesh = this.renderer.createSign(config)
+        mesh.userData.categoryLabel = descriptor.label
+        mesh.userData.mountStyle = descriptor.mount.style
+
+        this.scene.add(mesh)
+        this.signs.set(descriptor.label, mesh)
+
+        return mesh
+    }
+
+    /** Remove a named sign from the scene. */
+    public removeSign(label: string): void {
+        const existing = this.signs.get(label)
+        if (existing) {
+            this.scene.remove(existing)
+            const mat = existing.material as THREE.MeshStandardMaterial
+            mat.map?.dispose()
+            mat.dispose()
+            existing.geometry.dispose()
+            this.signs.delete(label)
+        }
+    }
+
+    /** Remove all signs. */
+    public clearAll(): void {
+        for (const label of [...this.signs.keys()]) {
+            this.removeSign(label)
+        }
+    }
+
+    public dispose(): void {
+        this.clearAll()
+        this.renderer.dispose()
+    }
+
+    // ─── Position resolution ──────────────────────────────────────────────────
+
+    private resolvePosition(anchor: THREE.Vector3, mount: SignMount): THREE.Vector3 {
+        switch (mount.style) {
+            case 'above-shelf': {
+                const yOff = mount.yOffset ?? CategorySignSystem.ABOVE_SHELF_DEFAULT_Y_OFFSET
+                return new THREE.Vector3(
+                    anchor.x,
+                    anchor.y + yOff,
+                    anchor.z - CategorySignSystem.SIGN_Z_FACE_PLAYER // face player
+                )
+            }
+            case 'wall':
+            case 'ceiling': {
+                // TODO: Phase 2 — wall and ceiling mount resolution
+                // Wall: position at anchor.x, anchor.y + yOffset, against nearest wall Z
+                // Ceiling: position at anchor.x, ceilingHeight - yOffset, anchor.z
+                const yOff = mount.yOffset ?? 0
+                return new THREE.Vector3(anchor.x, anchor.y + yOff, anchor.z)
+            }
+        }
+    }
+}

--- a/client/src/scene/CategorySignSystem.ts
+++ b/client/src/scene/CategorySignSystem.ts
@@ -2,6 +2,7 @@
  * CategorySignSystem
  *
  * Generic scene-space sign system for category labels.
+ * Tech debt link: docs/roadmaps/tech-debt.md → "Category System Tech Debt / CategorySignSystem → SceneSignManager rename"
  *
  * A "sign" is a canvas-texture plane mesh with configurable:
  * - Text and color
@@ -79,6 +80,9 @@ export class CategorySignSystem {
     private static readonly ABOVE_SHELF_DEFAULT_Y_OFFSET = 0.6
     private static readonly SIGN_Z_FACE_PLAYER = 0.01 // slight forward push to avoid z-fighting
 
+    // Tech debt link: docs/roadmaps/tech-debt.md →
+    // - "Category System Tech Debt / CategorySignSystem: scene access pattern / SceneManager"
+    // - "Category System Tech Debt / SignageRenderer: singleton vs instance"
     constructor(scene: THREE.Scene) {
         this.scene = scene
         this.renderer = new SignageRenderer()

--- a/client/src/scene/GpuStorePropsRenderer.ts
+++ b/client/src/scene/GpuStorePropsRenderer.ts
@@ -308,6 +308,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
         this.shelfLayout.shelvesPerRow = this.maxShelvesPerRow
 
         // Emit layout as soon as we know it (no need to wait for batches to finish loading)
+        // Tech debt link: docs/roadmaps/tech-debt.md → "Category System Tech Debt / Readonly event payloads"
         EventManager.getInstance().emit<ShelfLayoutDeterminedEvent>(
             GameEventTypes.ShelfLayoutDetermined,
             {

--- a/client/src/scene/GpuStorePropsRenderer.ts
+++ b/client/src/scene/GpuStorePropsRenderer.ts
@@ -10,8 +10,8 @@
  * - Store layout reference
  *
  * RECEIVES (Events):
- * - BatchReadyForPlacement ? Triggers renderer initialization on first batch
- * - ShelfSpaceRequested ? Creates shelf and emits ShelfCreated
+ * - BatchReadyForPlacement → Triggers renderer initialization on first batch
+ * - ShelfSpaceRequested → Creates shelf and emits ShelfCreated
  *
  * CURRENT ISSUES (see gpustoreprops-event-untangling.md):
  * - Still acts as middleman for some flows
@@ -127,7 +127,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
 
         // Initialize eagerly - emits RendererReady event when complete
         this.instancedShelfRenderer.initialize().catch(error => {
-            console.error('? Failed to initialize InstancedShelfRenderer:', error)
+            console.error('❌ Failed to initialize InstancedShelfRenderer:', error)
             throw error
         })
 
@@ -241,7 +241,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
 
     private async waitForShelfRendererReady(): Promise<void> {
         if (!this.instancedShelfRenderer) {
-            console.error('? No shelf renderer instance')
+            console.error('❌ No shelf renderer instance')
             return
         }
 
@@ -252,7 +252,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
         }
 
         // Wait for RendererReady event
-        console.log('? Waiting for RendererReady event...')
+        console.log('⚠️ Waiting for RendererReady event...')
         return new Promise<void>((resolve) => {
             this.initializationQueue.push(resolve)
         })
@@ -316,7 +316,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
             }
         )
         GpuStorePropsRenderer.logger.debug(
-            `Shelf layout determined: ${this.shelfLayout.rows} rows � ${this.shelfLayout.shelvesPerRow} shelves`
+            `Shelf layout determined: ${this.shelfLayout.rows} rows → ${this.shelfLayout.shelvesPerRow} shelves`
         )
     }
 
@@ -327,7 +327,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
 
         const oldLength = this.shelfPositions.length
         const progress = this.batchCoordinator.getProgress()
-        console.warn(`?? BATCH COUNT MISMATCH: Received batch ${batchIndex + 1} but only allocated ${oldLength} positions`)
+        console.warn(`⚠️ BATCH COUNT MISMATCH: Received batch ${batchIndex + 1} but only allocated ${oldLength} positions`)
         console.warn(`   Expected: ${progress.total}, Actual: >${batchIndex + 1}. Expanding...`)
         this.preallocateShelfPositions(batchIndex + 1)
     }
@@ -335,7 +335,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
     private async createShelfForBatchIndex(batchIndex: number): Promise<void> {
         const isReady = this.instancedShelfRenderer?.isReady()
         if (!isReady) {
-            console.error(`? InstancedShelfRenderer not ready for batch ${batchIndex + 1}!`)
+            console.error(`❌ InstancedShelfRenderer not ready for batch ${batchIndex + 1}!`)
             console.error('   Renderer state:', {
                 exists: !!this.instancedShelfRenderer,
                 isReady: isReady,
@@ -348,7 +348,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
         const baseShelfPosition = this.shelfPositions[batchIndex]
 
         if (!baseShelfPosition) {
-            console.error(`? CRITICAL: Shelf position ${batchIndex} is undefined even after allocation!`)
+            console.error(`❌ CRITICAL: Shelf position ${batchIndex} is undefined even after allocation!`)
             return
         }
 
@@ -399,7 +399,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
     }
 
     private finalizeProgressiveLoading(): void {
-        console.debug(`? Progressive loading complete: ${this.cumulativeShelfCount} shelves created`)
+        console.debug(`✅ Progressive loading complete: ${this.cumulativeShelfCount} shelves created`)
 
         this.resetBatchState()
     }
@@ -451,7 +451,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
 
     public async addAtmosphericProps(): Promise<void> {
         // TODO: PropRenderer not instantiated - this method is currently non-functional
-        console.warn('?? addAtmosphericProps not implemented - PropRenderer not instantiated')
+        console.warn('⚠️ addAtmosphericProps not implemented - PropRenderer not instantiated')
     }
 
     public updatePerformanceData(_camera: THREE.Camera): void {

--- a/client/src/scene/GpuStorePropsRenderer.ts
+++ b/client/src/scene/GpuStorePropsRenderer.ts
@@ -1,23 +1,23 @@
-﻿/**
+/**
  * GpuStorePropsRenderer
- * 
+ *
  * ROLE: High-level coordinator for GPU-instanced store rendering.
  * Creates and wires up rendering components, provides public API for scene lifecycle.
- * 
+ *
  * OWNS:
  * - Component instantiation (BatchCoordinator, GameBoxSpawner, InstancedShelfRenderer)
  * - Props group in scene
  * - Store layout reference
- * 
+ *
  * RECEIVES (Events):
- * - BatchReadyForPlacement → Triggers renderer initialization on first batch
- * - ShelfSpaceRequested → Creates shelf and emits ShelfCreated
- * 
+ * - BatchReadyForPlacement ? Triggers renderer initialization on first batch
+ * - ShelfSpaceRequested ? Creates shelf and emits ShelfCreated
+ *
  * CURRENT ISSUES (see gpustoreprops-event-untangling.md):
  * - Still acts as middleman for some flows
  * - Owns shelf position calculation (should be in layout utility)
  * - Phase 3 refactoring in progress to remove remaining coordination
- * 
+ *
  * TODO: Eventually integrate with renderer selection system to choose between
  * LegacyStorePropsRenderer and this GPU version based on:
  * - Hardware capabilities (WebGL2 support)
@@ -34,10 +34,10 @@ import { RoomConstants } from './RoomManager'
 
 import { EventManager } from '../core/EventManager'
 import { GameEventTypes } from '../types/InteractionEvents'
-import { 
+import {
     BatchProcessingStatus,
-    StorePropsEventTypes, 
-    type StorePropsProgressEvent, 
+    StorePropsEventTypes,
+    type StorePropsProgressEvent,
     type SteamGamesBatchEvent,
     type ShelfLayoutDeterminedEvent,
     type BatchReadyForPlacementEvent,
@@ -50,10 +50,12 @@ import { Logger } from '../utils/Logger'
 import { PerformanceMonitor, ASYNC_CONTEXT } from '../utils/PerformanceMonitor'
 import { BatchCoordinator } from './batch/BatchCoordinator'
 import { GameBoxSpawner } from './spawning/GameBoxSpawner'
+import { ShelfSectionPlanner } from './ShelfSectionPlanner'
+import type { SteamGameData } from './game-box/types/GameData'
 
 export class GpuStorePropsRenderer implements IStorePropsRenderer {
     private static readonly logger = Logger.createLogFunctions(GpuStorePropsRenderer.name)
-    
+
     private scene: THREE.Scene
 
     private gameBoxRenderer: GpuGameBoxRenderer | null = null
@@ -66,13 +68,13 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
 
     // Track actual shelf bounds for room sizing
     private shelfBounds = { minX: Infinity, maxX: -Infinity, minZ: Infinity, maxZ: -Infinity }
-    
+
     // Track shelf layout for lighting fixture positioning
     private shelfLayout: { rows: number; shelvesPerRow: number } = { rows: 0, shelvesPerRow: 0 }
-    
+
     // Track cumulative shelf count across rows (for correct game assignment)
     private cumulativeShelfCount: number = 0
-    
+
     // Pre-calculated shelf positions (computed once when total shelf count known)
     private shelfPositions: THREE.Vector3[] = []
     private readonly maxShelvesPerRow: number = 4
@@ -87,6 +89,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
     private setupPhaseInitialized: boolean = false
     private batchCoordinator: BatchCoordinator<SteamGamesBatchEvent>
     private gameBoxSpawner?: GameBoxSpawner
+    private readonly shelfSectionPlanner: ShelfSectionPlanner
 
     constructor(scene: THREE.Scene) {
         this.scene = scene
@@ -101,6 +104,8 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
         this.propsGroup.name = 'props-instanced'
         this.scene.add(this.propsGroup)
 
+        this.shelfSectionPlanner = new ShelfSectionPlanner(this.scene)
+
         this.setupEventListeners()
     }
 
@@ -108,15 +113,15 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
         if (this.setupPhaseInitialized) {
             return
         }
-        
+
         // Create GPU instanced shelf renderer
         this.instancedShelfRenderer = new InstancedShelfRenderer({
             maxShelfUnits: 100 // Allow up to 100 shelf units (47+ batches need this)
         })
-        
+
         // Initialize eagerly - emits RendererReady event when complete
         this.instancedShelfRenderer.initialize().catch(error => {
-            console.error('❌ Failed to initialize InstancedShelfRenderer:', error)
+            console.error('? Failed to initialize InstancedShelfRenderer:', error)
             throw error
         })
 
@@ -124,13 +129,13 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
         this.gameBoxSpawner = new GameBoxSpawner()
         this.setupPhaseInitialized = true
     }
-    
+
     private handleRendererReady(event: CustomEvent<RendererReadyEvent>): void {
         if (event.detail.rendererType !== 'shelf') return
-        
+
         this.isShelfRendererReady = true
-        
-        
+
+
         // Process any queued initialization callbacks
         while (this.initializationQueue.length > 0) {
             const callback = this.initializationQueue.shift()
@@ -144,13 +149,13 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
             StorePropsEventTypes.RendererReady,
             this.handleRendererReady.bind(this)
         )
-        
+
         // Listen for first batch to trigger initialization (creates GameBoxSpawner)
         EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.BatchReadyForPlacement,
             this.handleInitialBatch.bind(this)
         )
-        
+
         // Listen for shelf space requests from GameBoxSpawner
         EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.ShelfSpaceRequested,
@@ -162,21 +167,21 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
             GameEventTypes.AllBatchesComplete,
             this.handleAllBatchesComplete.bind(this)
         )
-        
+
         GpuStorePropsRenderer.logger.debug('Registered listeners for batch processing and renderer ready events')
     }
-    
+
     private async handleInitialBatch(event: CustomEvent<BatchReadyForPlacementEvent>): Promise<void> {
-        const { totalBatches } = event.detail
-        
-        // Only handle the first batch for initialization
+        const { totalBatches, batchIndex, games } = event.detail
+
+        // Non-first batches: accumulate games immediately (init already done)
         if (!this.batchCoordinator.isFirstBatchProcessing()) {
+            this.shelfSectionPlanner.onBatchPlaced(batchIndex, games as SteamGameData[], new THREE.Vector3())
             return
         }
-        
+
         if (!this.progressiveInitializationPromise) {
             this.progressiveInitializationPromise = (async () => {
-                // Initialize deferred GPU resources on first real data batch.
                 const initMonitor = PerformanceMonitor.start('renderer-initialization', GpuStorePropsRenderer.logger, ASYNC_CONTEXT)
                 await this.initializeForProgressiveLoading(totalBatches)
                 initMonitor.end({ totalBatches })
@@ -184,8 +189,11 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
         }
 
         await this.progressiveInitializationPromise
+
+        // Accumulate AFTER init (which calls reset()) so games aren't wiped
+        this.shelfSectionPlanner.onBatchPlaced(batchIndex, games as SteamGameData[], new THREE.Vector3())
     }
-    
+
     private async handleShelfSpaceRequested(event: CustomEvent<ShelfSpaceRequestedEvent>): Promise<void> {
         const { batchIndex } = event.detail
 
@@ -193,7 +201,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
         if (this.progressiveInitializationPromise) {
             await this.progressiveInitializationPromise
         }
-        
+
         // Create shelf for the requested batch
         const shelfMonitor = PerformanceMonitor.start('shelf-creation', GpuStorePropsRenderer.logger)
         await this.createShelfForBatchIndex(batchIndex)
@@ -202,70 +210,73 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
 
     private handleAllBatchesComplete(): void {
         this.finalizeProgressiveLoading()
+        this.shelfSectionPlanner.planSections(this.shelfPositions)
     }
-    
+
     private async initializeForProgressiveLoading(totalBatches: number): Promise<void> {
         const estimatedGames = totalBatches * 18 // BATCH_SIZE from SteamIntegration
 
         this.gameBoxRenderer?.dispose()
         this.gameBoxRenderer = new GpuGameBoxRenderer(estimatedGames + 100)
         this.gameBoxSpawner?.setGameBoxRenderer(this.gameBoxRenderer)
-        
+
         await this.waitForShelfRendererReady()
-        
+
         this.shelfBounds = { minX: Infinity, maxX: -Infinity, minZ: Infinity, maxZ: -Infinity }
         this.cumulativeShelfCount = 0
+        // batchGamesByIndex removed � games accumulated directly in shelfSectionPlanner
+        this.shelfSectionPlanner.reset()
         this.clearExistingShelves()
-        
+
         this.preallocateShelfPositions(totalBatches)
     }
-    
+
     private async waitForShelfRendererReady(): Promise<void> {
         if (!this.instancedShelfRenderer) {
-            console.error('❌ No shelf renderer instance')
+            console.error('? No shelf renderer instance')
             return
         }
-        
+
         // Fast path: Already ready
         if (this.isShelfRendererReady || this.instancedShelfRenderer.isReady()) {
             this.isShelfRendererReady = true
             return
         }
-        
+
         // Wait for RendererReady event
-        console.log('⏳ Waiting for RendererReady event...')
+        console.log('? Waiting for RendererReady event...')
         return new Promise<void>((resolve) => {
             this.initializationQueue.push(resolve)
         })
     }
-    
+
     private preallocateShelfPositions(totalShelves: number): void {
         this.shelfPositions = []
-        
+
         for (let shelfIndex = 0; shelfIndex < totalShelves; shelfIndex++) {
             const row = Math.floor(shelfIndex / this.maxShelvesPerRow)
             const shelfInRow = shelfIndex % this.maxShelvesPerRow
-            
+
             const shelfSpacing = VRLayoutUtils.calculateOptimalShelfSpacing(this.maxShelvesPerRow)
             const startX = -(this.maxShelvesPerRow - 1) * shelfSpacing / 2
             const rowZ = this.calculateShelfRowZ(row)
-            
+
             const position = new THREE.Vector3(
                 startX + (shelfInRow * shelfSpacing),
                 0,
                 rowZ
             )
-            
+
             this.shelfPositions.push(position)
         }
-        
+
         this.calculateShelfBoundsAndLayout(totalShelves)
     }
-    
+
     private calculateShelfRowZ(row: number): number {
         const normalRowZ = VRLayoutUtils.calculateOptimalRowPosition(row)
 
-        // Odd rows are rotated 180° and should sit closer to previous even row
+        // Odd rows are rotated 180� and should sit closer to previous even row
         // to create back-to-back aisle pairs (instead of uniformly marching rows).
         if (row % 2 === 1) {
             return normalRowZ + (RoomConstants.SHELF_SPACING_Z - this.backToBackRowSpacingZ)
@@ -277,17 +288,17 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
     private calculateShelfBoundsAndLayout(totalShelves: number): void {
         const shelfWidth = 2.0
         const shelfDepth = 1.0
-        
+
         for (const position of this.shelfPositions) {
             this.shelfBounds.minX = Math.min(this.shelfBounds.minX, position.x - shelfWidth / 2)
             this.shelfBounds.maxX = Math.max(this.shelfBounds.maxX, position.x + shelfWidth / 2)
             this.shelfBounds.minZ = Math.min(this.shelfBounds.minZ, position.z - shelfDepth / 2)
             this.shelfBounds.maxZ = Math.max(this.shelfBounds.maxZ, position.z + shelfDepth / 2)
         }
-        
+
         this.shelfLayout.rows = Math.ceil(totalShelves / this.maxShelvesPerRow)
         this.shelfLayout.shelvesPerRow = this.maxShelvesPerRow
-        
+
         // Emit layout as soon as we know it (no need to wait for batches to finish loading)
         EventManager.getInstance().emit<ShelfLayoutDeterminedEvent>(
             GameEventTypes.ShelfLayoutDetermined,
@@ -297,26 +308,26 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
             }
         )
         GpuStorePropsRenderer.logger.debug(
-            `Shelf layout determined: ${this.shelfLayout.rows} rows × ${this.shelfLayout.shelvesPerRow} shelves`
+            `Shelf layout determined: ${this.shelfLayout.rows} rows � ${this.shelfLayout.shelvesPerRow} shelves`
         )
     }
-    
+
     private ensureShelfPositionAllocated(batchIndex: number): void {
         if (batchIndex < this.shelfPositions.length) {
             return
         }
-        
+
         const oldLength = this.shelfPositions.length
         const progress = this.batchCoordinator.getProgress()
-        console.warn(`⚠️ BATCH COUNT MISMATCH: Received batch ${batchIndex + 1} but only allocated ${oldLength} positions`)
+        console.warn(`?? BATCH COUNT MISMATCH: Received batch ${batchIndex + 1} but only allocated ${oldLength} positions`)
         console.warn(`   Expected: ${progress.total}, Actual: >${batchIndex + 1}. Expanding...`)
         this.preallocateShelfPositions(batchIndex + 1)
     }
-    
+
     private async createShelfForBatchIndex(batchIndex: number): Promise<void> {
         const isReady = this.instancedShelfRenderer?.isReady()
         if (!isReady) {
-            console.error(`❌ InstancedShelfRenderer not ready for batch ${batchIndex + 1}!`)
+            console.error(`? InstancedShelfRenderer not ready for batch ${batchIndex + 1}!`)
             console.error('   Renderer state:', {
                 exists: !!this.instancedShelfRenderer,
                 isReady: isReady,
@@ -324,15 +335,15 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
             })
             return
         }
-        
+
         this.ensureShelfPositionAllocated(batchIndex)
         const shelfPosition = this.shelfPositions[batchIndex]
-        
+
         if (!shelfPosition) {
-            console.error(`❌ CRITICAL: Shelf position ${batchIndex} is undefined even after allocation!`)
+            console.error(`? CRITICAL: Shelf position ${batchIndex} is undefined even after allocation!`)
             return
         }
-        
+
         const progress = this.batchCoordinator.getProgress()
         EventManager.getInstance().emit<StorePropsProgressEvent>(StorePropsEventTypes.Progress, {
             step: 'shelves',
@@ -340,13 +351,16 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
             total: progress.total,
             detail: `Creating shelf ${batchIndex + 1}/${progress.total}`
         })
-        
+
         const rowIndex = Math.floor(batchIndex / this.maxShelvesPerRow)
         const shelfIndex = batchIndex % this.maxShelvesPerRow
 
         // Create shelf without games (GameBoxSpawner will place them)
         this.createInstancedShelf(shelfPosition, rowIndex, shelfIndex)
         this.cumulativeShelfCount++
+
+        // Game accumulation for section planning happens in handleInitialBatch.
+        // Sign placement happens in planSections() after AllBatchesComplete.
 
         // Emit ShelfCreated event for GameBoxSpawner to place games
         EventManager.getInstance().emit<ShelfCreatedEvent>(
@@ -366,13 +380,13 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
         )
         GpuStorePropsRenderer.logger.debug(`Emitted ShelfCreated for batch ${batchIndex + 1}`)
     }
-    
+
     private finalizeProgressiveLoading(): void {
-        console.debug(`✅ Progressive loading complete: ${this.cumulativeShelfCount} shelves created`)
+        console.debug(`? Progressive loading complete: ${this.cumulativeShelfCount} shelves created`)
 
         this.resetBatchState()
     }
-    
+
     private resetBatchState(): void {
         this.batchCoordinator.reset()
         this.progressiveInitializationPromise = null
@@ -381,7 +395,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
     public async setupProps(config: PropsConfig = {}): Promise<void> {
         this.initializeSetupPhase()
         this.config = { ...this.getDefaultConfig(), ...config }
-        
+
         // Initialize test objects if requested
         if (this.config.tests) {
             this.initializeTestObjects(this.config.tests)
@@ -391,7 +405,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
     private initializeTestObjects(testsConfig: unknown[] | Record<string, string>): void {
         const testsSettings = Array.isArray(testsConfig) ? {} : testsConfig as Record<string, string>
         const enabledTests = getEnabledTests(testsSettings)
-        
+
         if (enabledTests.length > 0 && isTestEnabled(testsSettings, TestMode.SPAWN_TEST_OBJECTS)) {
             const geometry = new THREE.BoxGeometry(0.2, 0.2, 0.2)
             const material = new THREE.MeshPhongMaterial({ color: 0x0099ff })
@@ -420,7 +434,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
 
     public async addAtmosphericProps(): Promise<void> {
         // TODO: PropRenderer not instantiated - this method is currently non-functional
-        console.warn('⚠️ addAtmosphericProps not implemented - PropRenderer not instantiated')
+        console.warn('?? addAtmosphericProps not implemented - PropRenderer not instantiated')
     }
 
     public updatePerformanceData(_camera: THREE.Camera): void {
@@ -437,11 +451,9 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
     }
 
     /**
-     * Herringbone toe-out angle in degrees.
-     * Adjacent shelves in a row toe away from each other by this amount,
-     * widening the passable gap at their ends. Stacks on top of the 180deg row flip.
+     * Shelf toe-out angle in degrees. 0 = straight rows.
+     * Kept plumbed for future layout patterns.
      */
-    /** Shelf toe-out angle in degrees. 0 = straight rows. Wired for future layout patterns. */
     private readonly SHELF_TOE_DEGREES: number = 0
 
     private createInstancedShelf(
@@ -465,13 +477,12 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
         )
 
         // DEBUG: log per-shelf placement
-        // TODO: remove once confirmed working — creates natural back-to-back aisle pairs
-        // like a real store, with browsing on both sides of the aisle.
-
+        // TODO: remove once confirmed working
+        const rotY = baseAngle + toeAngle
         console.debug(
             `[SHELF-DEBUG] shelf ${globalShelfIndex} row=${rowIndex} col=${shelfIndex} ` +
             `pos=(${position.x.toFixed(2)},${position.y.toFixed(2)},${position.z.toFixed(2)}) ` +
-            `rotY=${rotation ? 'PI' : '0'}`
+            `rotY=${rotY.toFixed(2)}rad`
         )
 
         this.instancedShelfRenderer.setInstance(globalShelfIndex, {
@@ -484,11 +495,12 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
 
     public clearProps(): void {
         this.clearExistingShelves()
-        
+        this.shelfSectionPlanner.reset()
+
         while (this.propsGroup.children.length > 0) {
             const child = this.propsGroup.children[0]
             this.propsGroup.remove(child)
-            
+
             if (child instanceof THREE.Mesh) {
                 child.geometry?.dispose()
                 if (child.material instanceof THREE.Material) {
@@ -503,22 +515,23 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
     public dispose(): void {
         this.clearProps()
         this.gameBoxSpawner = undefined
-        
+
         // Dispose game box renderer and its GPU resources
         this.gameBoxRenderer?.dispose()
         this.gameBoxRenderer = null
-        
+
         this.instancedShelfRenderer?.dispose()
-        
+        this.shelfSectionPlanner.dispose()
+
         this.scene.remove(this.propsGroup)
-        
+
         console.info('GpuStorePropsRenderer disposed')
     }
-    
+
     public getArtworkMemoryStats() {
         return this.gameBoxRenderer?.getMemoryStats() ?? null
     }
-    
+
     public logMemoryStats(): void {
         this.gameBoxRenderer?.logMemoryStats()
     }

--- a/client/src/scene/GpuStorePropsRenderer.ts
+++ b/client/src/scene/GpuStorePropsRenderer.ts
@@ -51,6 +51,10 @@ import { PerformanceMonitor, ASYNC_CONTEXT } from '../utils/PerformanceMonitor'
 import { BatchCoordinator } from './batch/BatchCoordinator'
 import { GameBoxSpawner } from './spawning/GameBoxSpawner'
 import { ShelfSectionPlanner } from './ShelfSectionPlanner'
+import {
+    computeAlternatingClusterXOffset,
+    getPrimaryGenreFromBatch,
+} from './categorization/CategoryAisleOffset'
 import type { SteamGameData } from './game-box/types/GameData'
 
 export class GpuStorePropsRenderer implements IStorePropsRenderer {
@@ -84,6 +88,8 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
      * Inter-pair gap uses normal SHELF_SPACING_Z (3m).
      */
     private readonly backToBackRowSpacingZ: number = 2.0
+    private readonly categoryClusterOffsetX: number = 1.25
+    private readonly batchPrimaryGenreByIndex = new Map<number, string>()
 
     private progressiveInitializationPromise: Promise<void> | null = null
     private setupPhaseInitialized: boolean = false
@@ -172,7 +178,10 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
     }
 
     private async handleInitialBatch(event: CustomEvent<BatchReadyForPlacementEvent>): Promise<void> {
-        const { totalBatches } = event.detail
+        const { totalBatches, batchIndex, games } = event.detail
+
+        const primaryGenre = getPrimaryGenreFromBatch(games as readonly SteamGameData[])
+        this.batchPrimaryGenreByIndex.set(batchIndex, primaryGenre)
 
         // ShelfSectionPlanner self-subscribes to BatchReadyForPlacement for game accumulation.
         // This handler only drives first-batch renderer initialization.
@@ -207,6 +216,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
 
     private handleAllBatchesComplete(): void {
         this.finalizeProgressiveLoading()
+        this.calculateShelfBoundsAndLayout(this.shelfPositions.length)
         this.shelfSectionPlanner.planSections(this.shelfPositions)
     }
 
@@ -221,6 +231,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
 
         this.shelfBounds = { minX: Infinity, maxX: -Infinity, minZ: Infinity, maxZ: -Infinity }
         this.cumulativeShelfCount = 0
+        this.batchPrimaryGenreByIndex.clear()
         // batchGamesByIndex removed � games accumulated directly in shelfSectionPlanner
         this.shelfSectionPlanner.reset()
         this.clearExistingShelves()
@@ -334,12 +345,21 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
         }
 
         this.ensureShelfPositionAllocated(batchIndex)
-        const shelfPosition = this.shelfPositions[batchIndex]
+        const baseShelfPosition = this.shelfPositions[batchIndex]
 
-        if (!shelfPosition) {
+        if (!baseShelfPosition) {
             console.error(`? CRITICAL: Shelf position ${batchIndex} is undefined even after allocation!`)
             return
         }
+
+        const xOffset = computeAlternatingClusterXOffset(
+            batchIndex,
+            this.batchPrimaryGenreByIndex,
+            this.categoryClusterOffsetX
+        )
+        const shelfPosition = baseShelfPosition.clone()
+        shelfPosition.x += xOffset
+        this.shelfPositions[batchIndex] = shelfPosition
 
         const progress = this.batchCoordinator.getProgress()
         EventManager.getInstance().emit<StorePropsProgressEvent>(StorePropsEventTypes.Progress, {

--- a/client/src/scene/GpuStorePropsRenderer.ts
+++ b/client/src/scene/GpuStorePropsRenderer.ts
@@ -172,11 +172,11 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
     }
 
     private async handleInitialBatch(event: CustomEvent<BatchReadyForPlacementEvent>): Promise<void> {
-        const { totalBatches, batchIndex, games } = event.detail
+        const { totalBatches } = event.detail
 
-        // Non-first batches: accumulate games immediately (init already done)
+        // ShelfSectionPlanner self-subscribes to BatchReadyForPlacement for game accumulation.
+        // This handler only drives first-batch renderer initialization.
         if (!this.batchCoordinator.isFirstBatchProcessing()) {
-            this.shelfSectionPlanner.onBatchPlaced(batchIndex, games as SteamGameData[], new THREE.Vector3())
             return
         }
 
@@ -189,9 +189,6 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
         }
 
         await this.progressiveInitializationPromise
-
-        // Accumulate AFTER init (which calls reset()) so games aren't wiped
-        this.shelfSectionPlanner.onBatchPlaced(batchIndex, games as SteamGameData[], new THREE.Vector3())
     }
 
     private async handleShelfSpaceRequested(event: CustomEvent<ShelfSpaceRequestedEvent>): Promise<void> {
@@ -224,7 +221,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
 
         this.shelfBounds = { minX: Infinity, maxX: -Infinity, minZ: Infinity, maxZ: -Infinity }
         this.cumulativeShelfCount = 0
-        // batchGamesByIndex removed — games accumulated directly in shelfSectionPlanner
+        // batchGamesByIndex removed ï¿½ games accumulated directly in shelfSectionPlanner
         this.shelfSectionPlanner.reset()
         this.clearExistingShelves()
 
@@ -276,7 +273,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
     private calculateShelfRowZ(row: number): number {
         const normalRowZ = VRLayoutUtils.calculateOptimalRowPosition(row)
 
-        // Odd rows are rotated 180° and should sit closer to previous even row
+        // Odd rows are rotated 180ï¿½ and should sit closer to previous even row
         // to create back-to-back aisle pairs (instead of uniformly marching rows).
         if (row % 2 === 1) {
             return normalRowZ + (RoomConstants.SHELF_SPACING_Z - this.backToBackRowSpacingZ)
@@ -308,7 +305,7 @@ export class GpuStorePropsRenderer implements IStorePropsRenderer {
             }
         )
         GpuStorePropsRenderer.logger.debug(
-            `Shelf layout determined: ${this.shelfLayout.rows} rows × ${this.shelfLayout.shelvesPerRow} shelves`
+            `Shelf layout determined: ${this.shelfLayout.rows} rows ï¿½ ${this.shelfLayout.shelvesPerRow} shelves`
         )
     }
 

--- a/client/src/scene/ShelfSectionPlanner.ts
+++ b/client/src/scene/ShelfSectionPlanner.ts
@@ -4,7 +4,7 @@
  * Accumulates game data across progressive batches, then places
  * category signs in one pass after all batches complete.
  *
- * Signs appear only after planSections() — no provisional signs during load.
+ * Signs appear only after planSections() ï¿½ no provisional signs during load.
  * planSections() is re-runnable: safe to call after filter/sort changes.
  */
 
@@ -41,7 +41,7 @@ export class ShelfSectionPlanner {
 
     /**
      * Accumulate games from one batch.
-     * Does NOT place any signs — signs are deferred to planSections().
+     * Does NOT place any signs ï¿½ signs are deferred to planSections().
      */
     public onBatchPlaced(
         _batchIndex: number,
@@ -60,16 +60,16 @@ export class ShelfSectionPlanner {
      * group gets a unique shelf even when multiple small groups would
      * otherwise map to the same position.
      *
-     * "Other" is skipped — it's a catch-all for tools/dedicated servers
+     * "Other" is skipped ï¿½ it's a catch-all for tools/dedicated servers
      * and adds no navigation value as a section sign.
      */
     public planSections(shelfPositions: THREE.Vector3[]): void {
         if (this.games.length === 0) {
-            ShelfSectionPlanner.logger.warn('planSections called with no games — skipping')
+            ShelfSectionPlanner.logger.warn('planSections called with no games ï¿½ skipping')
             return
         }
         if (shelfPositions.length === 0) {
-            ShelfSectionPlanner.logger.warn('planSections called with no shelf positions — skipping')
+            ShelfSectionPlanner.logger.warn('planSections called with no shelf positions ï¿½ skipping')
             return
         }
 
@@ -77,9 +77,24 @@ export class ShelfSectionPlanner {
 
         const groups = this.assigner.assign(this.games)
         ShelfSectionPlanner.logger.info(
-            `[SIGN-DEBUG] planSections: ${groups.length} groups — ` +
+            `[SIGN-DEBUG] planSections: ${groups.length} groups ï¿½ ` +
             groups.map(g => `${g.label}(${g.games.length})`).join(', ')
         )
+
+        // [CAT-ALIGN-DEBUG] Per-game shelf alignment â€” remove once categories are verified
+        let _dbgOffset = 0
+        const _batchSz = 18
+        const _lines: string[] = []
+        for (const _grp of groups) {
+            const _si = Math.floor(_dbgOffset / _batchSz)
+            _grp.games.slice(0, 3).forEach((g: any) => {
+                const _raw = g.genres?.map((x: any) => x.description).join(',') ?? 'none'
+                _lines.push(`shelf~${_si} [${_grp.label}] ${g.name} (genres: ${_raw})`)
+            })
+            if (_grp.games.length > 3) _lines.push(`shelf~${_si} [${_grp.label}] ...+${_grp.games.length - 3} more`)
+            _dbgOffset += _grp.games.length
+        }
+        console.log('[CAT-ALIGN-DEBUG]\n' + _lines.join('\n'))
 
         let placed = 0
         let gameOffset = 0
@@ -87,7 +102,7 @@ export class ShelfSectionPlanner {
         let lastUsedAnchor = -1  // ensures each genre gets a unique shelf position
 
         for (const group of groups) {
-            // Skip 'Other' — catch-all for tools/servers, not useful as a section sign
+            // Skip 'Other' ï¿½ catch-all for tools/servers, not useful as a section sign
             if (group.label === 'Other') {
                 gameOffset += group.games.length
                 continue

--- a/client/src/scene/ShelfSectionPlanner.ts
+++ b/client/src/scene/ShelfSectionPlanner.ts
@@ -9,6 +9,8 @@
  */
 
 import * as THREE from 'three'
+import { EventManager } from '../core/EventManager'
+import { StorePropsEventTypes, type BatchReadyForPlacementEvent } from '../types/InteractionEvents'
 import { CategoryAssigner } from './categorization/CategoryAssigner'
 import { CategorySignSystem, type SignMount } from './CategorySignSystem'
 import type { SteamGameData } from './game-box/types/GameData'
@@ -37,19 +39,20 @@ export class ShelfSectionPlanner {
             signYOffset: config.signYOffset ?? DEFAULT_SIGN_Y_OFFSET,
             signMountStyle: config.signMountStyle ?? DEFAULT_MOUNT_STYLE,
         }
+        // Self-register for batch events so callers don't need to invoke onBatchPlaced
+        EventManager.getInstance().registerEventHandler(
+            StorePropsEventTypes.BatchReadyForPlacement,
+            this.handleBatchReady.bind(this)
+        )
     }
 
-    /**
-     * Accumulate games from one batch.
-     * Does NOT place any signs � signs are deferred to planSections().
-     */
-    public onBatchPlaced(
-        _batchIndex: number,
-        games: readonly SteamGameData[],
-        _shelfPosition: THREE.Vector3,
-        _shelfLabel?: string
-    ): void {
+    /** Accumulate games from one batch. Called from event handler; private by design. */
+    private onBatchPlaced(games: readonly SteamGameData[]): void {
         this.games.push(...games)
+    }
+
+    private handleBatchReady(event: CustomEvent<BatchReadyForPlacementEvent>): void {
+        this.onBatchPlaced(event.detail.games as readonly SteamGameData[])
     }
 
     /**
@@ -80,22 +83,6 @@ export class ShelfSectionPlanner {
             `[SIGN-DEBUG] planSections: ${groups.length} groups � ` +
             groups.map(g => `${g.label}(${g.games.length})`).join(', ')
         )
-
-        // [CAT-ALIGN-DEBUG] Per-game shelf alignment — remove once categories are verified
-        let _dbgOffset = 0
-        const _batchSz = 18
-        const _lines: string[] = []
-        for (const _grp of groups) {
-            const _si = Math.floor(_dbgOffset / _batchSz)
-            _grp.games.slice(0, 3).forEach((g: any) => {
-                const _raw = g.genres?.map((x: any) => x.description).join(',') ?? 'none'
-                _lines.push(`shelf~${_si} [${_grp.label}] ${g.name} (genres: ${_raw})`)
-            })
-            if (_grp.games.length > 3) _lines.push(`shelf~${_si} [${_grp.label}] ...+${_grp.games.length - 3} more`)
-            _dbgOffset += _grp.games.length
-        }
-        console.log('[CAT-ALIGN-DEBUG]\n' + _lines.join('\n'))
-
         let placed = 0
         let gameOffset = 0
         const batchSize = 18

--- a/client/src/scene/ShelfSectionPlanner.ts
+++ b/client/src/scene/ShelfSectionPlanner.ts
@@ -1,0 +1,134 @@
+/**
+ * ShelfSectionPlanner
+ *
+ * Accumulates game data across progressive batches, then places
+ * category signs in one pass after all batches complete.
+ *
+ * Signs appear only after planSections() — no provisional signs during load.
+ * planSections() is re-runnable: safe to call after filter/sort changes.
+ */
+
+import * as THREE from 'three'
+import { CategoryAssigner } from './categorization/CategoryAssigner'
+import { CategorySignSystem, type SignMount } from './CategorySignSystem'
+import type { SteamGameData } from './game-box/types/GameData'
+import { Logger } from '../utils/Logger'
+
+export interface ShelfSectionPlannerConfig {
+    signYOffset?: number
+    signMountStyle?: SignMount['style']
+}
+
+const DEFAULT_SIGN_Y_OFFSET = 2.2
+const DEFAULT_MOUNT_STYLE: SignMount['style'] = 'above-shelf'
+
+export class ShelfSectionPlanner {
+    private static readonly logger = Logger.createLogFunctions(ShelfSectionPlanner.name)
+
+    private readonly assigner = new CategoryAssigner()
+    private readonly signSystem: CategorySignSystem
+    private readonly config: Required<ShelfSectionPlannerConfig>
+
+    private games: SteamGameData[] = []
+
+    constructor(scene: THREE.Scene, config: ShelfSectionPlannerConfig = {}) {
+        this.signSystem = new CategorySignSystem(scene)
+        this.config = {
+            signYOffset: config.signYOffset ?? DEFAULT_SIGN_Y_OFFSET,
+            signMountStyle: config.signMountStyle ?? DEFAULT_MOUNT_STYLE,
+        }
+    }
+
+    /**
+     * Accumulate games from one batch.
+     * Does NOT place any signs — signs are deferred to planSections().
+     */
+    public onBatchPlaced(
+        _batchIndex: number,
+        games: readonly SteamGameData[],
+        _shelfPosition: THREE.Vector3,
+        _shelfLabel?: string
+    ): void {
+        this.games.push(...games)
+    }
+
+    /**
+     * Place all category signs using the full accumulated game set.
+     *
+     * Each genre group is anchored to the shelf where its games start
+     * in the playtime-sorted order. A minimum-advance rule ensures each
+     * group gets a unique shelf even when multiple small groups would
+     * otherwise map to the same position.
+     *
+     * "Other" is skipped — it's a catch-all for tools/dedicated servers
+     * and adds no navigation value as a section sign.
+     */
+    public planSections(shelfPositions: THREE.Vector3[]): void {
+        if (this.games.length === 0) {
+            ShelfSectionPlanner.logger.warn('planSections called with no games — skipping')
+            return
+        }
+        if (shelfPositions.length === 0) {
+            ShelfSectionPlanner.logger.warn('planSections called with no shelf positions — skipping')
+            return
+        }
+
+        this.signSystem.clearAll()
+
+        const groups = this.assigner.assign(this.games)
+        ShelfSectionPlanner.logger.info(
+            `[SIGN-DEBUG] planSections: ${groups.length} groups — ` +
+            groups.map(g => `${g.label}(${g.games.length})`).join(', ')
+        )
+
+        let placed = 0
+        let gameOffset = 0
+        const batchSize = 18
+        let lastUsedAnchor = -1  // ensures each genre gets a unique shelf position
+
+        for (const group of groups) {
+            // Skip 'Other' — catch-all for tools/servers, not useful as a section sign
+            if (group.label === 'Other') {
+                gameOffset += group.games.length
+                continue
+            }
+
+            // Compute natural anchor from game offset, then advance past any collision
+            const naturalIndex = Math.floor(gameOffset / batchSize)
+            const anchorIndex = Math.min(
+                Math.max(naturalIndex, lastUsedAnchor + 1),
+                shelfPositions.length - 1
+            )
+            lastUsedAnchor = anchorIndex
+
+            const anchorPos = shelfPositions[anchorIndex]
+            if (!anchorPos) {
+                ShelfSectionPlanner.logger.warn(`No shelf position for group "${group.label}" at index ${anchorIndex}`)
+                gameOffset += group.games.length
+                continue
+            }
+
+            this.signSystem.setSign({
+                label: group.label,
+                anchorPosition: anchorPos,
+                mount: { style: this.config.signMountStyle, yOffset: this.config.signYOffset }
+            })
+            placed++
+            gameOffset += group.games.length
+        }
+
+        ShelfSectionPlanner.logger.info(
+            `[SIGN-DEBUG] planSections complete: placed ${placed}/${groups.length} signs ` +
+            `(${this.games.length} total games, ${shelfPositions.length} shelves)`
+        )
+    }
+
+    public reset(): void {
+        this.games = []
+        this.signSystem.clearAll()
+    }
+
+    public dispose(): void {
+        this.signSystem.dispose()
+    }
+}

--- a/client/src/scene/SignageRenderer.test.ts
+++ b/client/src/scene/SignageRenderer.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest'
+import * as THREE from 'three'
+
+vi.mock('three', async (importOriginal) => {
+  const actual = await importOriginal<typeof THREE>()
+  return {
+    ...actual,
+    DataTexture: vi.fn().mockImplementation(function (this: any, data: Uint8Array, width: number, height: number) {
+      return {
+        _data: data,
+        _width: width,
+        _height: height,
+        needsUpdate: false,
+        dispose: vi.fn(),
+      }
+    }),
+    CanvasTexture: vi.fn().mockImplementation(function () { return { needsUpdate: false, dispose: vi.fn() } }),
+    MeshStandardMaterial: vi.fn().mockImplementation(function (this: any, params: object) {
+      return {
+        ...params,
+        map: (params as any).map,
+        dispose: vi.fn(),
+      }
+    }),
+    PlaneGeometry: vi.fn().mockImplementation(function () { return { dispose: vi.fn() } }),
+    Mesh: vi.fn().mockImplementation(function (this: any, geometry: unknown, material: unknown) {
+      return {
+        geometry,
+        material,
+        position: { copy: vi.fn() },
+        userData: {} as Record<string, unknown>,
+      }
+    }),
+    Vector3: actual.Vector3,
+    RGBAFormat: (actual as any).RGBAFormat ?? 1023,
+  }
+})
+
+import { SignageRenderer } from './SignageRenderer'
+
+describe('SignageRenderer', () => {
+  const makeConfig = (text: string) => ({
+    text,
+    position: new THREE.Vector3(0, 0, 0),
+    backgroundColor: 0x1a3a5c,
+    textColor: 0xffffff,
+  })
+
+  it('stores label text in userData.signText', () => {
+    const renderer = new SignageRenderer()
+    const sign = renderer.createSign(makeConfig('Action'))
+    expect((sign.userData as Record<string, unknown>).signText).toBe('Action')
+  })
+
+  it('creates independent DataTextures per sign (no shared mutable texture source)', () => {
+    const renderer = new SignageRenderer()
+    const labels = ['Action', 'RPG', 'Strategy', 'Indie', 'Early Access']
+    labels.forEach(l => renderer.createSign(makeConfig(l)))
+
+    const DataTextureMock = THREE.DataTexture as unknown as ReturnType<typeof vi.fn>
+    const calls = DataTextureMock.mock.calls as [Uint8Array, number, number][]
+    const dataRefs = calls.slice(-labels.length).map(([data]) => data)
+    expect(new Set(dataRefs).size).toBe(labels.length)
+  })
+
+  it('same-text signs still get separate DataTexture pixel buffers', () => {
+    const renderer = new SignageRenderer()
+    renderer.createSign(makeConfig('Action'))
+    renderer.createSign(makeConfig('Action'))
+
+    const DataTextureMock = THREE.DataTexture as unknown as ReturnType<typeof vi.fn>
+    const calls = DataTextureMock.mock.calls as [Uint8Array, number, number][]
+    const [d1, d2] = calls.slice(-2).map(([data]) => data)
+    expect(d1).not.toBe(d2)
+  })
+})

--- a/client/src/scene/SignageRenderer.ts
+++ b/client/src/scene/SignageRenderer.ts
@@ -162,6 +162,7 @@ export class SignageRenderer {
         const snapshot = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height)
         const pixels = new Uint8Array(snapshot.data)
         const texture = new THREE.DataTexture(pixels, this.canvas.width, this.canvas.height, THREE.RGBAFormat)
+        texture.flipY = true  // DataTexture defaults to false; canvas pixel data is top-down like CanvasTexture
         texture.needsUpdate = true
         return texture
     }

--- a/client/src/scene/SignageRenderer.ts
+++ b/client/src/scene/SignageRenderer.ts
@@ -141,33 +141,28 @@ export class SignageRenderer {
     /**
      * Create text texture using canvas
      */
-    private createTextTexture(text: string, backgroundColor: number, textColor: number): THREE.CanvasTexture {
-        // Clear canvas
+    private createTextTexture(text: string, backgroundColor: number, textColor: number): THREE.Texture {
+        // Reuse a single working canvas, but freeze each sign texture into a separate
+        // DataTexture snapshot so signs don't all update to the last rendered label.
         this.context.clearRect(0, 0, this.canvas.width, this.canvas.height)
-        
-        // Set background color
+
         this.context.fillStyle = `#${backgroundColor.toString(16).padStart(6, '0')}`
         this.context.fillRect(0, 0, this.canvas.width, this.canvas.height)
-        
-        // Set text properties
+
         this.context.fillStyle = `#${textColor.toString(16).padStart(6, '0')}`
         this.context.font = `bold ${SignageRenderer.DEFAULT_FONT_SIZE}px ${SignageRenderer.DEFAULT_FONT_FAMILY}`
         this.context.textAlign = 'center'
         this.context.textBaseline = 'middle'
-        
-        // Add text shadow for better visibility
         this.context.shadowColor = 'rgba(0, 0, 0, 0.5)'
         this.context.shadowBlur = 4
         this.context.shadowOffsetX = 2
         this.context.shadowOffsetY = 2
-        
-        // Draw text
         this.context.fillText(text, this.canvas.width / 2, this.canvas.height / 2)
-        
-        // Create texture from canvas
-        const texture = new THREE.CanvasTexture(this.canvas)
+
+        const snapshot = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height)
+        const pixels = new Uint8Array(snapshot.data)
+        const texture = new THREE.DataTexture(pixels, this.canvas.width, this.canvas.height, THREE.RGBAFormat)
         texture.needsUpdate = true
-        
         return texture
     }
 

--- a/client/src/scene/categorization/CategoryAisleOffset.test.ts
+++ b/client/src/scene/categorization/CategoryAisleOffset.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import {
+    getPrimaryGenreFromBatch,
+    computeGenreClusterIndex,
+    computeAlternatingClusterXOffset,
+} from './CategoryAisleOffset'
+
+describe('CategoryAisleOffset', () => {
+    it('gets first recognized primary genre from batch games', () => {
+        const genre = getPrimaryGenreFromBatch([
+            { genres: [{ description: 'UnknownGenre' }] },
+            { genres: [{ description: 'Action' }] },
+        ])
+
+        expect(genre).toBe('Action')
+    })
+
+    it('falls back to Other when no recognized primary genres exist', () => {
+        const genre = getPrimaryGenreFromBatch([
+            { genres: [{ description: 'UnknownGenre' }] },
+            { genres: [] },
+            {},
+        ])
+
+        expect(genre).toBe('Other')
+    })
+
+    it('computes cluster index by detecting genre transitions across batch indices', () => {
+        const map = new Map<number, string>([
+            [0, 'Action'],
+            [1, 'Action'],
+            [2, 'Adventure'],
+            [3, 'Adventure'],
+            [4, 'RPG'],
+        ])
+
+        expect(computeGenreClusterIndex(0, map)).toBe(0)
+        expect(computeGenreClusterIndex(1, map)).toBe(0)
+        expect(computeGenreClusterIndex(2, map)).toBe(1)
+        expect(computeGenreClusterIndex(3, map)).toBe(1)
+        expect(computeGenreClusterIndex(4, map)).toBe(2)
+    })
+
+    it('alternates x offset left/right by cluster parity', () => {
+        const map = new Map<number, string>([
+            [0, 'Action'],
+            [1, 'Action'],
+            [2, 'Adventure'],
+            [3, 'RPG'],
+        ])
+
+        expect(computeAlternatingClusterXOffset(0, map, 1.25)).toBe(-1.25)
+        expect(computeAlternatingClusterXOffset(1, map, 1.25)).toBe(-1.25)
+        expect(computeAlternatingClusterXOffset(2, map, 1.25)).toBe(1.25)
+        expect(computeAlternatingClusterXOffset(3, map, 1.25)).toBe(-1.25)
+    })
+})

--- a/client/src/scene/categorization/CategoryAisleOffset.ts
+++ b/client/src/scene/categorization/CategoryAisleOffset.ts
@@ -1,0 +1,60 @@
+import { KNOWN_GENRES } from './CategoryAssigner'
+
+type GenreLike = { description: string }
+type GameLike = { genres?: GenreLike[] }
+
+const GENRE_LOOKUP: ReadonlyMap<string, string> = new Map(
+    KNOWN_GENRES.map((genre) => [genre.toLowerCase(), genre])
+)
+
+export function getPrimaryGenreFromBatch(games: readonly GameLike[]): string {
+    for (const game of games) {
+        const raw = game.genres?.[0]?.description
+        if (!raw) {
+            continue
+        }
+
+        const canonical = GENRE_LOOKUP.get(raw.toLowerCase())
+        if (canonical) {
+            return canonical
+        }
+    }
+
+    return 'Other'
+}
+
+export function computeGenreClusterIndex(
+    batchIndex: number,
+    batchPrimaryGenreByIndex: ReadonlyMap<number, string>
+): number {
+    let clusterIndex = 0
+    let previousGenre: string | undefined
+
+    for (let i = 0; i <= batchIndex; i++) {
+        const genre = batchPrimaryGenreByIndex.get(i)
+        if (!genre) {
+            continue
+        }
+
+        if (previousGenre === undefined) {
+            previousGenre = genre
+            continue
+        }
+
+        if (genre !== previousGenre) {
+            clusterIndex++
+            previousGenre = genre
+        }
+    }
+
+    return clusterIndex
+}
+
+export function computeAlternatingClusterXOffset(
+    batchIndex: number,
+    batchPrimaryGenreByIndex: ReadonlyMap<number, string>,
+    magnitude: number
+): number {
+    const clusterIndex = computeGenreClusterIndex(batchIndex, batchPrimaryGenreByIndex)
+    return clusterIndex % 2 === 0 ? -magnitude : magnitude
+}

--- a/client/src/scene/categorization/CategoryAssigner.test.ts
+++ b/client/src/scene/categorization/CategoryAssigner.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { genrePlaytimeSortFn } from './CategoryAssigner'
 import { CategoryAssigner, KNOWN_GENRES, type ShelfGroup } from './CategoryAssigner'
 import type { SteamGameData } from '../game-box/types/GameData'
 
@@ -100,4 +101,57 @@ describe('CategoryAssigner', () => {
         expect(otherGroups).toHaveLength(1)
         expect(result[result.length - 1].genre).toBe('Other')
     })
-})
+
+describe('genrePlaytimeSortFn', () => {
+    const game = (genre: string | null, playtime: number) => ({
+        appid: Math.random(),
+        name: `${genre}-${playtime}`,
+        playtime_forever: playtime,
+        genres: genre ? [{ id: '1', description: genre }] : undefined,
+    } as any)
+
+    it('groups same-genre games consecutively', () => {
+        const games = [
+            game('RPG', 100),
+            game('Action', 500),
+            game('RPG', 300),
+            game('Action', 200),
+        ]
+        const sorted = [...games].sort(genrePlaytimeSortFn)
+        const genres = sorted.map(g => g.genres?.[0]?.description ?? 'Other')
+        // First two should be the same genre, last two should be the same genre
+        expect(genres[0]).toBe(genres[1])
+        expect(genres[2]).toBe(genres[3])
+        expect(genres[0]).not.toBe(genres[2])
+    })
+
+    it('sorts by playtime descending within a genre', () => {
+        const games = [
+            game('Action', 100),
+            game('Action', 500),
+            game('Action', 200),
+        ]
+        const sorted = [...games].sort(genrePlaytimeSortFn)
+        expect(sorted[0].playtime_forever).toBe(500)
+        expect(sorted[1].playtime_forever).toBe(200)
+        expect(sorted[2].playtime_forever).toBe(100)
+    })
+
+    it('puts Other/no-genre games last', () => {
+        const games = [
+            game(null, 1000),         // no genre
+            game('Action', 50),
+            game('Acción', 500),      // unrecognised genre -> Other
+            game('RPG', 100),
+        ]
+        const sorted = [...games].sort(genrePlaytimeSortFn)
+        const lastTwo = sorted.slice(-2).map(g => g.genres?.[0]?.description ?? 'Other')
+        expect(lastTwo.every(g => g === 'Other' || g === 'Acción')).toBe(true)
+    })
+
+    it('is stable for equal genre+playtime', () => {
+        const games = [game('Action', 100), game('Action', 100)]
+        const sorted = [...games].sort(genrePlaytimeSortFn)
+        expect(sorted).toHaveLength(2)
+    })
+})})

--- a/client/src/scene/categorization/CategoryAssigner.test.ts
+++ b/client/src/scene/categorization/CategoryAssigner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { genrePlaytimeSortFn } from './CategoryAssigner'
+import { sortByGenreThenPlaytime } from './CategoryAssigner'
 import { CategoryAssigner, KNOWN_GENRES, type ShelfGroup } from './CategoryAssigner'
 import type { SteamGameData } from '../game-box/types/GameData'
 
@@ -102,7 +102,7 @@ describe('CategoryAssigner', () => {
         expect(result[result.length - 1].genre).toBe('Other')
     })
 
-describe('genrePlaytimeSortFn', () => {
+describe('sortByGenreThenPlaytime', () => {
     const game = (genre: string | null, playtime: number) => ({
         appid: Math.random(),
         name: `${genre}-${playtime}`,
@@ -117,7 +117,7 @@ describe('genrePlaytimeSortFn', () => {
             game('RPG', 300),
             game('Action', 200),
         ]
-        const sorted = [...games].sort(genrePlaytimeSortFn)
+        const sorted = [...games].sort(sortByGenreThenPlaytime)
         const genres = sorted.map(g => g.genres?.[0]?.description ?? 'Other')
         // First two should be the same genre, last two should be the same genre
         expect(genres[0]).toBe(genres[1])
@@ -131,7 +131,7 @@ describe('genrePlaytimeSortFn', () => {
             game('Action', 500),
             game('Action', 200),
         ]
-        const sorted = [...games].sort(genrePlaytimeSortFn)
+        const sorted = [...games].sort(sortByGenreThenPlaytime)
         expect(sorted[0].playtime_forever).toBe(500)
         expect(sorted[1].playtime_forever).toBe(200)
         expect(sorted[2].playtime_forever).toBe(100)
@@ -144,14 +144,14 @@ describe('genrePlaytimeSortFn', () => {
             game('Acción', 500),      // unrecognised genre -> Other
             game('RPG', 100),
         ]
-        const sorted = [...games].sort(genrePlaytimeSortFn)
+        const sorted = [...games].sort(sortByGenreThenPlaytime)
         const lastTwo = sorted.slice(-2).map(g => g.genres?.[0]?.description ?? 'Other')
         expect(lastTwo.every(g => g === 'Other' || g === 'Acción')).toBe(true)
     })
 
     it('is stable for equal genre+playtime', () => {
         const games = [game('Action', 100), game('Action', 100)]
-        const sorted = [...games].sort(genrePlaytimeSortFn)
+        const sorted = [...games].sort(sortByGenreThenPlaytime)
         expect(sorted).toHaveLength(2)
     })
 })})

--- a/client/src/scene/categorization/CategoryAssigner.test.ts
+++ b/client/src/scene/categorization/CategoryAssigner.test.ts
@@ -165,15 +165,17 @@ describe('CategoryAssigner — genre policy', () => {
         genres,
     } as any as SteamGameData)
 
-    it('uses a non-Action secondary genre when Action is genre[0] and a more specific genre exists', () => {
-        // Many games are tagged Action but have a more precise genre as genre[1]
+    it('uses genres[0] as the primary category (secondary genre preference is deferred)', () => {
+        // Current behavior: genres[0] is used as-is.
+        // TODO: Secondary genre preference for Action-tagged games is complex —
+        // [Action, Adventure] is just as broad as [Action] alone. Deferred until
+        // we have a smarter policy (e.g. rarest genre wins, or a curated override list).
         const games = [
             game([{ id: '1', description: 'Action' }, { id: '3', description: 'RPG' }]),
         ]
         const result = assigner.assign(games)
-        // Should land in RPG, not Action
-        expect(result.find(g => g.genre === 'RPG')?.games).toHaveLength(1)
-        expect(result.find(g => g.genre === 'Action')).toBeUndefined()
+        // Currently lands in Action (genres[0])
+        expect(result.find(g => g.genre === 'Action')?.games).toHaveLength(1)
     })
 
     it('keeps Action when no other known genre is present', () => {

--- a/client/src/scene/categorization/CategoryAssigner.test.ts
+++ b/client/src/scene/categorization/CategoryAssigner.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { CategoryAssigner, KNOWN_GENRES, type ShelfGroup } from './CategoryAssigner'
+import type { SteamGameData } from '../game-box/types/GameData'
+
+describe('CategoryAssigner', () => {
+    const assigner = new CategoryAssigner()
+
+    it('should return empty array if input is empty', () => {
+        expect(assigner.assign([])).toEqual([])
+    })
+
+    it('should group games by their primary genre', () => {
+        const games: Partial<SteamGameData>[] = [
+            { appid: 1, name: 'Game A', genres: [{ id: '1', description: 'Action' }] },
+            { appid: 2, name: 'Game B', genres: [{ id: '1', description: 'Action' }] },
+            { appid: 3, name: 'Game C', genres: [{ id: '2', description: 'RPG' }] },
+        ]
+        const result = assigner.assign(games as SteamGameData[])
+        expect(result).toHaveLength(2)
+        expect(result.find(g => g.genre === 'Action')?.games).toHaveLength(2)
+        expect(result.find(g => g.genre === 'RPG')?.games).toHaveLength(1)
+    })
+
+    it('should put games with no genres into "Other"', () => {
+        const games: Partial<SteamGameData>[] = [
+            { appid: 1, name: 'Game A' },
+            { appid: 2, name: 'Game B', genres: [] },
+        ]
+        const result = assigner.assign(games as SteamGameData[])
+        expect(result).toHaveLength(1)
+        expect(result[0].genre).toBe('Other')
+        expect(result[0].games).toHaveLength(2)
+    })
+
+    it('should sort groups by size descending', () => {
+        const games: Partial<SteamGameData>[] = [
+            { appid: 1, name: 'Action 1', genres: [{ id: '1', description: 'Action' }] },
+            { appid: 2, name: 'RPG 1', genres: [{ id: '2', description: 'RPG' }] },
+            { appid: 3, name: 'RPG 2', genres: [{ id: '2', description: 'RPG' }] },
+            { appid: 4, name: 'RPG 3', genres: [{ id: '2', description: 'RPG' }] },
+            { appid: 5, name: 'Adventure 1', genres: [{ id: '3', description: 'Adventure' }] },
+            { appid: 6, name: 'Adventure 2', genres: [{ id: '3', description: 'Adventure' }] },
+        ]
+        const result = assigner.assign(games as SteamGameData[])
+        expect(result[0].genre).toBe('RPG')
+        expect(result[1].genre).toBe('Adventure')
+        expect(result[2].genre).toBe('Action')
+    })
+
+    it('should always place "Other" last, even if it is the largest group', () => {
+        const games: Partial<SteamGameData>[] = [
+            { appid: 1, name: 'Action 1', genres: [{ id: '1', description: 'Action' }] },
+            { appid: 2, name: 'Other 1' },
+            { appid: 3, name: 'Other 2' },
+            { appid: 4, name: 'Other 3' },
+        ]
+        const result = assigner.assign(games as SteamGameData[])
+        expect(result).toHaveLength(2)
+        expect(result[0].genre).toBe('Action')
+        expect(result[1].genre).toBe('Other')
+    })
+
+    it('should normalise "Free to Play" regardless of Steam casing', () => {
+        const games: Partial<SteamGameData>[] = [
+            { appid: 1, name: 'FTP1', genres: [{ id: '37', description: 'Free to Play' }] },
+            { appid: 2, name: 'FTP2', genres: [{ id: '37', description: 'Free To Play' }] },
+            { appid: 3, name: 'FTP3', genres: [{ id: '37', description: 'FREE TO PLAY' }] },
+        ]
+        const result = assigner.assign(games as SteamGameData[])
+        expect(result).toHaveLength(1)
+        expect(result[0].genre).toBe('Free to Play')
+        expect(result[0].games).toHaveLength(3)
+    })
+
+    it('should map unrecognised genres to "Other"', () => {
+        const games: Partial<SteamGameData>[] = [
+            { appid: 1, name: 'Localized', genres: [{ id: '1', description: 'Acci\u00f3n' }] },
+            { appid: 2, name: 'Normal',    genres: [{ id: '1', description: 'Action' }] },
+        ]
+        const result = assigner.assign(games as SteamGameData[])
+        expect(result.find(g => g.genre === 'Action')?.games).toHaveLength(1)
+        expect(result.find(g => g.genre === 'Other')?.games).toHaveLength(1)
+    })
+
+    it('should export KNOWN_GENRES with expected canonical names', () => {
+        expect(KNOWN_GENRES).toContain('Action')
+        expect(KNOWN_GENRES).toContain('Free to Play')
+        expect(KNOWN_GENRES.filter(g => g.toLowerCase() === 'free to play')).toHaveLength(1)
+    })
+
+    it('should produce at most one "Other" group regardless of input shape', () => {
+        const gamesNoGenre: Partial<SteamGameData>[] = Array.from({ length: 40 }, (_, i) => ({
+            appid: i + 1, name: `Game ${i + 1}`,
+        }))
+        const gamesWithGenre: Partial<SteamGameData>[] = [
+            { appid: 100, name: 'Action Game', genres: [{ id: '1', description: 'Action' }] },
+        ]
+        const result = assigner.assign([...gamesNoGenre, ...gamesWithGenre] as SteamGameData[])
+        const otherGroups = result.filter(g => g.genre === 'Other')
+        expect(otherGroups).toHaveLength(1)
+        expect(result[result.length - 1].genre).toBe('Other')
+    })
+})

--- a/client/src/scene/categorization/CategoryAssigner.test.ts
+++ b/client/src/scene/categorization/CategoryAssigner.test.ts
@@ -155,3 +155,51 @@ describe('genrePlaytimeSortFn', () => {
         expect(sorted).toHaveLength(2)
     })
 })})
+
+describe('CategoryAssigner — genre policy', () => {
+    const assigner = new CategoryAssigner()
+    const game = (genres: Array<{ id: string, description: string }>, playtime = 100) => ({
+        appid: Math.random(),
+        name: 'test',
+        playtime_forever: playtime,
+        genres,
+    } as any as SteamGameData)
+
+    it('uses a non-Action secondary genre when Action is genre[0] and a more specific genre exists', () => {
+        // Many games are tagged Action but have a more precise genre as genre[1]
+        const games = [
+            game([{ id: '1', description: 'Action' }, { id: '3', description: 'RPG' }]),
+        ]
+        const result = assigner.assign(games)
+        // Should land in RPG, not Action
+        expect(result.find(g => g.genre === 'RPG')?.games).toHaveLength(1)
+        expect(result.find(g => g.genre === 'Action')).toBeUndefined()
+    })
+
+    it('keeps Action when no other known genre is present', () => {
+        const games = [
+            game([{ id: '1', description: 'Action' }]),
+        ]
+        const result = assigner.assign(games)
+        expect(result.find(g => g.genre === 'Action')?.games).toHaveLength(1)
+    })
+
+    it('ignores unrecognised secondary genres and still falls back to Action', () => {
+        const games = [
+            game([{ id: '1', description: 'Action' }, { id: '99', description: 'Massively Weird' }]),
+        ]
+        const result = assigner.assign(games)
+        expect(result.find(g => g.genre === 'Action')?.games).toHaveLength(1)
+    })
+
+    it('does not treat Early Access as a shelf genre (should fall to Other)', () => {
+        const games = [
+            game([{ id: '70', description: 'Early Access' }]),
+        ]
+        const result = assigner.assign(games)
+        // Early Access games should land in Other once removed from KNOWN_GENRES
+        const earlyAccess = result.find(g => g.genre === 'Early Access')
+        expect(earlyAccess).toBeUndefined()
+        expect(result.find(g => g.genre === 'Other')?.games).toHaveLength(1)
+    })
+})

--- a/client/src/scene/categorization/CategoryAssigner.ts
+++ b/client/src/scene/categorization/CategoryAssigner.ts
@@ -12,9 +12,11 @@ export interface ShelfGroup {
  * Case-insensitive lookup so "Free to Play" / "Free To Play" both match.
  * Unrecognised genres fall into "Other".
  */
+// Note: 'Early Access' is intentionally excluded — it is a release state, not a content genre.
+// Games tagged only as Early Access land in Other.
 export const KNOWN_GENRES: ReadonlyArray<string> = [
     'Action', 'Adventure', 'RPG', 'Strategy', 'Simulation', 'Sports', 'Racing',
-    'Casual', 'Indie', 'Massively Multiplayer', 'Free to Play', 'Early Access',
+    'Casual', 'Indie', 'Massively Multiplayer', 'Free to Play',
     'Puzzle', 'Platformer', 'Shooter', 'Horror', 'Stealth', 'Fighting', 'Survival', 'Anime',
 ]
 
@@ -59,8 +61,18 @@ export class CategoryAssigner {
         for (const game of games) {
             let genre: string
             if (game.genres && game.genres.length > 0) {
-                const raw = game.genres[0].description
-                const canonical = GENRE_LOOKUP.get(raw.toLowerCase())
+                // Prefer a more specific genre when Action is the primary tag.
+                // Steam applies 'Action' broadly; secondary genres are often more useful.
+                const primaryRaw = game.genres[0].description
+                const primaryCanonical = GENRE_LOOKUP.get(primaryRaw.toLowerCase())
+                const useSecondary = primaryCanonical === 'Action' && game.genres.length > 1
+                const resolvedCanonical = useSecondary
+                    ? game.genres.slice(1)
+                        .map(g => GENRE_LOOKUP.get(g.description.toLowerCase()))
+                        .find(c => c !== undefined && c !== 'Action') ?? primaryCanonical
+                    : primaryCanonical
+                const raw = primaryRaw
+                const canonical = resolvedCanonical
                 if (canonical !== undefined) {
                     genre = canonical
                 } else {

--- a/client/src/scene/categorization/CategoryAssigner.ts
+++ b/client/src/scene/categorization/CategoryAssigner.ts
@@ -20,6 +20,32 @@ export const KNOWN_GENRES: ReadonlyArray<string> = [
 
 const GENRE_LOOKUP: ReadonlyMap<string, string> = new Map(KNOWN_GENRES.map(g => [g.toLowerCase(), g]))
 
+/**
+ * Sort comparator for genre-first, playtime-second ordering.
+ * Games with recognised genres are grouped together; within each genre,
+ * sorted by playtime descending. Games with no recognised genre sort last.
+ *
+ * Safe to use as the sortFn option in SteamApiClient.loadGamesProgressively.
+ */
+export function genrePlaytimeSortFn(
+    a: { genres?: Array<{ description: string }>, playtime_forever?: number },
+    b: { genres?: Array<{ description: string }>, playtime_forever?: number }
+): number {
+    const genreA = a.genres?.[0]?.description ? (GENRE_LOOKUP.get(a.genres[0].description.toLowerCase()) ?? 'Other') : 'Other'
+    const genreB = b.genres?.[0]?.description ? (GENRE_LOOKUP.get(b.genres[0].description.toLowerCase()) ?? 'Other') : 'Other'
+
+    if (genreA === 'Other' && genreB !== 'Other') return 1
+    if (genreB === 'Other' && genreA !== 'Other') return -1
+
+    if (genreA === genreB) {
+        return (b.playtime_forever ?? 0) - (a.playtime_forever ?? 0)
+    }
+
+    const idxA = KNOWN_GENRES.indexOf(genreA)
+    const idxB = KNOWN_GENRES.indexOf(genreB)
+    return idxA - idxB
+}
+
 export class CategoryAssigner {
     private static readonly logger = Logger.createLogFunctions(CategoryAssigner.name)
 
@@ -51,7 +77,7 @@ export class CategoryAssigner {
         }
 
         if (noGenreCount > 0) {
-            CategoryAssigner.logger.warn(`[CAT-DEBUG] ${noGenreCount}/${games.length} games had no recognised genre — landed in "Other".`)
+            CategoryAssigner.logger.warn(`[CAT-DEBUG] ${noGenreCount}/${games.length} games had no recognised genre ï¿½ landed in "Other".`)
         }
 
         const shelfGroups: ShelfGroup[] = Array.from(groupsMap.entries()).map(([genre, groupGames]) => ({

--- a/client/src/scene/categorization/CategoryAssigner.ts
+++ b/client/src/scene/categorization/CategoryAssigner.ts
@@ -67,7 +67,7 @@ export class CategoryAssigner {
                 const canonical = GENRE_LOOKUP.get(raw.toLowerCase())
                 genre = canonical ?? otherGroupName
                 if (!canonical) {
-                    CategoryAssigner.logger.warn(`[CAT-DEBUG] Unrecognized genre "${raw}" for "${game.name}" (appid ${game.appid}) → Other`)
+                    CategoryAssigner.logger.warn(`[CAT-DEBUG] Unrecognized genre "${raw}" for "${game.name}" (appid ${game.appid}) -> Other`)
                     noGenreCount++
                 }
             } else {
@@ -79,7 +79,7 @@ export class CategoryAssigner {
         }
 
         if (noGenreCount > 0) {
-            CategoryAssigner.logger.warn(`[CAT-DEBUG] ${noGenreCount}/${games.length} games had no recognised genre � landed in "Other".`)
+            CategoryAssigner.logger.warn(`[CAT-DEBUG] ${noGenreCount}/${games.length} games had no recognised genre -> landed in "Other".`)
         }
 
         const shelfGroups: ShelfGroup[] = Array.from(groupsMap.entries()).map(([genre, groupGames]) => ({

--- a/client/src/scene/categorization/CategoryAssigner.ts
+++ b/client/src/scene/categorization/CategoryAssigner.ts
@@ -1,0 +1,69 @@
+import type { SteamGameData } from '../game-box/types/GameData'
+import { Logger } from '../../utils/Logger'
+
+export interface ShelfGroup {
+    genre: string
+    label: string
+    games: SteamGameData[]
+}
+
+/**
+ * Hardcoded list of recognised genre names, in display-canonical casing.
+ * Case-insensitive lookup so "Free to Play" / "Free To Play" both match.
+ * Unrecognised genres fall into "Other".
+ */
+export const KNOWN_GENRES: ReadonlyArray<string> = [
+    'Action', 'Adventure', 'RPG', 'Strategy', 'Simulation', 'Sports', 'Racing',
+    'Casual', 'Indie', 'Massively Multiplayer', 'Free to Play', 'Early Access',
+    'Puzzle', 'Platformer', 'Shooter', 'Horror', 'Stealth', 'Fighting', 'Survival', 'Anime',
+]
+
+const GENRE_LOOKUP: ReadonlyMap<string, string> = new Map(KNOWN_GENRES.map(g => [g.toLowerCase(), g]))
+
+export class CategoryAssigner {
+    private static readonly logger = Logger.createLogFunctions(CategoryAssigner.name)
+
+    assign(games: SteamGameData[]): ShelfGroup[] {
+        if (!games || games.length === 0) return []
+
+        const groupsMap = new Map<string, SteamGameData[]>()
+        const otherGroupName = 'Other'
+        let noGenreCount = 0
+
+        for (const game of games) {
+            let genre: string
+            if (game.genres && game.genres.length > 0) {
+                const raw = game.genres[0].description
+                const canonical = GENRE_LOOKUP.get(raw.toLowerCase())
+                if (canonical !== undefined) {
+                    genre = canonical
+                } else {
+                    CategoryAssigner.logger.warn(`[CAT-DEBUG] Unrecognized genre "${raw}" for "${game.name}" (appid ${game.appid}) ? Other`)
+                    genre = otherGroupName
+                    noGenreCount++
+                }
+            } else {
+                genre = otherGroupName
+                noGenreCount++
+            }
+            if (!groupsMap.has(genre)) groupsMap.set(genre, [])
+            groupsMap.get(genre)!.push(game)
+        }
+
+        if (noGenreCount > 0) {
+            CategoryAssigner.logger.warn(`[CAT-DEBUG] ${noGenreCount}/${games.length} games had no recognised genre — landed in "Other".`)
+        }
+
+        const shelfGroups: ShelfGroup[] = Array.from(groupsMap.entries()).map(([genre, groupGames]) => ({
+            genre, label: genre, games: groupGames
+        }))
+
+        shelfGroups.sort((a, b) => {
+            if (a.genre === otherGroupName) return 1
+            if (b.genre === otherGroupName) return -1
+            return b.games.length - a.games.length
+        })
+
+        return shelfGroups
+    }
+}

--- a/client/src/scene/categorization/CategoryAssigner.ts
+++ b/client/src/scene/categorization/CategoryAssigner.ts
@@ -61,18 +61,8 @@ export class CategoryAssigner {
         for (const game of games) {
             let genre: string
             if (game.genres && game.genres.length > 0) {
-                // Prefer a more specific genre when Action is the primary tag.
-                // Steam applies 'Action' broadly; secondary genres are often more useful.
-                const primaryRaw = game.genres[0].description
-                const primaryCanonical = GENRE_LOOKUP.get(primaryRaw.toLowerCase())
-                const useSecondary = primaryCanonical === 'Action' && game.genres.length > 1
-                const resolvedCanonical = useSecondary
-                    ? game.genres.slice(1)
-                        .map(g => GENRE_LOOKUP.get(g.description.toLowerCase()))
-                        .find(c => c !== undefined && c !== 'Action') ?? primaryCanonical
-                    : primaryCanonical
-                const raw = primaryRaw
-                const canonical = resolvedCanonical
+                const raw = game.genres[0].description
+                const canonical = GENRE_LOOKUP.get(raw.toLowerCase())
                 if (canonical !== undefined) {
                     genre = canonical
                 } else {

--- a/client/src/scene/categorization/CategoryAssigner.ts
+++ b/client/src/scene/categorization/CategoryAssigner.ts
@@ -23,13 +23,15 @@ export const KNOWN_GENRES: ReadonlyArray<string> = [
 const GENRE_LOOKUP: ReadonlyMap<string, string> = new Map(KNOWN_GENRES.map(g => [g.toLowerCase(), g]))
 
 /**
- * Sort comparator for genre-first, playtime-second ordering.
- * Games with recognised genres are grouped together; within each genre,
- * sorted by playtime descending. Games with no recognised genre sort last.
+ * Sort comparator: canonical genre index first, playtime descending within each genre.
+ * Unrecognised genres sort last.
  *
- * Safe to use as the sortFn option in SteamApiClient.loadGamesProgressively.
+ * Use as the sortFn option in SteamApiClient.loadGamesProgressively.
+ * TD: generic-sort — replace with a generic sortByFields(['genre', 'playtime']) utility
+ * once the sort-policy abstraction is designed.
  */
-export function genrePlaytimeSortFn(
+// TD: generic-sort — this should be a generic sortByFields utility once sort policy is formalized
+export function sortByGenreThenPlaytime(
     a: { genres?: Array<{ description: string }>, playtime_forever?: number },
     b: { genres?: Array<{ description: string }>, playtime_forever?: number }
 ): number {
@@ -63,11 +65,9 @@ export class CategoryAssigner {
             if (game.genres && game.genres.length > 0) {
                 const raw = game.genres[0].description
                 const canonical = GENRE_LOOKUP.get(raw.toLowerCase())
-                if (canonical !== undefined) {
-                    genre = canonical
-                } else {
-                    CategoryAssigner.logger.warn(`[CAT-DEBUG] Unrecognized genre "${raw}" for "${game.name}" (appid ${game.appid}) ? Other`)
-                    genre = otherGroupName
+                genre = canonical ?? otherGroupName
+                if (!canonical) {
+                    CategoryAssigner.logger.warn(`[CAT-DEBUG] Unrecognized genre "${raw}" for "${game.name}" (appid ${game.appid}) → Other`)
                     noGenreCount++
                 }
             } else {
@@ -86,6 +86,10 @@ export class CategoryAssigner {
             genre, label: genre, games: groupGames
         }))
 
+        // Sort groups by size desc, Other last. This sorts groups, not individual games;
+        // it is not redundant with sortByGenreThenPlaytime which sorts games within the pipeline.
+        // Sort groups by size desc, Other last. Not redundant with sortByGenreThenPlaytime
+        // (which sorts individual games upstream; this sorts the resulting groups).
         shelfGroups.sort((a, b) => {
             if (a.genre === otherGroupName) return 1
             if (b.genre === otherGroupName) return -1

--- a/client/src/scene/categorization/CategoryAssigner.ts
+++ b/client/src/scene/categorization/CategoryAssigner.ts
@@ -64,6 +64,7 @@ export function sortByGenreThenPlaytime(
  * Data transformer: maps a flat list of SteamGameData into ShelfGroup[] bucketed by genre.
  * Responsibility: grouping only. Sorting policy lives upstream (SteamApiClient sortFn)
  * and group ordering is a separate concern from the transform itself.
+ * Tech debt link: docs/roadmaps/tech-debt.md → "Category System Tech Debt / CategoryAssigner is a temporary classification hack"
  */
 export class CategoryAssigner {
     private static readonly logger = Logger.createLogFunctions(CategoryAssigner.name)

--- a/client/src/scene/categorization/CategoryAssigner.ts
+++ b/client/src/scene/categorization/CategoryAssigner.ts
@@ -1,6 +1,16 @@
 import type { SteamGameData } from '../game-box/types/GameData'
 import { Logger } from '../../utils/Logger'
 
+
+/**
+ * Well-known group names for category assignment.
+ * Using an enum prevents magic string scatter and makes exhaustive checks possible.
+ */
+export const CategoryGroupName = {
+    Other: 'Other',
+} as const
+export type CategoryGroupName = typeof CategoryGroupName[keyof typeof CategoryGroupName]
+
 export interface ShelfGroup {
     genre: string
     label: string
@@ -50,6 +60,11 @@ export function sortByGenreThenPlaytime(
     return idxA - idxB
 }
 
+/**
+ * Data transformer: maps a flat list of SteamGameData into ShelfGroup[] bucketed by genre.
+ * Responsibility: grouping only. Sorting policy lives upstream (SteamApiClient sortFn)
+ * and group ordering is a separate concern from the transform itself.
+ */
 export class CategoryAssigner {
     private static readonly logger = Logger.createLogFunctions(CategoryAssigner.name)
 
@@ -57,7 +72,7 @@ export class CategoryAssigner {
         if (!games || games.length === 0) return []
 
         const groupsMap = new Map<string, SteamGameData[]>()
-        const otherGroupName = 'Other'
+        const otherGroupName: string = CategoryGroupName.Other
         let noGenreCount = 0
 
         for (const game of games) {

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -114,6 +114,9 @@ export class GameBoxSpawner {
                 gameIndex += frontGames.length
             }
             if (gameIndex < games.length) {
+                // TD: wall-shelf-back-side — wall-mounted shelves should not fill the back side.
+                // Currently all shelves fill both sides. When wall vs. floor-standing shelf types
+                // are differentiated, gate this on shelf.isWallMounted or similar.
                 const backGames = games.slice(gameIndex, gameIndex + GameLayoutConstants.GAMES_PER_SURFACE)
                 if (backGames.length > 0) {
                     this.createGameBoxes(shelfPosition, surface, backGames, ShelfSide.Back, shelfRotationY)

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -15,125 +15,86 @@ import { Logger } from '../../utils/Logger'
 
 /**
  * GameBoxSpawner
- * 
+ *
  * Responsible for spawning game boxes on shelves using the instanced renderer.
- * Handles game distribution across shelf surfaces (front/back of each shelf board).
- * 
- * Extracted from GpuStorePropsRenderer to isolate game placement logic.
  * Event-driven flow:
- * - Observes BatchReadyForPlacement
- * - Emits ShelfSpaceRequested
- * - Observes ShelfCreated
- * - Emits GamesPlaced
+ * - Observes BatchReadyForPlacement ? stores games, emits ShelfSpaceRequested
+ * - Observes ShelfCreated ? places games on shelf, emits GamesPlaced
+ *
+ * Category assignment is NOT this class's responsibility. Signs are placed
+ * by ShelfSectionPlanner after all batches complete.
  */
 export class GameBoxSpawner {
     private static logger = Logger.createLogFunctions(GameBoxSpawner.name)
     private gameBoxRenderer?: GpuGameBoxRenderer
-    
-    // Track pending games waiting for shelf creation
     private pendingGames: Map<number, readonly SteamGameData[]> = new Map()
-    
+
     constructor(gameBoxRenderer?: GpuGameBoxRenderer) {
         this.gameBoxRenderer = gameBoxRenderer
-
         EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.BatchReadyForPlacement,
             this.handleBatchReadyForPlacement.bind(this)
         )
-        
         EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.ShelfCreated,
             this.handleShelfCreated.bind(this)
         )
-        
         GameBoxSpawner.logger.debug('Registered listeners for BatchReadyForPlacement and ShelfCreated events')
     }
 
     public setGameBoxRenderer(gameBoxRenderer: GpuGameBoxRenderer): void {
         this.gameBoxRenderer = gameBoxRenderer
     }
-    
-    /**
-     * Handle BatchReadyForPlacement event
-     * Stores games and requests shelf space via event
-     */
+
     private handleBatchReadyForPlacement(event: CustomEvent<BatchReadyForPlacementEvent>): void {
         const { games, batchIndex, totalBatches } = event.detail
-        
+
         GameBoxSpawner.logger.debug(
-            `[EVENT PATH] BatchReadyForPlacement received: ` +
-            `batch ${batchIndex + 1}/${totalBatches}, ${games.length} games. ` +
-            `Emitting ShelfSpaceRequested...`
+            `[EVENT PATH] BatchReadyForPlacement received: batch ${batchIndex + 1}/${totalBatches}, ${games.length} games.`
         )
-        
-        // Store games pending shelf creation
+
         this.pendingGames.set(batchIndex, games)
-        
-        // Emit ShelfSpaceRequested event
+
         EventManager.getInstance().emit<ShelfSpaceRequestedEvent>(
             StorePropsEventTypes.ShelfSpaceRequested,
             {
                 gamesCount: games.length,
-                batchIndex: batchIndex,
+                batchIndex,
                 status: BatchProcessingStatus.ShelfRequested,
                 lastModified: Date.now()
             }
         )
         GameBoxSpawner.logger.debug(`Emitted ShelfSpaceRequested for batch ${batchIndex + 1}`)
     }
-    
-    /**
-     * Handle ShelfCreated event
-     * Retrieves pending games and places them on the shelf
-     */
+
     private handleShelfCreated(event: CustomEvent<ShelfCreatedEvent>): void {
         const { position, batchIndex, rowIndex = 0, shelfIndex = 0, shelfRotationY = 0 } = event.detail
-        
+
         GameBoxSpawner.logger.debug(
             `[EVENT PATH] ShelfCreated received for batch ${batchIndex + 1}. ` +
-            `Spawning games at position (${position.x.toFixed(1)}, ${position.y.toFixed(1)}, ${position.z.toFixed(1)})`
+            `Spawning games at (${position.x.toFixed(1)}, ${position.y.toFixed(1)}, ${position.z.toFixed(1)})`
         )
-        
+
         const games = this.pendingGames.get(batchIndex)
         if (!games) {
-            GameBoxSpawner.logger.warn(`No pending games found for batch ${batchIndex}`);
+            GameBoxSpawner.logger.warn(`No pending games found for batch ${batchIndex}`)
             EventManager.getInstance().emit<GamesPlacedEvent>(
                 StorePropsEventTypes.GamesPlaced,
-                {
-                    batchIndex,
-                    status: BatchProcessingStatus.Failed
-                }
+                { batchIndex, status: BatchProcessingStatus.Failed }
             )
             return
         }
-        
-        // Spawn games using event-driven path
+
         this.spawnGamesOnShelf(position, games, rowIndex, shelfIndex, shelfRotationY)
-        
-        // Clean up pending games
         this.pendingGames.delete(batchIndex)
-        
-        // Emit GamesPlaced event
+
         EventManager.getInstance().emit<GamesPlacedEvent>(
             StorePropsEventTypes.GamesPlaced,
-            {
-                batchIndex: batchIndex,
-                status: BatchProcessingStatus.GamesPlaced
-            }
+            { batchIndex, status: BatchProcessingStatus.GamesPlaced }
         )
-        GameBoxSpawner.logger.debug(
-            `[EVENT PATH] Spawned ${games.length} games, emitted GamesPlaced for batch ${batchIndex + 1}`
-        )
+        GameBoxSpawner.logger.debug(`[EVENT PATH] Spawned ${games.length} games, emitted GamesPlaced for batch ${batchIndex + 1}`)
     }
-    
-    /**
-     * Spawn games on a shelf at the given position
-     * 
-     * @param shelfPosition - World position of shelf origin
-     * @param games - Games to place on this shelf
-     * @param rowIndex - Row index (for debugging)
-     * @param shelfIndex - Shelf index within row (for debugging)
-     */
+
     spawnGamesOnShelf(
         shelfPosition: THREE.Vector3,
         games: readonly SteamGameData[],
@@ -141,28 +102,18 @@ export class GameBoxSpawner {
         _shelfIndex: number,
         shelfRotationY: number = 0
     ): void {
-        // Get shelf surface configuration using shared utility (GPU path: hardcoded surfaces)
         const shelfSurfaces = ShelfSurfaceUtils.findShelfSurfaces(null, true)
-        
-        if (shelfSurfaces.length === 0) {
-            return
-        }
-        
+        if (shelfSurfaces.length === 0) return
+
         let gameIndex = 0
-        
         for (const surface of shelfSurfaces) {
             if (gameIndex >= games.length) break
-            
             const frontGames = games.slice(gameIndex, gameIndex + GameLayoutConstants.GAMES_PER_SURFACE)
             if (frontGames.length > 0) {
                 this.createGameBoxes(shelfPosition, surface, frontGames, ShelfSide.Front, shelfRotationY)
                 gameIndex += frontGames.length
             }
-            
             if (gameIndex < games.length) {
-                // TD: wall-shelf-back-side — wall-mounted shelves should not fill the back side.
-                // Currently all shelves fill both sides. When wall vs. floor-standing shelf types
-                // are differentiated, gate this on shelf.isWallMounted or similar.
                 const backGames = games.slice(gameIndex, gameIndex + GameLayoutConstants.GAMES_PER_SURFACE)
                 if (backGames.length > 0) {
                     this.createGameBoxes(shelfPosition, surface, backGames, ShelfSide.Back, shelfRotationY)
@@ -171,10 +122,7 @@ export class GameBoxSpawner {
             }
         }
     }
-    
-    /**
-     * Create game boxes for a set of games on a specific shelf surface
-     */
+
     private createGameBoxes(
         shelfPosition: THREE.Vector3,
         surface: ShelfSurface,
@@ -186,25 +134,15 @@ export class GameBoxSpawner {
             GameBoxSpawner.logger.warn('GameBoxRenderer unavailable while creating game boxes')
             return
         }
-
         const boxDimensions = this.gameBoxRenderer.getDimensions()
         const gamePositions = GameBoxUtils.calculateGamePositions(
-            shelfPosition,
-            surface,
-            games as SteamGameData[], // Cast readonly to mutable for legacy utility
-            side,
-            boxDimensions,
-            shelfRotationY
+            shelfPosition, surface, games as SteamGameData[], side, boxDimensions, shelfRotationY
         )
-        
         for (let i = 0; i < games.length; i++) {
             this.createSingleGameBox(games[i], gamePositions[i], side, i, shelfRotationY)
         }
     }
-    
-    /**
-     * Create a single game box at the specified position
-     */
+
     private createSingleGameBox(
         game: SteamGameData,
         worldPosition: THREE.Vector3,
@@ -219,7 +157,6 @@ export class GameBoxSpawner {
         const effectiveSide = shelfRotationY === Math.PI
             ? (side === ShelfSide.Front ? ShelfSide.Back : ShelfSide.Front)
             : side
-
         this.gameBoxRenderer.createGameBoxAuto(game, worldPosition, effectiveSide)
     }
 }

--- a/client/src/steam-integration/SteamIntegration.ts
+++ b/client/src/steam-integration/SteamIntegration.ts
@@ -20,6 +20,7 @@ import type { SteamLoadGamesEvent, SteamLoadFromCacheEvent, SteamCacheRefreshEve
 import type { SettingChangedEvent } from '../core/AppSettings'
 import { AppSettings } from '../core/AppSettings'
 import { DataManager, DataDomain } from '../core/data'
+import { genrePlaytimeSortFn } from '../scene/categorization/CategoryAssigner'
 
 export interface SteamIntegrationConfig {
     apiBaseUrl?: string
@@ -155,7 +156,8 @@ export class SteamIntegration {
             
             // Progressive loading via events - GameLibraryManager listens to GamesBatchReady
             await this.steamClient.loadGamesProgressively(userGames, {
-                maxGames: this.config.maxGames
+                maxGames: this.config.maxGames,
+                sortFn: genrePlaytimeSortFn,
             })
             
             // Complete loading - actual count from library state (populated via onBatchReady)
@@ -299,7 +301,8 @@ export class SteamIntegration {
             
             // Progressive loading via events - GameLibraryManager listens to GamesBatchReady  
             await this.steamClient.loadGamesProgressively(cachedGames, {
-                maxGames: cachedGames.game_count
+                maxGames: cachedGames.game_count,
+                sortFn: genrePlaytimeSortFn,
             })
             
             const gamesLoaded = this.gameLibrary.getState().userData?.games?.length ?? 0

--- a/client/src/steam-integration/SteamIntegration.ts
+++ b/client/src/steam-integration/SteamIntegration.ts
@@ -20,7 +20,7 @@ import type { SteamLoadGamesEvent, SteamLoadFromCacheEvent, SteamCacheRefreshEve
 import type { SettingChangedEvent } from '../core/AppSettings'
 import { AppSettings } from '../core/AppSettings'
 import { DataManager, DataDomain } from '../core/data'
-import { genrePlaytimeSortFn } from '../scene/categorization/CategoryAssigner'
+import { sortByGenreThenPlaytime } from '../scene/categorization/CategoryAssigner'
 
 export interface SteamIntegrationConfig {
     apiBaseUrl?: string
@@ -157,7 +157,7 @@ export class SteamIntegration {
             // Progressive loading via events - GameLibraryManager listens to GamesBatchReady
             await this.steamClient.loadGamesProgressively(userGames, {
                 maxGames: this.config.maxGames,
-                sortFn: genrePlaytimeSortFn,
+                sortFn: sortByGenreThenPlaytime,
             })
             
             // Complete loading - actual count from library state (populated via onBatchReady)
@@ -302,7 +302,7 @@ export class SteamIntegration {
             // Progressive loading via events - GameLibraryManager listens to GamesBatchReady  
             await this.steamClient.loadGamesProgressively(cachedGames, {
                 maxGames: cachedGames.game_count,
-                sortFn: genrePlaytimeSortFn,
+                sortFn: sortByGenreThenPlaytime,
             })
             
             const gamesLoaded = this.gameLibrary.getState().userData?.games?.length ?? 0

--- a/client/src/steam/SteamApiClient.ts
+++ b/client/src/steam/SteamApiClient.ts
@@ -294,12 +294,14 @@ export class SteamApiClient {
         steamUser: SteamUser,
         options: {
             maxGames?: number
+            /** Optional comparator to override default playtime-descending sort. */
+            sortFn?: (a: SteamGame, b: SteamGame) => number
         } = {}
     ): Promise<SteamGame[]> {
-        const { maxGames = 10 } = options
+        const { maxGames = 10, sortFn } = options
         const BATCH_SIZE = 18 // One shelf's worth
         
-        const sortedGames = this.sortAndLimitGames(steamUser.games, maxGames)
+        const sortedGames = this.sortAndLimitGames(steamUser.games, maxGames, sortFn)
         const appids = sortedGames.map(g => g.appid)
         
         const { cachedAppids, uncachedAppids, cachedAppDetails } = await this.partitionByCache(appids)
@@ -331,9 +333,10 @@ export class SteamApiClient {
         return results
     }
 
-    private sortAndLimitGames(games: SteamGame[], maxGames: number): SteamGame[] {
+    private sortAndLimitGames(games: SteamGame[], maxGames: number, sortFn?: (a: SteamGame, b: SteamGame) => number): SteamGame[] {
+        const comparator = sortFn ?? ((a: SteamGame, b: SteamGame) => (b.playtime_forever ?? 0) - (a.playtime_forever ?? 0))
         return [...games]
-            .sort((a, b) => (b.playtime_forever ?? 0) - (a.playtime_forever ?? 0))
+            .sort(comparator)
             .slice(0, maxGames)
     }
 

--- a/client/src/styles/category-reference-panel.css
+++ b/client/src/styles/category-reference-panel.css
@@ -1,0 +1,175 @@
+/**
+ * Category Reference Panel Styles
+ */
+
+.cat-ref-toggle-btn {
+    background: rgba(0, 0, 0, 0.75);
+    border: 1px solid #555;
+    border-radius: 6px;
+    color: white;
+    cursor: pointer;
+    font-size: 18px;
+    padding: 6px 10px;
+    transition: background 0.2s, border-color 0.2s;
+}
+
+.cat-ref-toggle-btn:hover {
+    background: rgba(60, 60, 60, 0.9);
+    border-color: #888;
+}
+
+.cat-ref-toggle-btn.active {
+    background: rgba(30, 80, 140, 0.85);
+    border-color: var(--panel-accent);
+}
+
+/* ── Panel ──────────────────────────────────────────────────────────────── */
+
+.cat-ref-panel {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(860px, 92vw);
+    max-height: 80dvh;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 10px;
+    color: var(--panel-text);
+    font-family: var(--panel-font);
+    font-size: var(--panel-font-size);
+    z-index: 2500;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.7);
+}
+
+.cat-ref-panel.hidden {
+    display: none;
+}
+
+.cat-ref-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 16px;
+    background: rgba(30, 30, 50, 0.95);
+    border-bottom: 1px solid #444;
+    font-size: 14px;
+    font-weight: bold;
+    flex-shrink: 0;
+}
+
+.cat-ref-close {
+    background: none;
+    border: none;
+    color: #aaa;
+    cursor: pointer;
+    font-size: 16px;
+    padding: 2px 6px;
+    border-radius: 4px;
+}
+
+.cat-ref-close:hover {
+    color: white;
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.cat-ref-body {
+    overflow-y: auto;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* ── Sections ────────────────────────────────────────────────────────────── */
+
+.cat-section h3 {
+    margin: 0 0 4px;
+    font-size: 13px;
+    color: #aac4ff;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.cat-count {
+    color: var(--panel-text-muted);
+    font-weight: normal;
+}
+
+.cat-section-note {
+    margin: 0 0 8px;
+    color: var(--panel-text-muted);
+    font-size: 11px;
+}
+
+.cat-section-note code {
+    color: #c0e0a0;
+    background: rgba(255, 255, 255, 0.06);
+    padding: 1px 4px;
+    border-radius: 3px;
+}
+
+/* ── Table ───────────────────────────────────────────────────────────────── */
+
+.cat-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+
+.cat-table thead tr {
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.cat-table th {
+    text-align: left;
+    padding: 5px 8px;
+    color: #aaa;
+    font-weight: normal;
+    border-bottom: 1px solid #333;
+    white-space: nowrap;
+}
+
+.cat-table td {
+    padding: 4px 8px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    vertical-align: top;
+}
+
+.cat-label {
+    font-weight: bold;
+    color: #e8e8e8;
+    white-space: nowrap;
+    width: 160px;
+}
+
+.cat-status {
+    white-space: nowrap;
+    width: 70px;
+}
+
+.cat-desc {
+    color: #aaa;
+    line-height: 1.4;
+}
+
+/* ── Status badges ────────────────────────────────────────────────────────── */
+
+.cat-row--live .cat-status {
+    color: #5dd;
+}
+
+.cat-row--planned .cat-status {
+    color: #fd8;
+}
+
+.cat-row--idea .cat-status {
+    color: #a88;
+}
+
+.cat-row:hover td {
+    background: rgba(255, 255, 255, 0.03);
+}

--- a/client/src/ui/CategoryReferencePanel.ts
+++ b/client/src/ui/CategoryReferencePanel.ts
@@ -1,0 +1,199 @@
+/**
+ * Category Reference Panel
+ *
+ * Quick-reference panel for game categories / sort dimensions.
+ * Intended as a dev/design tool — provides a single glance at:
+ *   - Steam API genres (what the store actually serves)
+ *   - Planned meta-categories (library-state based)
+ *   - Planned sort/filter dimensions (recency, play-next, etc.)
+ *
+ * Toggle button lives in #ui-right-center-group alongside the binder and lighting panel.
+ * Toggle shortcut: G (genre reference)
+ */
+
+import { KNOWN_GENRES } from '../scene/categorization/CategoryAssigner'
+import '../styles/category-reference-panel.css'
+
+// ─── Static category data ──────────────────────────────────────────────────
+
+interface CategoryEntry {
+    label: string
+    description: string
+    status: 'live' | 'planned' | 'idea'
+}
+
+const STEAM_GENRE_CATEGORIES: CategoryEntry[] = KNOWN_GENRES.map(g => ({
+    label: g,
+    description: `Steam genre — matched case-insensitively from genres[0].description`,
+    status: 'live',
+}))
+
+const META_CATEGORIES: CategoryEntry[] = [
+    {
+        label: 'New to Library',
+        description: 'Games added in the last 30–90 days (date_added from Steam).',
+        status: 'planned',
+    },
+    {
+        label: 'Play Next',
+        description: 'Unplayed or short-playtime games surfaced for discovery (< 2h playtime).',
+        status: 'planned',
+    },
+    {
+        label: 'Recently Updated',
+        description: 'Games with a recent build/patch (last_played or build_id delta). Better as a sort dimension than a shelf.',
+        status: 'idea',
+    },
+    {
+        label: 'Recently Played',
+        description: 'Games with recent playtime activity — a time-sorted view, not a shelf category.',
+        status: 'idea',
+    },
+]
+
+const SORT_DIMENSIONS: CategoryEntry[] = [
+    {
+        label: 'Alphabetical',
+        description: 'A–Z by game name.',
+        status: 'planned',
+    },
+    {
+        label: 'Most Played',
+        description: 'Descending by total playtime_forever.',
+        status: 'planned',
+    },
+    {
+        label: 'Recently Played',
+        description: 'Descending by rtime_last_played.',
+        status: 'planned',
+    },
+    {
+        label: 'Recently Updated',
+        description: 'Descending by build date / patch timestamp (requires Store API).',
+        status: 'idea',
+    },
+    {
+        label: 'Metacritic',
+        description: 'Descending by metacritic.score where available.',
+        status: 'idea',
+    },
+]
+
+// ─── Panel ────────────────────────────────────────────────────────────────────
+
+export class CategoryReferencePanel {
+    private container: HTMLElement | null = null
+    private toggleButton: HTMLElement | null = null
+    private isOpen = false
+    private keyboardHandler: ((e: KeyboardEvent) => void) | null = null
+
+    public init(): void {
+        this.createToggleButton()
+        this.createPanel()
+        this.keyboardHandler = (e: KeyboardEvent) => {
+            if (
+                e.key === 'g' || e.key === 'G' &&
+                !e.ctrlKey && !e.metaKey &&
+                !(document.activeElement instanceof HTMLInputElement) &&
+                !(document.activeElement instanceof HTMLTextAreaElement)
+            ) {
+                this.toggle()
+            }
+        }
+        document.addEventListener('keydown', this.keyboardHandler)
+    }
+
+    private createToggleButton(): void {
+        this.toggleButton = document.createElement('button')
+        this.toggleButton.id = 'cat-ref-toggle-btn'
+        this.toggleButton.className = 'cat-ref-toggle-btn'
+        this.toggleButton.innerHTML = '🏷️'
+        this.toggleButton.title = 'Category Reference (G)'
+        this.toggleButton.addEventListener('click', () => this.toggle())
+
+        const slot = document.getElementById('ui-right-center-group') ?? document.getElementById('ui-slot-top-right')
+        if (slot) {
+            slot.appendChild(this.toggleButton)
+        } else {
+            document.body.appendChild(this.toggleButton)
+        }
+    }
+
+    private createPanel(): void {
+        this.container = document.createElement('div')
+        this.container.id = 'cat-ref-panel'
+        this.container.className = 'cat-ref-panel hidden'
+        this.container.innerHTML = this.buildHTML()
+
+        document.body.appendChild(this.container)
+    }
+
+    private buildHTML(): string {
+        const renderRows = (entries: CategoryEntry[]): string =>
+            entries.map(e => `
+                <tr class="cat-row cat-row--${e.status}">
+                    <td class="cat-label">${e.label}</td>
+                    <td class="cat-status">${e.status}</td>
+                    <td class="cat-desc">${e.description}</td>
+                </tr>
+            `).join('')
+
+        return `
+            <div class="cat-ref-header">
+                <span>🏷️ Category Reference</span>
+                <button class="cat-ref-close" title="Close">✕</button>
+            </div>
+            <div class="cat-ref-body">
+
+                <section class="cat-section">
+                    <h3>Steam Genres <span class="cat-count">(${STEAM_GENRE_CATEGORIES.length})</span></h3>
+                    <p class="cat-section-note">Matched case-insensitively from <code>genres[0].description</code>. Unrecognised → Other.</p>
+                    <table class="cat-table">
+                        <thead><tr><th>Label</th><th>Status</th><th>Notes</th></tr></thead>
+                        <tbody>${renderRows(STEAM_GENRE_CATEGORIES)}</tbody>
+                    </table>
+                </section>
+
+                <section class="cat-section">
+                    <h3>Meta / Library-State Categories</h3>
+                    <p class="cat-section-note">Based on library data (playtime, date added, etc.), not Steam genre tags.</p>
+                    <table class="cat-table">
+                        <thead><tr><th>Label</th><th>Status</th><th>Notes</th></tr></thead>
+                        <tbody>${renderRows(META_CATEGORIES)}</tbody>
+                    </table>
+                </section>
+
+                <section class="cat-section">
+                    <h3>Sort Dimensions</h3>
+                    <p class="cat-section-note">These are better as sort/filter controls than as shelves. Design TBD.</p>
+                    <table class="cat-table">
+                        <thead><tr><th>Label</th><th>Status</th><th>Notes</th></tr></thead>
+                        <tbody>${renderRows(SORT_DIMENSIONS)}</tbody>
+                    </table>
+                </section>
+
+            </div>
+        `
+    }
+
+    private toggle(): void {
+        this.isOpen = !this.isOpen
+        this.container?.classList.toggle('hidden', !this.isOpen)
+        if (this.toggleButton) {
+            this.toggleButton.classList.toggle('active', this.isOpen)
+        }
+        if (this.isOpen) {
+            // Wire close button each time we open (innerHTML is static so it survives)
+            const closeBtn = this.container?.querySelector('.cat-ref-close')
+            closeBtn?.addEventListener('click', () => this.toggle(), { once: true })
+        }
+    }
+
+    public dispose(): void {
+        if (this.keyboardHandler) {
+            document.removeEventListener('keydown', this.keyboardHandler)
+        }
+        this.container?.remove()
+        this.toggleButton?.remove()
+    }
+}

--- a/client/src/ui/coordinators/SystemUICoordinator.ts
+++ b/client/src/ui/coordinators/SystemUICoordinator.ts
@@ -12,6 +12,7 @@ import * as THREE from 'three'
 import { PauseMenuManager } from '../pause/PauseMenuManager'
 import { PerformanceMonitorUI } from '../PerformanceMonitor'
 import { LightingControlsPanel } from '../LightingControlsPanel'
+import { CategoryReferencePanel } from '../CategoryReferencePanel'
 import { EventManager } from '../../core/EventManager'
 import type { DebugStatsProvider } from '../../core/DebugStatsProvider'
 import { AppSettings } from '../../core/AppSettings'
@@ -23,6 +24,7 @@ export class SystemUICoordinator {
     private pauseMenuManager: PauseMenuManager
     private performanceMonitor: PerformanceMonitorUI
     private lightingControlsPanel?: LightingControlsPanel
+    private categoryReferencePanel?: CategoryReferencePanel
     private eventManager: EventManager
     private appSettings: AppSettings
     private renderLoopRegistry: RenderLoopRegistry
@@ -85,6 +87,9 @@ export class SystemUICoordinator {
         
         // Initialize integrated lighting controls panel
         this.initializeLightingControls()
+
+        // Category reference panel (dev/debug tool)
+        this.initializeCategoryReferencePanel()
         
         // Register update method with render loop
         this.renderLoopRegistry.register(this.constructor.name, this.updatePerformanceStats.bind(this))
@@ -126,6 +131,13 @@ export class SystemUICoordinator {
             this.lightingControlsPanel = new LightingControlsPanel(this.eventManager, this.appSettings)
             // Show the integrated panel by default since the button is now part of it
             this.lightingControlsPanel.show()
+        }
+    }
+
+    private initializeCategoryReferencePanel(): void {
+        if (!this.categoryReferencePanel) {
+            this.categoryReferencePanel = new CategoryReferencePanel()
+            this.categoryReferencePanel.init()
         }
     }
 

--- a/docs/plans/open-subagent-threads.md
+++ b/docs/plans/open-subagent-threads.md
@@ -1,6 +1,6 @@
 # Open Subagent Threads
 
-Tracks ongoing and queued work for bounded subagent tasks. When a thread completes, remove it — completed work lives in git history and roadmap docs, not here.
+Tracks queued subagent work. Remove threads when complete — completed work lives in git history and roadmap docs.
 
 ---
 
@@ -12,51 +12,33 @@ Tracks ongoing and queued work for bounded subagent tasks. When a thread complet
 
 ## Queued / Ready to Start
 
-### Thread: UI Normalization (6.6)
-**Status**: Greenlit — start when ready  
-**Model**: gemini-3-flash (mechanical, bounded work)  
-**Mode**: one-shot subagent, one file or small set per run  
-**Work**: Design tokens now in `client/src/ui/tokens.css`. Next: Phase B base components.  
-**Ref**: `docs/plans/ui-normalization-plan.md`  
-**Depends on**: Nothing blocking  
-**Notes**: One small change per subagent run — not "edit 20 files"
+### Thread: UI Normalization — Phase B components
+**Status**: In progress (UIButton + UICheckbox done)
+**Model**: gemini-3-flash
+**Mode**: one-shot subagent, one component per run
+**Work**: Design tokens live in `client/src/ui/tokens.css`. Base components done: UIButton, UICheckbox.
+**Next**: UIPanel.ts + ui-panel.css (standard container with header + body)
+**Ref**: `docs/plans/ui-normalization-plan.md` Phase B
+**Notes**: One component per subagent run — not multi-file sweeps
 
 ---
 
-### Thread: Steam Categorization — CategoryAssigner
-**Status**: Ready to start (data already exists!)  
-**Model**: gemini-3-flash  
-**Mode**: one-shot subagent, single file scope  
-**Ref**: `docs/plans/feature-priority-spec.md`, `client/src/steam/types/SteamMetadata.ts`
+### Thread: Popcorn Ceiling Texture Improvement
+**Status**: Queued — start when visual design cycles open
+**Model preference (design pass)**: gemini-pro → opus → sonnet
+**Constraint**: Output = implementation-ready plan for gemini-flash execution. Minimal iteration — design power up front, cheap model for implementation.
+**Goal**: Improve popcorn ceiling procedural texture to read convincingly in-scene at VR scale.
+- Focus on denser/higher-res tiling pattern (drop ceiling tiles are ~1ft × 1ft — tight, repeating, obvious seams)
+- Popcorn doesn't have clean seams so must rely on noise density and bump quality
+- Leads into stucco wall variant later (parking stucco for now — wall shelves take priority)
 
-**What exists already:**
-- `SteamGameData.genres[]` — type `SteamGenre[]` (`id: string, description: string`)
-- `SteamGameData.categories[]` — type `SteamCategory[]` (`id: number, description: string`)
-- `STEAM_STORE_SECTIONS` in `StoreLayoutConfig.ts` — dead code placeholder section names
+**Deliverable**: `docs/plans/popcorn-ceiling-plan.md` — specific canvas/noise algorithm changes a flash subagent can implement without design ambiguity
 
-**Subagent task A — CategoryAssigner (one file):**
-Create `client/src/scene/categorization/CategoryAssigner.ts`:
-- Input: `SteamGameData[]`
-- Output: `ShelfGroup[]` where `ShelfGroup = { genre: string; label: string; games: SteamGameData[] }`
-- Group by `genres[0].description` (primary genre)
-- Games with no genre go into an `"Other"` group
-- Sort groups: largest first, `"Other"` always last
-- Write unit tests alongside
-
-**Subagent task B — FeaturePriorityConfig (one file):**
-Create `client/src/ui/FeaturePriorityConfig.ts`:
-- `HIDDEN_PRIORITY = 9999` constant
-- Default priority table as a `Map<number, number>` (categoryId → priority)
-- Helper: `sortAndFilterCategories(categories: SteamCategory[]): SteamCategory[]`
-  - Filters out `priority >= HIDDEN_PRIORITY`
-  - Sorts remaining by priority ascending
-- Write unit tests
-
-**These are independent — either can run first.**
+---
 
 ### Thread: getInstance Singleton Refactor
-**Status**: Queued — defer until fresh branch  
-**Work**: Apply `#current` getter singleton pattern to other classes (post-MeshPrewarmer prototype).  
-**Notes**: DataManager changes are significant — do those on a fresh branch when ready. Other singletons can be lighter touches.
+**Status**: Queued — defer until fresh branch
+**Work**: Apply `#current` getter singleton pattern to other classes beyond MeshPrewarmer.
+**Notes**: DataManager changes are significant — own branch. Other singletons can be lighter touches.
 
 ---

--- a/docs/roadmaps/phase2-ready-for-friends.md
+++ b/docs/roadmaps/phase2-ready-for-friends.md
@@ -433,6 +433,28 @@
 - **Flat / Wolfenstein-mode**: Uniform ambient, no dynamic lights — like the pre-dynamic-lights era of the codebase. Fast, nostalgic, great fallback.
 - **Blacklight room**: UV-style ambient with glowing accent colors. Pairs naturally with the planned basement room variant.
 
+**Tone knob presets (corporate → dank scale):**
+A single knob/control with named positions controlling the overall emotional tone of lighting:
+- **Corporate**: Bright, even, neutral/cool — high ambient, minimal shadow, productive feel
+- **Cheery**: Warm-white, upbeat, slightly directional — old-school store with good bulbs
+- **Dim**: Cozy warm, soft shadows, lower ambient — closing-time video store feel
+- **Dank**: Very low ambient, strong contrast, cool shadows — sketchy basement vibes
+
+---
+
+### Feature 8.5.1 (revised): Dongle Switch Panel
+**Context**: Second lighting control panel design — runs alongside current panel, not replacing it.
+
+**Visual design concept**:
+- A row of retro dongle-style rocker switches (on/off positions) — one per light in the scene
+- Each switch has a tiny LED indicator at its tip reflecting current light state
+- Switches labeled with a strip of hand-torn masking tape (canvas texture)
+- Human-readable labels for each light group (not raw WebGL names)
+  - Raw WebGL names retained as tooltips for developer context
+- A tone knob to one side — rotates through the 4 preset positions (corporate / cheery / dim / dank)
+
+**Implementation note**: This is a design-phase item. Wait until UI normalization baseline (Phase B) is in place before building. Requires the lighting preset system (Feature 8.5.0) to exist first.
+
 **Additional lighting atmosphere ideas** (brainstorm, subject to review):
 - **Golden hour / warm close**: Warm directional from low angle, long shadows — cozy evening feel
 - **Neon city**: Deep dark ambient, colored point lights (magenta/cyan/green) — cyberpunk

--- a/docs/roadmaps/tech-debt.md
+++ b/docs/roadmaps/tech-debt.md
@@ -516,3 +516,50 @@ class Foo {
 **Context**: Signs now use DataTexture pixel snapshots. InstancedLabelRenderer uses a texture array approach. Worth reviewing if one can serve both, or if the approaches should stay separate for different use cases (sign = large static label, game box = dense small label). Revisit during UI normalization or when sign rendering needs improving.
 **Source**: Apr 2026
 
+
+
+---
+
+## Category System Tech Debt (from PR #38 review, Apr 2026)
+
+### Generic sort-by-field utility
+**Priority**: Medium (next categories refactor)
+**Context**: sortByGenreThenPlaytime in CategoryAssigner.ts is a one-off comparator. The right abstraction is a generic sortByFields(['genre', 'playtime']) function that takes field names as parameters. TypeScript's mapped types make this achievable without losing type safety. The current function has a TD comment.
+**Next steps**:
+- Design a sortByFields<T>(fields: (keyof T)[]) utility in src/utils/
+- Replace sortByGenreThenPlaytime with a call to it
+- Move sort policy out of CategoryAssigner (see "Sort policy in SteamApiClient" below)
+
+### Sort policy belongs off SteamApiClient
+**Priority**: Medium
+**Context**: SteamApiClient.loadGamesProgressively accepts a sortFn param (currently used for sortByGenreThenPlaytime). This works as a pass-through, but the sort policy — what field order we care about — doesn't belong in the data-fetching layer. It's a presentation concern.
+**Next steps**:
+- Move sort application upstream: caller assembles sort policy, passes pre-sorted games to the pipeline
+- Or: introduce a GameSortPipeline that wraps the fetch and handles transform
+- Discuss when designing the "groups ? shelves conversation" layout system
+
+### CategorySignSystem ? SceneSignManager rename
+**Priority**: Low (next sign-related work)
+**Context**: CategorySignSystem is named too narrowly — it handles sign placement in a scene, not just category signs. When ceiling signs (recently-played) are added it'll look wrong.
+**Candidate name**: SceneSignManager
+**Next steps**: Rename file + class when we add the second sign type; no need to do it in isolation
+
+### CategoryAssigner is a temporary classification hack
+**Priority**: Medium (before user-tag pipeline)
+**Context**: The current genre-lookup approach is known-imperfect. It was introduced as a stand-in while we pursue Steam user tags (from SteamSpy API) as a better category source. Once tags are available, CategoryAssigner will likely be replaced or heavily refactored.
+**Note**: Don't over-invest in refining the genre-lookup logic; invest in the tag pipeline instead.
+
+### CategorySignSystem: scene access pattern / SceneManager
+**Priority**: Medium (architecture cleanup)
+**Context**: CategorySignSystem takes scene as a constructor param. The desired pattern is to get scene from a DataManager / SceneManager static accessor, so there's one access pattern for the scene across all code.
+**Proposed**: Add a SceneManager with a static get(index: SceneIndex): THREE.Scene that pulls from the DataManager. Register scenes with an index enum on creation.
+**Next steps**: Design SceneManager interface; migrate CategorySignSystem and other direct-scene-param classes
+
+### SignageRenderer: singleton vs instance
+**Priority**: Low
+**Context**: SignageRenderer is currently instantiated per-use. If it holds no instance state (all methods are pure given inputs), it could be a module with exported functions, or a singleton. Evaluate when touching sign rendering.
+
+### Readonly event payloads
+**Priority**: Low/Medium
+**Context**: Events should emit eadonly everything to prevent accidental mutation of shared event data. Currently not enforced. Worth a lint rule or type-level enforcement.
+**Next steps**: Add Readonly<T> wrapping to all emitted event payloads in InteractionEvents.ts; consider a custom ESLint rule

--- a/docs/roadmaps/tech-debt.md
+++ b/docs/roadmaps/tech-debt.md
@@ -510,3 +510,9 @@ class Foo {
 - Suppress or fix anything not worth fixing now (with explicit comments)
 - Once baseline is clean, add lint step to the same run as unit tests
 - Enforce: lint must be clean for PR merge going forward
+
+### UI: Compare SignageRenderer DataTexture approach with InstancedLabelRenderer
+**Priority**: Low
+**Context**: Signs now use DataTexture pixel snapshots. InstancedLabelRenderer uses a texture array approach. Worth reviewing if one can serve both, or if the approaches should stay separate for different use cases (sign = large static label, game box = dense small label). Revisit during UI normalization or when sign rendering needs improving.
+**Source**: Apr 2026
+

--- a/docs/roadmaps/tech-debt.md
+++ b/docs/roadmaps/tech-debt.md
@@ -481,3 +481,32 @@ class Foo {
 
 ---
 
+
+---
+
+## Intake Queue (2026-04-05 additions)
+
+### Memory budget monitoring
+**Priority**: High (as soon as we have cycles)
+**Context**: No current way to compare estimated VRAM/RAM usage (GpuMemoryEstimator) against actual measured usage. Need Playwright to report actual memory usage figures and a watch target we periodically check.
+**Next steps**:
+- Wire GpuMemoryEstimator output into the Debug UI tab (already noted elsewhere, but cross-ref here)
+- Add Playwright page.metrics() or performance.memory reporting to the visual test suite
+- Set soft budget watch targets (e.g. JS heap < 500MB) that emit warnings in CI/visual test output
+
+### Frame time monitoring
+**Priority**: High (as soon as we have cycles)
+**Context**: Frame time (ms) should be tracked as a routine health metric alongside tests.
+**Next steps**:
+- Collect rAF delta averages during Playwright startup test
+- Write to test-results/perf-report.json alongside console-report.json
+- Set soft watch target (e.g. avg < 16ms at startup settle time)
+
+### Linter baseline pass + CI integration
+**Priority**: High (end of Phase 1 / Phase 2 prep)
+**Context**: Linter is currently not a routine check. Before Phase 2, we want a clean lint baseline and automated enforcement.
+**Next steps**:
+- Run `yarn lint` (or `npx eslint src`), triage all current errors/warnings
+- Suppress or fix anything not worth fixing now (with explicit comments)
+- Once baseline is clean, add lint step to the same run as unit tests
+- Enforce: lint must be clean for PR merge going forward


### PR DESCRIPTION
…n tests

Clean branch built from master with only intended category-related changes:

- Add CategoryAssigner with KNOWN_GENRES canonical list + case-insensitive lookup
- Add CategoryAssigner tests (9 unit tests)
- Add CategorySignSystem and ShelfSectionPlanner (single-pass signs after all batches)
- Remove batch-time category inference from GameBoxSpawner
- GpuStorePropsRenderer accumulates games safely across init/ordering
- Fix sign anchor collisions via minimum-advance anchor policy (small groups no longer stack to one shelf)
- Fix SignageRenderer shared-canvas bug (all signs showing same text)
- Add SignageRenderer regression tests (independent canvas per sign)
- Add CategoryReferencePanel UI (+ CSS) and wire to SteamBrickAndMortarApp
- Update InteractionEvents.ShelfCreatedEvent optional fields used by GPU pipeline
- Carry roadmap/tech-debt/open-thread docs updates