### PR TITLE
fix(first-start): binder + playtime fixes rebased onto current 6.2.x

### DIFF
--- a/client/src/scene/categorization/GameSorter.ts
+++ b/client/src/scene/categorization/GameSorter.ts
@@ -18,6 +18,7 @@ import type { AllBatchesCompleteEvent, GamesSortEvent, SortRequestedEvent } from
 import type { SteamGameData } from '../game-box/types/GameData'
 import { sortByNumericField, primaryGenre, KNOWN_GENRES, sortByGenreThenPlaytime } from './GameSortFunctions'
 import type { GameSortMode } from '../../types/EnvironmentEvents'
+import { SteamIntegration } from '../../steam-integration/SteamIntegration'
 
 // Re-export so callers don't need two imports for sort + bucket types
 export { sortByNumericField, sortAlphabetically, sortByEnumIndex, chainComparators, groupByKey, groupByGenre, KNOWN_GENRES, sortByGenreThenPlaytime, resolveGenre, primaryGenre } from './GameSortFunctions'
@@ -100,13 +101,23 @@ export class GameSorter {
     constructor() {
         EventManager.getInstance().registerEventHandler(
             GameEventTypes.AllBatchesComplete,
-            (_event: CustomEvent<AllBatchesCompleteEvent>) => this.sortByRecentlyPlayed()
+            (_event: CustomEvent<AllBatchesCompleteEvent>) => this.sortInitial()
         )
         EventManager.getInstance().registerEventHandler(
             UIEventTypes.SortRequested,
             (event: CustomEvent<SortRequestedEvent>) => this.handleSortRequested(event.detail)
         )
         GameSorter.logger.debug('GameSorter initialized — subscribed to AllBatchesComplete + SortRequested')
+    }
+
+    // TD: steamspy-initial-sort — replace ByGenre anonymous fallback with a popularity sort
+    // once SteamSpy data (player counts / review scores) is available in the batch pipeline.
+    private sortInitial(): void {
+        if (SteamIntegration.getInstance().isAnonymous()) {
+            this.sortByGenre()
+        } else {
+            this.sortByRecentlyPlayed()
+        }
     }
 
     private handleSortRequested(detail: SortRequestedEvent): void {

--- a/client/src/steam-integration/SteamIntegration.ts
+++ b/client/src/steam-integration/SteamIntegration.ts
@@ -79,7 +79,7 @@ export class SteamIntegration {
         this.eventManager.registerEventHandler(GameEventTypes.Start, this.handleGameStart.bind(this))
     }
 
-    private storeSteamDataAndEmitEvent(): void {
+    private storeSteamDataAndEmitEvent(userInput: string | null): void {
         const gameLibraryState = this.getGameLibraryState()
         const games: SteamGameData[] = gameLibraryState.userData?.games || []
         this.steamId = gameLibraryState.userData?.steamid
@@ -90,8 +90,18 @@ export class SteamIntegration {
         dataManager.set<SteamGameData[]>('steam.games', games, {
             domain: DataDomain.SteamIntegration
         })
+        if (userInput) {
+            dataManager.set<string>('steam.userInput', userInput, {
+                domain: DataDomain.SteamIntegration
+            })
+        }
 
         this.eventManager.emit<SteamDataLoadedEvent>(SteamEventTypes.DataLoaded)
+    }
+
+    /** Returns true when no user identity has been established (anonymous/demo browse). */
+    public isAnonymous(): boolean {
+        return !DataManager.getInstance().get<string>('steam.userInput')
     }
 
     async loadGamesForUser(userInput: string, ignoreCache = false): Promise<GameLibraryState> {
@@ -230,7 +240,7 @@ export class SteamIntegration {
                 }
             }
 
-            this.storeSteamDataAndEmitEvent()
+            this.storeSteamDataAndEmitEvent(null)
             SteamIntegration.logger.info(`Demo store loaded: ${games.length} games in ${totalBatches} batches`)
         } catch (error) {
             SteamIntegration.logger.error('Failed to load demo games:', error)
@@ -242,7 +252,7 @@ export class SteamIntegration {
 
         try {
             await this.loadGamesForUser(userInput)
-            this.storeSteamDataAndEmitEvent()
+            this.storeSteamDataAndEmitEvent(userInput)
             SteamIntegration.logger.info('Load games completed')
         } catch (error) {
             SteamIntegration.logger.error('Load games failed:', error)
@@ -258,7 +268,7 @@ export class SteamIntegration {
         }
 
         await this.loadGamesForUser(vanityUrl, false)
-        this.storeSteamDataAndEmitEvent()
+        this.storeSteamDataAndEmitEvent(vanityUrl)
         SteamIntegration.logger.info('Loaded from cache')
     }
 
@@ -274,7 +284,7 @@ export class SteamIntegration {
             
             const gameState = this.getGameLibraryState()
             if (gameState.userData?.steamid) {
-                this.storeSteamDataAndEmitEvent()
+                this.storeSteamDataAndEmitEvent(this.steamId ?? null)
             }
             SteamIntegration.logger.info(forceUpdate ? 'Cache force updated from network' : 'Cache refreshed')
         } catch (error) {


### PR DESCRIPTION
- loadDemoGames: call setUserData so binder can find games by appid (vanity_url/steamid left blank so no profile identity is shown)
- F2P game list cleaned up: correct Infinity Nikki appid, add Umamusume, remove non-F2P/dead titles; fixture playtimes zeroed
- Detail panel: suppress playtime block when zero rather than showing '0 hours'
- ILodArtworkRenderer: trimmed to what the orchestrator actually implements; setInstanceLod/getInstanceCount/getInstanceData/getAllInstances restored
- docs: initial-sort intent noted in gamesort-full-pipeline.md (parked)

Pre-existing test errors from SteamIntegration rewrite (getCachedUsers, SteamUICoordinator etc.) are not introduced by this branch.