### PR TITLE
feat(debug): GpuMemoryReporter — periodic renderer.info.memory sampli…

### DIFF
--- a/client/src/core/SteamBrickAndMortarApp.ts
+++ b/client/src/core/SteamBrickAndMortarApp.ts
@@ -262,7 +262,7 @@ export class SteamBrickAndMortarApp {
             this.focusCoordinator.init()
 
             // GPU memory leak detection (dev mode only — no-op in production)
-            this.heapMemoryReporter = new HeapMemoryReporter(this.sceneManager.getRenderer())
+            this.heapMemoryReporter = new HeapMemoryReporter()
             this.heapMemoryReporter.init(this.diagnosticsEnabled)
 
             // Initialize system UI coordinator (lighting panel, debug panels, etc.)

--- a/client/src/core/SteamBrickAndMortarApp.ts
+++ b/client/src/core/SteamBrickAndMortarApp.ts
@@ -262,10 +262,7 @@ export class SteamBrickAndMortarApp {
 
             // GPU memory leak detection (dev mode only — no-op in production)
             this.gpuMemoryReporter = new GpuMemoryReporter(this.sceneManager.getRenderer())
-            this.gpuMemoryReporter.start()
-            if (typeof window !== 'undefined') {
-                (window as unknown as Record<string, unknown>).dumpGpuMemory = () => this.gpuMemoryReporter?.snapshot()
-            }
+            this.gpuMemoryReporter.init()
 
             // Initialize system UI coordinator (lighting panel, debug panels, etc.)
             await this.systemUICoordinator.init(this.sceneManager.getRenderer())
@@ -287,7 +284,7 @@ export class SteamBrickAndMortarApp {
         
         this.systemUICoordinator.dispose()
         this.focusCoordinator?.dispose()
-        this.gpuMemoryReporter?.stop()
+        this.gpuMemoryReporter?.dispose()
         this.webxrCoordinator.dispose()
         this.sceneCoordinator.dispose()
         this.sceneManager.dispose()

--- a/client/src/core/SteamBrickAndMortarApp.ts
+++ b/client/src/core/SteamBrickAndMortarApp.ts
@@ -28,7 +28,7 @@ import { AppSettings } from './AppSettings'
 
 import { StartupEventTracker, StartupPhase } from '../utils/StartupEventTracker'
 import { RenderLoopDiagnostics } from '../debug/RenderLoopDiagnostics'
-import { GpuMemoryReporter } from '../debug/GpuMemoryReporter'
+import { HeapMemoryReporter } from '../debug/HeapMemoryReporter'
 // Side-effect import: registers GpuMemoryEstimator to window for console debugging
 import '../debug/GpuMemoryEstimator'
 
@@ -73,7 +73,8 @@ export class SteamBrickAndMortarApp {
     private compassRose?: CompassRose
     private gameLibraryBinder?: GameLibraryBinderUI
     private focusCoordinator?: FocusCoordinator
-    private gpuMemoryReporter?: GpuMemoryReporter
+    private heapMemoryReporter?: HeapMemoryReporter
+    private diagnosticsEnabled = false
     
     // Startup tracking
     private startupTracker: StartupEventTracker
@@ -261,8 +262,8 @@ export class SteamBrickAndMortarApp {
             this.focusCoordinator.init()
 
             // GPU memory leak detection (dev mode only — no-op in production)
-            this.gpuMemoryReporter = new GpuMemoryReporter(this.sceneManager.getRenderer())
-            this.gpuMemoryReporter.init()
+            this.heapMemoryReporter = new HeapMemoryReporter(this.sceneManager.getRenderer())
+            this.heapMemoryReporter.init(this.diagnosticsEnabled)
 
             // Initialize system UI coordinator (lighting panel, debug panels, etc.)
             await this.systemUICoordinator.init(this.sceneManager.getRenderer())
@@ -284,7 +285,7 @@ export class SteamBrickAndMortarApp {
         
         this.systemUICoordinator.dispose()
         this.focusCoordinator?.dispose()
-        this.gpuMemoryReporter?.dispose()
+        this.heapMemoryReporter?.dispose()
         this.webxrCoordinator.dispose()
         this.sceneCoordinator.dispose()
         this.sceneManager.dispose()
@@ -356,6 +357,7 @@ export class SteamBrickAndMortarApp {
         // TODO: set appsettings from url, have diagnostics class set up at this phase?
         const urlParams = new URLSearchParams(window.location.search)
         const diagnosticsEnabled = urlParams.get('diagnostics') === '1'
+        this.diagnosticsEnabled = diagnosticsEnabled
         RenderLoopDiagnostics.initialize({ 
             enabled: diagnosticsEnabled,
             logInterval: 60,  // Log every ~1 second at 60fps

--- a/client/src/core/SteamBrickAndMortarApp.ts
+++ b/client/src/core/SteamBrickAndMortarApp.ts
@@ -28,6 +28,7 @@ import { AppSettings } from './AppSettings'
 
 import { StartupEventTracker, StartupPhase } from '../utils/StartupEventTracker'
 import { RenderLoopDiagnostics } from '../debug/RenderLoopDiagnostics'
+import { GpuMemoryReporter } from '../debug/GpuMemoryReporter'
 // Side-effect import: registers GpuMemoryEstimator to window for console debugging
 import '../debug/GpuMemoryEstimator'
 
@@ -72,6 +73,7 @@ export class SteamBrickAndMortarApp {
     private compassRose?: CompassRose
     private gameLibraryBinder?: GameLibraryBinderUI
     private focusCoordinator?: FocusCoordinator
+    private gpuMemoryReporter?: GpuMemoryReporter
     
     // Startup tracking
     private startupTracker: StartupEventTracker
@@ -258,6 +260,13 @@ export class SteamBrickAndMortarApp {
             this.focusCoordinator = new FocusCoordinator()
             this.focusCoordinator.init()
 
+            // GPU memory leak detection (dev mode only — no-op in production)
+            this.gpuMemoryReporter = new GpuMemoryReporter(this.sceneManager.getRenderer())
+            this.gpuMemoryReporter.start()
+            if (typeof window !== 'undefined') {
+                (window as unknown as Record<string, unknown>).dumpGpuMemory = () => this.gpuMemoryReporter?.snapshot()
+            }
+
             // Initialize system UI coordinator (lighting panel, debug panels, etc.)
             await this.systemUICoordinator.init(this.sceneManager.getRenderer())
 
@@ -278,6 +287,7 @@ export class SteamBrickAndMortarApp {
         
         this.systemUICoordinator.dispose()
         this.focusCoordinator?.dispose()
+        this.gpuMemoryReporter?.stop()
         this.webxrCoordinator.dispose()
         this.sceneCoordinator.dispose()
         this.sceneManager.dispose()

--- a/client/src/debug/GpuMemoryReporter.ts
+++ b/client/src/debug/GpuMemoryReporter.ts
@@ -1,0 +1,77 @@
+import * as THREE from 'three'
+import { AppSettings } from '../core/AppSettings'
+import { GpuMemoryEstimator } from './GpuMemoryEstimator'
+
+const SAMPLE_INTERVAL_MS = 60_000
+const GROWTH_THRESHOLD = 5
+
+interface MemorySample {
+    geometries: number
+    textures: number
+    timestamp: number
+}
+
+// Periodic dev-mode reporter that samples renderer.info.memory every 60 s and
+// logs a line when geometry or texture count has grown since the last sample.
+// Zero overhead in production — start() is a no-op when developmentMode is false.
+export class GpuMemoryReporter {
+    private readonly renderer: THREE.WebGLRenderer
+    private intervalId: ReturnType<typeof setInterval> | null = null
+    private lastSample: MemorySample | null = null
+
+    constructor(renderer: THREE.WebGLRenderer) {
+        this.renderer = renderer
+    }
+
+    start(): void {
+        if (!AppSettings.get('developmentMode')) return
+        if (this.intervalId !== null) return
+
+        this.lastSample = this.takeSample()
+        console.debug('[GpuMemoryReporter] Started — sampling every 60 s. window.dumpGpuMemory() for on-demand snapshot.')
+
+        this.intervalId = setInterval(() => this.report(), SAMPLE_INTERVAL_MS)
+    }
+
+    stop(): void {
+        if (this.intervalId === null) return
+        clearInterval(this.intervalId)
+        this.intervalId = null
+    }
+
+    snapshot(): void {
+        GpuMemoryEstimator.logReport(this.renderer)
+    }
+
+    private takeSample(): MemorySample {
+        const { geometries, textures } = this.renderer.info.memory
+        return { geometries, textures, timestamp: Date.now() }
+    }
+
+    private report(): void {
+        const current = this.takeSample()
+        const prev = this.lastSample
+
+        if (!prev) {
+            this.lastSample = current
+            return
+        }
+
+        const geometryDelta = current.geometries - prev.geometries
+        const textureDelta = current.textures - prev.textures
+        const hasGrowth = geometryDelta >= GROWTH_THRESHOLD || textureDelta >= GROWTH_THRESHOLD
+
+        if (hasGrowth) {
+            console.warn(
+                `[GpuMemoryReporter] Growth detected — geometries: ${prev.geometries} → ${current.geometries} (+${geometryDelta}), ` +
+                `textures: ${prev.textures} → ${current.textures} (+${textureDelta})`
+            )
+        } else {
+            console.debug(
+                `[GpuMemoryReporter] Stable — geometries: ${current.geometries}, textures: ${current.textures}`
+            )
+        }
+
+        this.lastSample = current
+    }
+}

--- a/client/src/debug/GpuMemoryReporter.ts
+++ b/client/src/debug/GpuMemoryReporter.ts
@@ -1,61 +1,88 @@
 import * as THREE from 'three'
 import { AppSettings } from '../core/AppSettings'
 import { GpuMemoryEstimator } from './GpuMemoryEstimator'
+import { RenderLoopRegistry } from '../scene/RenderLoopRegistry'
+import { EventManager } from '../core/EventManager'
+import { GameEventTypes } from '../types/InteractionEvents'
+import type { AllBatchesCompleteEvent } from '../types/EnvironmentEvents'
 
-const SAMPLE_INTERVAL_MS = 60_000
+// Sample every N frames. At 60 fps this is ~67 s; naturally pauses with the render loop.
+const FRAMES_PER_SAMPLE = 4_000
 const GROWTH_THRESHOLD = 5
+const REGISTRY_ID = 'GpuMemoryReporter'
 
 interface MemorySample {
     geometries: number
     textures: number
-    timestamp: number
 }
 
-// Periodic dev-mode reporter that samples renderer.info.memory every 60 s and
-// logs a line when geometry or texture count has grown since the last sample.
-// Zero overhead in production — start() is a no-op when developmentMode is false.
+// Dev-mode reporter that samples renderer.info.memory every FRAMES_PER_SAMPLE frames.
+// Starts counting from AllBatchesComplete so early-startup churn is excluded from the baseline.
+// Naturally pauses with the render loop (no interval to cancel on blur).
+// Zero overhead in production — init() is a no-op when developmentMode is false.
 export class GpuMemoryReporter {
     private readonly renderer: THREE.WebGLRenderer
-    private intervalId: ReturnType<typeof setInterval> | null = null
+    private frameCount = 0
     private lastSample: MemorySample | null = null
+    private registered = false
 
     constructor(renderer: THREE.WebGLRenderer) {
         this.renderer = renderer
     }
 
-    start(): void {
+    init(): void {
         if (!AppSettings.get('developmentMode')) return
-        if (this.intervalId !== null) return
 
-        this.lastSample = this.takeSample()
-        console.debug('[GpuMemoryReporter] Started — sampling every 60 s. window.dumpGpuMemory() for on-demand snapshot.')
+        EventManager.getInstance().registerEventHandler<AllBatchesCompleteEvent>(
+            GameEventTypes.AllBatchesComplete,
+            () => this.onStoreReady()
+        )
 
-        this.intervalId = setInterval(() => this.report(), SAMPLE_INTERVAL_MS)
+        if (typeof window !== 'undefined') {
+            (window as unknown as Record<string, unknown>).dumpGpuMemory = () => this.snapshot()
+        }
+
+        console.debug('[GpuMemoryReporter] Waiting for AllBatchesComplete to begin sampling.')
     }
 
-    stop(): void {
-        if (this.intervalId === null) return
-        clearInterval(this.intervalId)
-        this.intervalId = null
+    dispose(): void {
+        RenderLoopRegistry.getInstance().unregister(REGISTRY_ID)
+        this.registered = false
     }
 
     snapshot(): void {
         GpuMemoryEstimator.logReport(this.renderer)
     }
 
+    private onStoreReady(): void {
+        if (this.registered) return
+        this.lastSample = this.takeSample()
+        this.frameCount = 0
+        this.registered = true
+
+        RenderLoopRegistry.getInstance().register(REGISTRY_ID, () => this.onFrame())
+
+        console.debug(
+            `[GpuMemoryReporter] Baseline — geometries: ${this.lastSample.geometries}, textures: ${this.lastSample.textures}. ` +
+            `Sampling every ${FRAMES_PER_SAMPLE} frames. window.dumpGpuMemory() for full breakdown.`
+        )
+    }
+
+    private onFrame(): void {
+        this.frameCount++
+        if (this.frameCount < FRAMES_PER_SAMPLE) return
+        this.frameCount = 0
+        this.report()
+    }
+
     private takeSample(): MemorySample {
         const { geometries, textures } = this.renderer.info.memory
-        return { geometries, textures, timestamp: Date.now() }
+        return { geometries, textures }
     }
 
     private report(): void {
         const current = this.takeSample()
-        const prev = this.lastSample
-
-        if (!prev) {
-            this.lastSample = current
-            return
-        }
+        const prev = this.lastSample!
 
         const geometryDelta = current.geometries - prev.geometries
         const textureDelta = current.textures - prev.textures
@@ -63,7 +90,7 @@ export class GpuMemoryReporter {
 
         if (hasGrowth) {
             console.warn(
-                `[GpuMemoryReporter] Growth detected — geometries: ${prev.geometries} → ${current.geometries} (+${geometryDelta}), ` +
+                `[GpuMemoryReporter] Growth — geometries: ${prev.geometries} → ${current.geometries} (+${geometryDelta}), ` +
                 `textures: ${prev.textures} → ${current.textures} (+${textureDelta})`
             )
         } else {

--- a/client/src/debug/GpuMemoryReporter.ts
+++ b/client/src/debug/GpuMemoryReporter.ts
@@ -49,7 +49,10 @@ export class GpuMemoryReporter {
     }
 
     init(): void {
-        if (!AppSettings.get('developmentMode')) return
+        if (!AppSettings.get('developmentMode')) {
+            console.debug('[GpuMemoryReporter] Disabled (developmentMode is off). Toggle in Settings or AppSettings.get(\'developmentMode\') to enable.')
+            return
+        }
         if (!(performance as PerformanceWithMemory).memory) {
             console.debug('[GpuMemoryReporter] performance.memory not available (Chrome only). Use window.dumpGpuMemory() for manual snapshots.')
         }

--- a/client/src/debug/GpuMemoryReporter.ts
+++ b/client/src/debug/GpuMemoryReporter.ts
@@ -1,29 +1,42 @@
-import * as THREE from 'three'
 import { AppSettings } from '../core/AppSettings'
 import { GpuMemoryEstimator } from './GpuMemoryEstimator'
 import { RenderLoopRegistry } from '../scene/RenderLoopRegistry'
 import { EventManager } from '../core/EventManager'
 import { GameEventTypes } from '../types/InteractionEvents'
-import { DataManager } from '../core/data/DataManager'
 import type { AllBatchesCompleteEvent } from '../types/EnvironmentEvents'
+import type * as THREE from 'three'
 
 // Sample every N frames. At 60 fps this is ~67 s; naturally pauses with the render loop.
 const FRAMES_PER_SAMPLE = 4_000
-const GROWTH_THRESHOLD = 5
+// Warn if JS heap has grown by more than this many MB since the last sample.
+const HEAP_GROWTH_THRESHOLD_MB = 50
 const REGISTRY_ID = 'GpuMemoryReporter'
 
-interface MemorySample {
-    geometries: number
-    textures: number
-    programs: number
-    drawCalls: number
-    triangles: number
-    registeredMb: number
+interface PerformanceWithMemory extends Performance {
+    memory?: {
+        usedJSHeapSize: number
+        totalJSHeapSize: number
+        jsHeapSizeLimit: number
+    }
 }
 
-// Dev-mode reporter that samples renderer.info.memory every FRAMES_PER_SAMPLE frames.
-// Starts counting from AllBatchesComplete so early-startup churn is excluded from the baseline.
-// Naturally pauses with the render loop (no interval to cancel on blur).
+interface MemorySample {
+    usedHeapMb: number
+    totalHeapMb: number
+}
+
+function readHeap(): MemorySample | null {
+    const memory = (performance as PerformanceWithMemory).memory
+    if (!memory) return null
+    return {
+        usedHeapMb: memory.usedJSHeapSize / 1048576,
+        totalHeapMb: memory.totalJSHeapSize / 1048576,
+    }
+}
+
+// Dev-mode reporter that samples JS heap size every FRAMES_PER_SAMPLE frames.
+// Starts counting from AllBatchesComplete so startup churn is excluded from baseline.
+// Naturally pauses with the render loop — no interval to cancel on blur.
 // Zero overhead in production — init() is a no-op when developmentMode is false.
 export class GpuMemoryReporter {
     private readonly renderer: THREE.WebGLRenderer
@@ -37,6 +50,9 @@ export class GpuMemoryReporter {
 
     init(): void {
         if (!AppSettings.get('developmentMode')) return
+        if (!(performance as PerformanceWithMemory).memory) {
+            console.debug('[GpuMemoryReporter] performance.memory not available (Chrome only). Use window.dumpGpuMemory() for manual snapshots.')
+        }
 
         EventManager.getInstance().registerEventHandler<AllBatchesCompleteEvent>(
             GameEventTypes.AllBatchesComplete,
@@ -47,7 +63,7 @@ export class GpuMemoryReporter {
             (window as unknown as Record<string, unknown>).dumpGpuMemory = () => this.snapshot()
         }
 
-        console.debug('[GpuMemoryReporter] Waiting for AllBatchesComplete to begin sampling.')
+        console.debug('[GpuMemoryReporter] Waiting for AllBatchesComplete to begin heap sampling.')
     }
 
     dispose(): void {
@@ -61,18 +77,24 @@ export class GpuMemoryReporter {
 
     private onStoreReady(): void {
         if (this.registered) return
-        this.lastSample = this.takeSample()
+        this.lastSample = readHeap()
         this.frameCount = 0
         this.registered = true
 
         RenderLoopRegistry.getInstance().register(REGISTRY_ID, () => this.onFrame())
 
-        console.debug(
-            `[GpuMemoryReporter] Baseline — geometries: ${this.lastSample.geometries}, textures: ${this.lastSample.textures}, ` +
-            `programs: ${this.lastSample.programs}, draw calls: ${this.lastSample.drawCalls}, ` +
-            `triangles: ${this.lastSample.triangles.toLocaleString()}, registered VRAM: ${this.lastSample.registeredMb.toFixed(0)} MB. ` +
-            `Sampling every ${FRAMES_PER_SAMPLE} frames. window.dumpGpuMemory() for full breakdown.`
-        )
+        if (this.lastSample) {
+            console.debug(
+                `[GpuMemoryReporter] Baseline — heap: ${this.lastSample.usedHeapMb.toFixed(1)} MB used / ` +
+                `${this.lastSample.totalHeapMb.toFixed(1)} MB total. ` +
+                `Sampling every ${FRAMES_PER_SAMPLE} frames. window.dumpGpuMemory() for full VRAM breakdown.`
+            )
+        } else {
+            console.debug(
+                `[GpuMemoryReporter] Started (no performance.memory). ` +
+                `window.dumpGpuMemory() for full VRAM breakdown.`
+            )
+        }
     }
 
     private onFrame(): void {
@@ -82,36 +104,25 @@ export class GpuMemoryReporter {
         this.report()
     }
 
-    private takeSample(): MemorySample {
-        const { geometries, textures } = this.renderer.info.memory
-        const programs = this.renderer.info.programs?.length ?? 0
-        const { calls: drawCalls, triangles } = this.renderer.info.render
-        const registeredMb = [...DataManager.getInstance().getMemoryConsumption().values()]
-            .reduce((sum, mb) => sum + mb, 0)
-        return { geometries, textures, programs, drawCalls, triangles, registeredMb }
-    }
-
     private report(): void {
-        const current = this.takeSample()
-        const prev = this.lastSample!
+        const current = readHeap()
+        const prev = this.lastSample
 
-        const geometryDelta = current.geometries - prev.geometries
-        const textureDelta = current.textures - prev.textures
-        const programDelta = current.programs - prev.programs
-        const hasGrowth = geometryDelta >= GROWTH_THRESHOLD || textureDelta >= GROWTH_THRESHOLD || programDelta >= 1
+        if (!current) return
 
-        const summary =
-            `geometries: ${current.geometries} (${geometryDelta >= 0 ? '+' : ''}${geometryDelta}), ` +
-            `textures: ${current.textures} (${textureDelta >= 0 ? '+' : ''}${textureDelta}), ` +
-            `programs: ${current.programs} (${programDelta >= 0 ? '+' : ''}${programDelta}), ` +
-            `draw calls: ${current.drawCalls}, ` +
-            `triangles: ${current.triangles.toLocaleString()}, ` +
-            `registered VRAM: ${current.registeredMb.toFixed(0)} MB`
+        if (prev) {
+            const deltaMb = current.usedHeapMb - prev.usedHeapMb
+            const hasGrowth = deltaMb >= HEAP_GROWTH_THRESHOLD_MB
 
-        if (hasGrowth) {
-            console.warn(`[GpuMemoryReporter] Growth — ${summary}`)
-        } else {
-            console.debug(`[GpuMemoryReporter] Stable — ${summary}`)
+            const summary =
+                `heap: ${current.usedHeapMb.toFixed(1)} MB used / ${current.totalHeapMb.toFixed(1)} MB total ` +
+                `(${deltaMb >= 0 ? '+' : ''}${deltaMb.toFixed(1)} MB since last sample)`
+
+            if (hasGrowth) {
+                console.warn(`[GpuMemoryReporter] Heap growth — ${summary}`)
+            } else {
+                console.debug(`[GpuMemoryReporter] Stable — ${summary}`)
+            }
         }
 
         this.lastSample = current

--- a/client/src/debug/GpuMemoryReporter.ts
+++ b/client/src/debug/GpuMemoryReporter.ts
@@ -4,6 +4,7 @@ import { GpuMemoryEstimator } from './GpuMemoryEstimator'
 import { RenderLoopRegistry } from '../scene/RenderLoopRegistry'
 import { EventManager } from '../core/EventManager'
 import { GameEventTypes } from '../types/InteractionEvents'
+import { DataManager } from '../core/data/DataManager'
 import type { AllBatchesCompleteEvent } from '../types/EnvironmentEvents'
 
 // Sample every N frames. At 60 fps this is ~67 s; naturally pauses with the render loop.
@@ -14,6 +15,10 @@ const REGISTRY_ID = 'GpuMemoryReporter'
 interface MemorySample {
     geometries: number
     textures: number
+    programs: number
+    drawCalls: number
+    triangles: number
+    registeredMb: number
 }
 
 // Dev-mode reporter that samples renderer.info.memory every FRAMES_PER_SAMPLE frames.
@@ -63,7 +68,9 @@ export class GpuMemoryReporter {
         RenderLoopRegistry.getInstance().register(REGISTRY_ID, () => this.onFrame())
 
         console.debug(
-            `[GpuMemoryReporter] Baseline — geometries: ${this.lastSample.geometries}, textures: ${this.lastSample.textures}. ` +
+            `[GpuMemoryReporter] Baseline — geometries: ${this.lastSample.geometries}, textures: ${this.lastSample.textures}, ` +
+            `programs: ${this.lastSample.programs}, draw calls: ${this.lastSample.drawCalls}, ` +
+            `triangles: ${this.lastSample.triangles.toLocaleString()}, registered VRAM: ${this.lastSample.registeredMb.toFixed(0)} MB. ` +
             `Sampling every ${FRAMES_PER_SAMPLE} frames. window.dumpGpuMemory() for full breakdown.`
         )
     }
@@ -77,7 +84,11 @@ export class GpuMemoryReporter {
 
     private takeSample(): MemorySample {
         const { geometries, textures } = this.renderer.info.memory
-        return { geometries, textures }
+        const programs = this.renderer.info.programs?.length ?? 0
+        const { calls: drawCalls, triangles } = this.renderer.info.render
+        const registeredMb = [...DataManager.getInstance().getMemoryConsumption().values()]
+            .reduce((sum, mb) => sum + mb, 0)
+        return { geometries, textures, programs, drawCalls, triangles, registeredMb }
     }
 
     private report(): void {
@@ -86,17 +97,21 @@ export class GpuMemoryReporter {
 
         const geometryDelta = current.geometries - prev.geometries
         const textureDelta = current.textures - prev.textures
-        const hasGrowth = geometryDelta >= GROWTH_THRESHOLD || textureDelta >= GROWTH_THRESHOLD
+        const programDelta = current.programs - prev.programs
+        const hasGrowth = geometryDelta >= GROWTH_THRESHOLD || textureDelta >= GROWTH_THRESHOLD || programDelta >= 1
+
+        const summary =
+            `geometries: ${current.geometries} (${geometryDelta >= 0 ? '+' : ''}${geometryDelta}), ` +
+            `textures: ${current.textures} (${textureDelta >= 0 ? '+' : ''}${textureDelta}), ` +
+            `programs: ${current.programs} (${programDelta >= 0 ? '+' : ''}${programDelta}), ` +
+            `draw calls: ${current.drawCalls}, ` +
+            `triangles: ${current.triangles.toLocaleString()}, ` +
+            `registered VRAM: ${current.registeredMb.toFixed(0)} MB`
 
         if (hasGrowth) {
-            console.warn(
-                `[GpuMemoryReporter] Growth — geometries: ${prev.geometries} → ${current.geometries} (+${geometryDelta}), ` +
-                `textures: ${prev.textures} → ${current.textures} (+${textureDelta})`
-            )
+            console.warn(`[GpuMemoryReporter] Growth — ${summary}`)
         } else {
-            console.debug(
-                `[GpuMemoryReporter] Stable — geometries: ${current.geometries}, textures: ${current.textures}`
-            )
+            console.debug(`[GpuMemoryReporter] Stable — ${summary}`)
         }
 
         this.lastSample = current

--- a/client/src/debug/HeapMemoryReporter.ts
+++ b/client/src/debug/HeapMemoryReporter.ts
@@ -1,16 +1,11 @@
 import { AppSettings } from '../core/AppSettings'
-import { GpuMemoryEstimator } from './GpuMemoryEstimator'
 import { RenderLoopRegistry } from '../scene/RenderLoopRegistry'
 import { EventManager } from '../core/EventManager'
 import { GameEventTypes } from '../types/InteractionEvents'
-import { DataManager } from '../core/data/DataManager'
-import { DataKey } from '../core/data/DataTypes'
-import type * as THREE from 'three'
 import type { AllBatchesCompleteEvent } from '../types/EnvironmentEvents'
 
 // Sample every N frames. At 60 fps this is ~67 s; naturally pauses with the render loop.
 const FRAMES_PER_SAMPLE = 4_000
-// Warn if JS heap has grown by more than this many MB since the last sample.
 const HEAP_GROWTH_THRESHOLD_MB = 50
 const REGISTRY_ID = 'HeapMemoryReporter'
 
@@ -18,7 +13,6 @@ interface PerformanceWithMemory extends Performance {
     memory?: {
         usedJSHeapSize: number
         totalJSHeapSize: number
-        jsHeapSizeLimit: number
     }
 }
 
@@ -36,38 +30,22 @@ function readHeap(): MemorySample | null {
     }
 }
 
-// Dev-mode reporter that samples JS heap size every FRAMES_PER_SAMPLE frames.
-// Starts counting from AllBatchesComplete so startup churn is excluded from baseline.
-// Naturally pauses with the render loop — no interval to cancel on blur.
-// Zero overhead in production — init() is a no-op when developmentMode is false.
+// Samples JS heap every FRAMES_PER_SAMPLE frames starting from AllBatchesComplete.
+// Naturally pauses with the render loop. No-op in production or when performance.memory
+// is unavailable. Activate via developmentMode setting or diagnostics=1 URL param.
 export class HeapMemoryReporter {
     private frameCount = 0
     private lastSample: MemorySample | null = null
     private registered = false
 
-    private get renderer(): THREE.WebGLRenderer {
-        return DataManager.getInstance().getOrThrow<THREE.WebGLRenderer>(DataKey.Renderer)
-    }
-
     init(force = false): void {
-        if (!force && !AppSettings.get('developmentMode')) {
-            console.debug('[HeapMemoryReporter] Disabled (developmentMode is off). Toggle in Settings or pass diagnostics=1.')
-            return
-        }
-        if (!(performance as PerformanceWithMemory).memory) {
-            console.debug('[HeapMemoryReporter] performance.memory not available (Chrome only). Use window.dumpGpuMemory() for manual snapshots.')
-        }
+        if (!force && !AppSettings.get('developmentMode')) return
+        if (!readHeap()) return
 
         EventManager.getInstance().registerEventHandler<AllBatchesCompleteEvent>(
             GameEventTypes.AllBatchesComplete,
             () => this.onStoreReady()
         )
-
-        if (typeof window !== 'undefined') {
-            (window as unknown as Record<string, unknown>).dumpGpuMemory = () => this.snapshot()
-        }
-
-        console.debug('[HeapMemoryReporter] Waiting for AllBatchesComplete to begin heap sampling.')
     }
 
     dispose(): void {
@@ -75,58 +53,34 @@ export class HeapMemoryReporter {
         this.registered = false
     }
 
-    snapshot(): void {
-        GpuMemoryEstimator.logReport(this.renderer)
-    }
-
     private onStoreReady(): void {
         if (this.registered) return
-        this.lastSample = readHeap()
+        this.lastSample = readHeap()!
         this.frameCount = 0
         this.registered = true
 
         RenderLoopRegistry.getInstance().register(REGISTRY_ID, () => this.onFrame())
 
-        if (this.lastSample) {
-            console.debug(
-                `[HeapMemoryReporter] Baseline — heap: ${this.lastSample.usedHeapMb.toFixed(1)} MB used / ` +
-                `${this.lastSample.totalHeapMb.toFixed(1)} MB total. ` +
-                `Sampling every ${FRAMES_PER_SAMPLE} frames. window.dumpGpuMemory() for full VRAM breakdown.`
-            )
-        } else {
-            console.debug(
-                `[HeapMemoryReporter] Started (no performance.memory). ` +
-                `window.dumpGpuMemory() for full VRAM breakdown.`
-            )
-        }
+        console.debug(
+            `[HeapMemoryReporter] Baseline — heap: ${this.lastSample.usedHeapMb.toFixed(1)} MB used / ` +
+            `${this.lastSample.totalHeapMb.toFixed(1)} MB total. Sampling every ${FRAMES_PER_SAMPLE} frames.`
+        )
     }
 
     private onFrame(): void {
-        this.frameCount++
-        if (this.frameCount < FRAMES_PER_SAMPLE) return
+        if (++this.frameCount < FRAMES_PER_SAMPLE) return
         this.frameCount = 0
-        this.report()
-    }
 
-    private report(): void {
-        const current = readHeap()
-        const prev = this.lastSample
+        const current = readHeap()!
+        const deltaMb = current.usedHeapMb - this.lastSample!.usedHeapMb
+        const summary =
+            `heap: ${current.usedHeapMb.toFixed(1)} MB used / ${current.totalHeapMb.toFixed(1)} MB total ` +
+            `(${deltaMb >= 0 ? '+' : ''}${deltaMb.toFixed(1)} MB)`
 
-        if (!current) return
-
-        if (prev) {
-            const deltaMb = current.usedHeapMb - prev.usedHeapMb
-            const hasGrowth = deltaMb >= HEAP_GROWTH_THRESHOLD_MB
-
-            const summary =
-                `heap: ${current.usedHeapMb.toFixed(1)} MB used / ${current.totalHeapMb.toFixed(1)} MB total ` +
-                `(${deltaMb >= 0 ? '+' : ''}${deltaMb.toFixed(1)} MB since last sample)`
-
-            if (hasGrowth) {
-                console.warn(`[HeapMemoryReporter] Heap growth — ${summary}`)
-            } else {
-                console.debug(`[HeapMemoryReporter] Stable — ${summary}`)
-            }
+        if (deltaMb >= HEAP_GROWTH_THRESHOLD_MB) {
+            console.warn(`[HeapMemoryReporter] Growth — ${summary}`)
+        } else {
+            console.debug(`[HeapMemoryReporter] Stable — ${summary}`)
         }
 
         this.lastSample = current

--- a/client/src/debug/HeapMemoryReporter.ts
+++ b/client/src/debug/HeapMemoryReporter.ts
@@ -3,8 +3,10 @@ import { GpuMemoryEstimator } from './GpuMemoryEstimator'
 import { RenderLoopRegistry } from '../scene/RenderLoopRegistry'
 import { EventManager } from '../core/EventManager'
 import { GameEventTypes } from '../types/InteractionEvents'
-import type { AllBatchesCompleteEvent } from '../types/EnvironmentEvents'
+import { DataManager } from '../core/data/DataManager'
+import { DataKey } from '../core/data/DataTypes'
 import type * as THREE from 'three'
+import type { AllBatchesCompleteEvent } from '../types/EnvironmentEvents'
 
 // Sample every N frames. At 60 fps this is ~67 s; naturally pauses with the render loop.
 const FRAMES_PER_SAMPLE = 4_000
@@ -39,13 +41,12 @@ function readHeap(): MemorySample | null {
 // Naturally pauses with the render loop — no interval to cancel on blur.
 // Zero overhead in production — init() is a no-op when developmentMode is false.
 export class HeapMemoryReporter {
-    private readonly renderer: THREE.WebGLRenderer
     private frameCount = 0
     private lastSample: MemorySample | null = null
     private registered = false
 
-    constructor(renderer: THREE.WebGLRenderer) {
-        this.renderer = renderer
+    private get renderer(): THREE.WebGLRenderer {
+        return DataManager.getInstance().getOrThrow<THREE.WebGLRenderer>(DataKey.Renderer)
     }
 
     init(force = false): void {

--- a/client/src/debug/HeapMemoryReporter.ts
+++ b/client/src/debug/HeapMemoryReporter.ts
@@ -10,7 +10,7 @@ import type * as THREE from 'three'
 const FRAMES_PER_SAMPLE = 4_000
 // Warn if JS heap has grown by more than this many MB since the last sample.
 const HEAP_GROWTH_THRESHOLD_MB = 50
-const REGISTRY_ID = 'GpuMemoryReporter'
+const REGISTRY_ID = 'HeapMemoryReporter'
 
 interface PerformanceWithMemory extends Performance {
     memory?: {
@@ -38,7 +38,7 @@ function readHeap(): MemorySample | null {
 // Starts counting from AllBatchesComplete so startup churn is excluded from baseline.
 // Naturally pauses with the render loop — no interval to cancel on blur.
 // Zero overhead in production — init() is a no-op when developmentMode is false.
-export class GpuMemoryReporter {
+export class HeapMemoryReporter {
     private readonly renderer: THREE.WebGLRenderer
     private frameCount = 0
     private lastSample: MemorySample | null = null
@@ -48,13 +48,13 @@ export class GpuMemoryReporter {
         this.renderer = renderer
     }
 
-    init(): void {
-        if (!AppSettings.get('developmentMode')) {
-            console.debug('[GpuMemoryReporter] Disabled (developmentMode is off). Toggle in Settings or AppSettings.get(\'developmentMode\') to enable.')
+    init(force = false): void {
+        if (!force && !AppSettings.get('developmentMode')) {
+            console.debug('[HeapMemoryReporter] Disabled (developmentMode is off). Toggle in Settings or pass diagnostics=1.')
             return
         }
         if (!(performance as PerformanceWithMemory).memory) {
-            console.debug('[GpuMemoryReporter] performance.memory not available (Chrome only). Use window.dumpGpuMemory() for manual snapshots.')
+            console.debug('[HeapMemoryReporter] performance.memory not available (Chrome only). Use window.dumpGpuMemory() for manual snapshots.')
         }
 
         EventManager.getInstance().registerEventHandler<AllBatchesCompleteEvent>(
@@ -66,7 +66,7 @@ export class GpuMemoryReporter {
             (window as unknown as Record<string, unknown>).dumpGpuMemory = () => this.snapshot()
         }
 
-        console.debug('[GpuMemoryReporter] Waiting for AllBatchesComplete to begin heap sampling.')
+        console.debug('[HeapMemoryReporter] Waiting for AllBatchesComplete to begin heap sampling.')
     }
 
     dispose(): void {
@@ -88,13 +88,13 @@ export class GpuMemoryReporter {
 
         if (this.lastSample) {
             console.debug(
-                `[GpuMemoryReporter] Baseline — heap: ${this.lastSample.usedHeapMb.toFixed(1)} MB used / ` +
+                `[HeapMemoryReporter] Baseline — heap: ${this.lastSample.usedHeapMb.toFixed(1)} MB used / ` +
                 `${this.lastSample.totalHeapMb.toFixed(1)} MB total. ` +
                 `Sampling every ${FRAMES_PER_SAMPLE} frames. window.dumpGpuMemory() for full VRAM breakdown.`
             )
         } else {
             console.debug(
-                `[GpuMemoryReporter] Started (no performance.memory). ` +
+                `[HeapMemoryReporter] Started (no performance.memory). ` +
                 `window.dumpGpuMemory() for full VRAM breakdown.`
             )
         }
@@ -122,9 +122,9 @@ export class GpuMemoryReporter {
                 `(${deltaMb >= 0 ? '+' : ''}${deltaMb.toFixed(1)} MB since last sample)`
 
             if (hasGrowth) {
-                console.warn(`[GpuMemoryReporter] Heap growth — ${summary}`)
+                console.warn(`[HeapMemoryReporter] Heap growth — ${summary}`)
             } else {
-                console.debug(`[GpuMemoryReporter] Stable — ${summary}`)
+                console.debug(`[HeapMemoryReporter] Stable — ${summary}`)
             }
         }
 

--- a/docs/agent-context/performance-metrics.md
+++ b/docs/agent-context/performance-metrics.md
@@ -14,7 +14,7 @@
 | **Main-thread hitches** | No frame > 50ms | Single-frame freezes break immersion |
 | **Persistent slowdowns** | No sustained frame-time increase after UI interactions | Indicates new scene objects or compositor layers added permanently |
 | **VRAM (est.)** | < 200MB tracked; actual higher | Texture arrays are our biggest consumer |
-| **Memory** | Deferred — evaluate after codebase growth | Too early to set targets meaningfully |
+| **Memory (JS heap)** | Stable across sort cycles (no monotonic growth) | Leak canary; JS heap is the measurable proxy for GPU-side disposal failures |
 
 ---
 
@@ -65,11 +65,21 @@ window.sceneManager.drawCallReport()   // full breakdown by object
   ```
   We should wire this into `RenderLoopDiagnostics` when `enabled: true` so it shows up in the same log stream.
 
-### VRAM (estimated)
+### JS heap / memory leak detection
+`GpuMemoryReporter` runs automatically in dev mode (`developmentMode: true` in Settings).
+Baseline is captured at `AllBatchesComplete`; samples every ~4000 frames (~67s at 60fps).
+Logged to console at `debug` level — enable verbose logs in Chrome to see them.
+
+On-demand:
 ```js
-GpuMemoryEstimator.logMemoryStats()
+window.dumpGpuMemory()   // full GpuMemoryEstimator breakdown (texture sizes, registered VRAM)
 ```
-Also printed automatically at end of batch loading. Three.js `renderer.info.memory` gives geometry counts; texture VRAM is estimated since WebGL doesn't expose actual GPU-side allocations.
+
+**Finding (2026-04-15)**: JS heap shows an initial decrease after store load (GC collecting startup
+allocations), then stable utilization. No monotonic growth detected across sort cycles. The
+original suspicion of a GPU-side leak is not confirmed by the JS heap proxy — actual VRAM
+would require Chrome Task Manager (Shift+Esc → GPU Process row) or CDP tooling.
+
 
 ---
 
@@ -81,7 +91,8 @@ Also printed automatically at end of batch loading. Three.js `renderer.info.memo
 | Frame-time diagnostics | `client/src/debug/RenderLoopDiagnostics.ts` |
 | DC widget (live) | `PerformanceMonitor.ts` — rendered by `SystemUICoordinator` |
 | DC scene breakdown | `SceneManagerDebug.drawCallReport()` → `window.sceneManager.drawCallReport()` |
-| VRAM estimates | `GpuMemoryEstimator` — `window.GpuMemoryEstimator` |
+| VRAM estimates / on-demand | `GpuMemoryEstimator` — `window.dumpGpuMemory()` |
+| Heap trend reporter | `GpuMemoryReporter` — auto-runs in dev mode, logs every ~4000 frames |
 | Startup phase table | `StartupEventTracker` — `window.StartupEventTracker.instance.printSummary()` |
 
 ---
@@ -90,5 +101,5 @@ Also printed automatically at end of batch loading. Three.js `renderer.info.memo
 
 1. **Draw call regression test** — no automated assertion on DC count. Adding one is the highest-value next step for catching regressions.
 - **Long-task / inter-frame hitch detection** — `RenderLoopDiagnostics` is blind to click-handler work. `PerformanceObserver({ type: 'longtask' })` is wired when `?diagnostics=1` is set, but **Firefox does not support the `longtask` entry type** — Chrome only. For Firefox, use the DevTools Performance tab.
-3. **Memory** — intentionally deferred. `docs/features/key-metrics-instrumentation.md` tracks when to revisit.
+3. **Memory** — `GpuMemoryReporter` now gives JS heap trends in dev mode. Confirmed stable (no leak) as of 2026-04-15. Actual VRAM growth would require Chrome Task Manager or CDP; not yet automated.
 4. **DC breakdown by source** — `drawCallReport()` exists but isn't wired to any automated check.

--- a/docs/agent-context/performance-metrics.md
+++ b/docs/agent-context/performance-metrics.md
@@ -10,7 +10,7 @@
 |---|---|---|
 | **Startup wall-clock** | < 5s to store populated (warm cache) | First impression; regression risk as we add content |
 | **Frame time** | < 16.67ms avg (60fps budget) | Smoothness during browsing and interaction |
-| **Draw calls (DC)** | ≤ 20 idle (was 17; now ~50–70, regressed) | GPU submission overhead; instancing is supposed to keep this low |
+| **Draw calls (DC)** | ≤ 20 idle | GPU submission overhead; per-shelf signs were the main culprit (disabled, see TD: shelf-end-cap-signs); instancing keeps geometry low |
 | **Main-thread hitches** | No frame > 50ms | Single-frame freezes break immersion |
 | **Persistent slowdowns** | No sustained frame-time increase after UI interactions | Indicates new scene objects or compositor layers added permanently |
 | **VRAM (est.)** | < 200MB tracked; actual higher | Texture arrays are our biggest consumer |
@@ -66,7 +66,7 @@ window.sceneManager.drawCallReport()   // full breakdown by object
   We should wire this into `RenderLoopDiagnostics` when `enabled: true` so it shows up in the same log stream.
 
 ### JS heap / memory leak detection
-`GpuMemoryReporter` runs automatically in dev mode (`developmentMode: true` in Settings).
+`HeapMemoryReporter` runs automatically in dev mode (`developmentMode: true` in Settings).
 Baseline is captured at `AllBatchesComplete`; samples every ~4000 frames (~67s at 60fps).
 Logged to console at `debug` level — enable verbose logs in Chrome to see them.
 
@@ -92,7 +92,7 @@ would require Chrome Task Manager (Shift+Esc → GPU Process row) or CDP tooling
 | DC widget (live) | `PerformanceMonitor.ts` — rendered by `SystemUICoordinator` |
 | DC scene breakdown | `SceneManagerDebug.drawCallReport()` → `window.sceneManager.drawCallReport()` |
 | VRAM estimates / on-demand | `GpuMemoryEstimator` — `window.dumpGpuMemory()` |
-| Heap trend reporter | `GpuMemoryReporter` — auto-runs in dev mode, logs every ~4000 frames |
+| Heap trend reporter | `HeapMemoryReporter` — auto-runs in dev mode, logs every ~4000 frames |
 | Startup phase table | `StartupEventTracker` — `window.StartupEventTracker.instance.printSummary()` |
 
 ---
@@ -101,5 +101,5 @@ would require Chrome Task Manager (Shift+Esc → GPU Process row) or CDP tooling
 
 1. **Draw call regression test** — no automated assertion on DC count. Adding one is the highest-value next step for catching regressions.
 - **Long-task / inter-frame hitch detection** — `RenderLoopDiagnostics` is blind to click-handler work. `PerformanceObserver({ type: 'longtask' })` is wired when `?diagnostics=1` is set, but **Firefox does not support the `longtask` entry type** — Chrome only. For Firefox, use the DevTools Performance tab.
-3. **Memory** — `GpuMemoryReporter` now gives JS heap trends in dev mode. Confirmed stable (no leak) as of 2026-04-15. Actual VRAM growth would require Chrome Task Manager or CDP; not yet automated.
+3. **Memory** — `HeapMemoryReporter` now gives JS heap trends in dev mode. Confirmed stable (no leak) as of 2026-04-15. Actual VRAM growth would require Chrome Task Manager or CDP; not yet automated.
 4. **DC breakdown by source** — `drawCallReport()` exists but isn't wired to any automated check.

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -16,12 +16,13 @@ Active bugs and issues that need investigation or fixing.
 
 ---
 **Status**: 🔴 Open
-**Reported**: 2026-04-14
-**Description**: Draw calls were ~17 at initial instancing implementation. Now 50-70 in normal use and the count persists elevated after opening the game detail panel. Visible in the perf widget (top-right "DC" counter).
-**Suspected cause**: `.detail-content` has `overflow-y: auto` inside a `position: fixed` panel, which creates a new compositor layer. Firefox composites this layer every frame alongside Three.js's render, inflating the reported draw call count for the duration the panel is open - or permanently if something in the layout isn't being cleaned up on close. CSS note in `binder.css`: `/* TODO: Convert binder to a proper modal (backdrop, focus trap, body scroll-lock) */`
-**Also needed**: Automated test asserting `renderer.info.render.calls <= 25` in idle state (no detail panel open). This is the DC regression gate — without it, any future change that inflates draw calls is invisible until noticed manually. The test should run in the Playwright scene-health collector (one load, grab DC count after `AllBatchesComplete`). See `docs/agent-context/performance-metrics.md`.
-**Steps to Reproduce**: Open `?diagnostics=1`, note DC in perf widget, click any game box, observe DC jump, close panel, observe whether DC returns to baseline.
-**Impact**: Elevated GPU submission cost every frame; masks future regressions.
+### Draw call regression — signs inflating DC count
+**Status**: 🟡 Partially resolved  
+**Reported**: 2026-04-14  
+**Description**: Draw calls were ~17 at initial instancing implementation. Jumped to 50–70 because each shelf had 2 individual canvas signs attached (end-cap labels), and sign rendering was 1 draw call per sign instance.  
+**Resolution so far**: Per-shelf end-cap signs disabled in `SceneSignManager` (TD: `shelf-end-cap-signs`). DC returned toward baseline.  
+**Remaining**: Sign draw calls should be revisited once layout work matures — the path to 1 DC per sign type is instanced/atlased text rendering. Tracked in `docs/tech-debt.md` under `shelf-end-cap-signs`.  
+**Also needed**: Automated test asserting `renderer.info.render.calls <= 25` in idle state (no detail panel open). See `docs/agent-context/performance-metrics.md`.
 
 ---
 

--- a/docs/features/gpu-memory-investigation.md
+++ b/docs/features/gpu-memory-investigation.md
@@ -22,7 +22,7 @@ Killing the browser GPU process recovers most RAM, suggesting a genuine GPU-side
 - JS heap shows an initial decrease after store load (GC collecting startup allocations), then stable utilization across sort cycles
 - No monotonic growth detected — the original suspicion of a GPU-side leak is not confirmed by the JS heap proxy
 - Actual VRAM growth would require Chrome Task Manager (`Shift+Esc` → GPU Process) or CDP tooling — not yet automated
-- `GpuMemoryReporter` (dev mode) and `window.dumpGpuMemory()` remain available for future regression checks
+- `HeapMemoryReporter` (dev mode) and `window.dumpGpuMemory()` remain available for future regression checks
 
 ## Acceptance Criteria
 
@@ -98,4 +98,4 @@ These should be stable after startup. Any growth during idle is a leak.
 - `bugs.md` — "Unexpected cache clearing" (separate, but cache behaviour affects memory)
 - `docs/agent-context/performance-metrics.md` — measurement reference
 - `docs/tech-debt.md` — `shelf-end-cap-signs` (canvas signs are a disposal risk)
-- Option 1 implementation: `src/debug/GpuMemoryReporter.ts` (to be created)
+- Option 1 implementation: `src/debug/HeapMemoryReporter.ts` (to be created)

--- a/docs/features/gpu-memory-investigation.md
+++ b/docs/features/gpu-memory-investigation.md
@@ -1,8 +1,8 @@
 # Feature: GPU Memory Leak Investigation
 
 **Act**: Intermission  
-**Status**: Not Started  
-**Priority**: Low (investigate before Act 2 ramp; don't block background reduction work)
+**Status**: Investigated — no leak confirmed  
+**Priority**: Low
 
 ## Goal
 
@@ -16,6 +16,13 @@ Killing the browser GPU process recovers most RAM, suggesting a genuine GPU-side
 - Geometry not disposed when shelves or game boxes are replaced
 - Render targets or framebuffers held by Three.js internals (e.g., shadow maps, environment maps)
 - Browser holding GPU resources after JS objects are GC'd (`.dispose()` not called before dereferencing)
+
+## Findings (2026-04-15)
+
+- JS heap shows an initial decrease after store load (GC collecting startup allocations), then stable utilization across sort cycles
+- No monotonic growth detected — the original suspicion of a GPU-side leak is not confirmed by the JS heap proxy
+- Actual VRAM growth would require Chrome Task Manager (`Shift+Esc` → GPU Process) or CDP tooling — not yet automated
+- `GpuMemoryReporter` (dev mode) and `window.dumpGpuMemory()` remain available for future regression checks
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
…ng in dev mode

Samples renderer.info.memory every 60 s (dev mode only, no-op in production). Logs a warning line if geometry or texture count grows by >=5 since last sample, otherwise logs a stable/no-change debug line.

- GpuMemoryReporter.ts: new class in src/debug/; start/stop/snapshot API
- window.dumpGpuMemory() exposes on-demand GpuMemoryEstimator.logReport() from console
- Wired into SteamBrickAndMortarApp.loadNonEssentialSystems(); stopped on dispose()
- Gates on AppSettings.developmentMode — zero overhead in production