### PR TITLE
feat(renderer): library-lifetime renderer + layout-switch without Ste…

### DIFF
--- a/WORK.md
+++ b/WORK.md
@@ -1,25 +1,33 @@
-# WORK.md — feat-group-sort-separation
+# WORK.md — feat-renderer-lifecycle
 
-**Branch:** `openclaw/feat-group-sort-separation`  
+**Branch:** `openclaw/feat-renderer-lifecycle`  
 **Base:** `act1-intermission`
 
 ## Goal
-Separate Group, Sort, and Layout as three independent player-facing controls.
-No shimming: clean split, old fused `GameSortMode` deleted.
+- Renderer initialized once per library load, sized to full game count
+- Layout switches rebuild geometry without reloading library (no Steam API hit)
+- All capacity checks removed
 
 ## Approach
-1. **Types first** (`GroupMode`, `SortMode`, update `Section` + events)
-2. **Logic** (`GroupResolver` partitions, `GameSorter`/`SectionSorter` sorts within)
-3. **UI** (`LayoutControlPanel` — three dropdowns)
+
+1. `StorePropsCoordinator.handleLayoutRequested`:
+   - Remove `SteamEventTypes.LoadLibrary` emit
+   - Instead: emit `ClearRequest` + `SetupRequest` + `GameDataReady` (from DataManager)
+
+2. `GameBoxSpawner`:
+   - Listen to `GameDataReady` to initialize renderer at library size
+   - On `ClearRequest` (layout switch): `clearPlacements()` only, keep renderer + prefetchResults
+   - On genuine library reload signal: full dispose+recreate
+   - Remove all capacity checks
+
+3. Distinguish layout-switch ClearRequest from library-reload ClearRequest:
+   - Option A: `StorePropsCoordinator` emits a separate `SceneRebuildRequested` event for layout switches
+   - Option B: `ClearRequest` payload carries a `reason: 'layout-switch' | 'library-reload'`
+   - Leaning toward Option B — same event, more information, no new event type
 
 ## Affected files
-- [ ] `src/types/LayoutTypes.ts` — add `GroupMode`/`GroupModes`
-- [ ] `src/types/EnvironmentEvents.ts` — `GroupMode`/`SortMode` in events, delete old `GameSortModes`
-- [ ] `src/scene/categorization/GameSorter.ts` — rewrite as two-stage
-- [ ] `src/scene/categorization/GroupResolver.ts` — new file
-- [ ] `src/ui/LayoutSortPanel.ts` → `src/ui/LayoutControlPanel.ts` — three dropdowns
-- [ ] `src/ui/index.ts` or wiring — re-export
-
-## Open questions
-- Does `SteamIntegration.isAnonymous()` check for initial group mode still make sense? 
-  (anonymous → no recency data → default group 'by-genre' still valid)
+- [ ] `StorePropsCoordinator.ts` — remove LoadLibrary from layout switch
+- [ ] `GameBoxSpawner.ts` — renderer init on GameDataReady; clearPlacements on layout-switch ClearRequest
+- [ ] `PropsEvents.ts` — add reason field to StorePropsClearRequestEvent
+- [ ] `SteamIntegration.ts` — emit ClearRequest with reason='library-reload'
+- [ ] Tests

--- a/client/src/scene/instancing/InstancedShelfRenderer.ts
+++ b/client/src/scene/instancing/InstancedShelfRenderer.ts
@@ -56,7 +56,12 @@ import type {
 import { ShelfStickerHandler } from '../stickers/ShelfStickerHandler'
 import { buildShelfGeometryTemplates, buildShelfUnitTemplate, ShelfGeometryType, type ShelfPartTemplate } from './ShelfGeometryBuilder'
 import { EventManager } from '../../core/EventManager'
-import { GameEventTypes, StorePropsEventTypes, type ShelfReadyEvent } from '../../types/InteractionEvents'
+import {
+    GameEventTypes,
+    StorePropsEventTypes,
+    type ShelfReadyEvent,
+    type ShelfLayoutDeterminedEvent,
+} from '../../types/InteractionEvents'
 import { Logger } from '../../utils/Logger'
 import { MeshPrewarmer } from '../../utils/MeshPrewarmer'
 import { SystemCapabilitiesDetector } from '../../utils/SystemCapabilities'
@@ -122,6 +127,7 @@ export class InstancedShelfRenderer implements IInstancedRenderer {
 
     private readonly boundUpdateGPU: () => void
     private readonly boundHandleShelfReady: (event: CustomEvent<ShelfReadyEvent>) => void
+    private readonly boundHandleShelfLayoutDetermined: (event: CustomEvent<ShelfLayoutDeterminedEvent>) => void
     
     // TODO: Consider making sticker system fully pluggable (dependency injection or optional feature)
     private readonly stickerHandler: ShelfStickerHandler
@@ -168,6 +174,12 @@ export class InstancedShelfRenderer implements IInstancedRenderer {
         this.boundHandleShelfReady = (event: CustomEvent<ShelfReadyEvent>) =>
             this.handleShelfReady(event.detail)
 
+        this.boundHandleShelfLayoutDetermined = () => {
+            // Layout-switch flows can emit ShelfReady/ShelfLayoutDetermined without new batch events.
+            // Flush matrices to GPU here so shelves become visible even when SomeBatchesComplete does not fire.
+            this.updateGPU()
+        }
+
         EventManager.getInstance().registerEventHandler(
             GameEventTypes.SomeBatchesComplete,
             this.boundUpdateGPU
@@ -176,6 +188,10 @@ export class InstancedShelfRenderer implements IInstancedRenderer {
         EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.ShelfReady,
             this.boundHandleShelfReady
+        )
+        EventManager.getInstance().registerEventHandler(
+            GameEventTypes.ShelfLayoutDetermined,
+            this.boundHandleShelfLayoutDetermined
         )
         
         InstancedShelfRenderer.logger.debug(`🏪 Created (max units: ${this.maxShelfUnits})`)
@@ -583,6 +599,10 @@ export class InstancedShelfRenderer implements IInstancedRenderer {
         EventManager.getInstance().deregisterEventHandler(
             StorePropsEventTypes.ShelfReady,
             this.boundHandleShelfReady
+        )
+        EventManager.getInstance().deregisterEventHandler(
+            GameEventTypes.ShelfLayoutDetermined,
+            this.boundHandleShelfLayoutDetermined
         )
         
         // Dispose all managers

--- a/client/src/scene/props/PropsEvents.ts
+++ b/client/src/scene/props/PropsEvents.ts
@@ -44,9 +44,17 @@ export interface StorePropsSetupCompletedEvent extends BaseInteractionEvent {
     // completion is the signal; no payload needed
 }
 
-/** Emitted by SteamIntegration to tear down the current store before a reload. */
+/**
+ * Emitted to tear down the current store.
+ *
+ * reason:
+ *   'library-reload' — a new library is about to load; consumers must dispose GPU resources
+ *                      and clear prefetch state (full teardown)
+ *   'layout-switch'  — layout geometry is rebuilding but game data is unchanged; consumers
+ *                      should clear placements and shelf positions only (no GPU dispose)
+ */
 export interface StorePropsClearRequestEvent extends BaseInteractionEvent {
-    // no payload needed
+    reason: 'library-reload' | 'layout-switch'
 }
 
 // =============================================================================

--- a/client/src/scene/props/StorePropsCoordinator.ts
+++ b/client/src/scene/props/StorePropsCoordinator.ts
@@ -15,7 +15,7 @@
  * Pure coordinators (event wiring + plain data) are singletons with reset():
  *   ShelfLayoutCoordinator, BatchCoordinator, GameBoxSpawner
  *
- * GPU resource owners are disposable — reconstructed when GPU state must be fresh:
+ * GPU resource owners are disposable - reconstructed when GPU state must be fresh:
  *   InstancedShelfRenderer (owns InstancedMesh allocations)
  *
  * On layout switch: reset pure coordinators, dispose+reconstruct GPU owner.
@@ -27,16 +27,16 @@
 import * as THREE from 'three'
 import { EventManager, EventSource } from '../../core/EventManager'
 import { Logger } from '../../utils/Logger'
-import { GameEventTypes, RoomEventTypes, StorePropsEventTypes, SteamEventTypes, UIEventTypes } from '../../types/InteractionEvents'
+import { GameEventTypes, RoomEventTypes, StorePropsEventTypes, UIEventTypes } from '../../types/InteractionEvents'
 import type {
     StorePropsSetupRequestEvent,
     StorePropsSetupCompletedEvent,
     StorePropsClearRequestEvent,
 } from './PropsEvents'
+
 import type { RoomResizedEvent } from '../../types/InteractionEvents'
 import type { BatchReadyForPlacementEvent } from '../../types/InteractionEvents'
-import type { SteamLoadLibraryEvent } from '../../types/InteractionEvents'
-import { type LayoutRequestedEvent } from '../../types/EnvironmentEvents'
+import { type LayoutRequestedEvent, type GameDataReadyEvent } from '../../types/EnvironmentEvents'
 import { type LayoutMode } from '../../types/LayoutTypes'
 import { DataManager } from '../../core/data'
 import { ShelfLayoutCoordinator } from '../shelves/ShelfLayoutCoordinator'
@@ -48,10 +48,10 @@ class StorePropsCoordinator {
 
     private readonly eventManager: EventManager
 
-    // Singletons — initialised on first SetupRequest, alive for app lifetime
+    // Singletons - initialised on first SetupRequest, alive for app lifetime
     private shelfLayoutCoordinator: ShelfLayoutCoordinator | null = null
 
-    // GPU resource owner — disposed and reconstructed on layout switch
+    // GPU resource owner - disposed and reconstructed on layout switch
     private instancedShelfRenderer: InstancedShelfRenderer | null = null
 
     private scene: THREE.Scene | null = null
@@ -60,11 +60,8 @@ class StorePropsCoordinator {
     // Tracks last-seen batch count to detect library switches
     private lastTotalBatches = 0
 
-    // Active layout mode — drives ShelfLayoutCoordinator on next batch run
+    // Active layout mode - drives ShelfLayoutCoordinator on next batch run
     private activeLayoutMode: LayoutMode = 'arc'
-
-    // True while a layout-switch rebuild is in progress; suppresses spurious ClearRequest handling
-    private layoutSwitchInProgress = false
 
     static {
         new StorePropsCoordinator()
@@ -103,12 +100,12 @@ class StorePropsCoordinator {
         if (!this.scene) {
             this.scene = DataManager.getInstance().get<THREE.Scene>('core.mainScene')
             if (!this.scene) {
-                StorePropsCoordinator.logger.warn('Main scene not available — store props setup aborted')
+                StorePropsCoordinator.logger.warn('Main scene not available - store props setup aborted')
                 return
             }
         }
 
-        // ShelfLayoutCoordinator is a singleton — BatchCoordinator and GameBoxSpawner
+        // ShelfLayoutCoordinator is a singleton - BatchCoordinator and GameBoxSpawner
         // self-register at import time and need no explicit initialisation here.
         if (!this.shelfLayoutCoordinator) {
             this.shelfLayoutCoordinator = ShelfLayoutCoordinator.getInstance(this.activeLayoutMode)
@@ -130,15 +127,14 @@ class StorePropsCoordinator {
         })
     }
 
-    private handleClearRequest(_event: CustomEvent<StorePropsClearRequestEvent>): void {
-        if (this.layoutSwitchInProgress) {
-            StorePropsCoordinator.logger.debug('ClearRequest suppressed during layout switch')
-            return
-        }
+    private handleClearRequest(event: CustomEvent<StorePropsClearRequestEvent>): void {
         // BatchCoordinator and GameBoxSpawner handle ClearRequest internally.
-        this.instancedShelfRenderer?.reset()
+        // On layout-switch, the instanced shelf renderer is already disposed by handleLayoutRequested.
+        if (event.detail.reason !== 'layout-switch') {
+            this.instancedShelfRenderer?.reset()
+        }
         this.lastTotalBatches = 0
-        StorePropsCoordinator.logger.info('Store props cleared')
+        StorePropsCoordinator.logger.info(`Store props cleared (reason: ${event.detail.reason})`)
     }
 
     private handleBatchReadyForPlacement(event: CustomEvent<BatchReadyForPlacementEvent>): void {
@@ -146,7 +142,7 @@ class StorePropsCoordinator {
 
         if (this.lastTotalBatches > 0 && totalBatches !== this.lastTotalBatches) {
             StorePropsCoordinator.logger.debug(
-                `Batch count changed (${this.lastTotalBatches} → ${totalBatches}) — resetting shelf renderer`
+                `Batch count changed (${this.lastTotalBatches} → ${totalBatches}) - resetting shelf renderer`
             )
             this.instancedShelfRenderer?.reset()
         }
@@ -161,7 +157,7 @@ class StorePropsCoordinator {
         }
 
         if (!this.scene) {
-            StorePropsCoordinator.logger.warn('Cannot place entrance mat — scene not available')
+            StorePropsCoordinator.logger.warn('Cannot place entrance mat - scene not available')
             return
         }
 
@@ -181,30 +177,37 @@ class StorePropsCoordinator {
     private handleLayoutRequested(detail: LayoutRequestedEvent): void {
         if (detail.layoutMode === this.activeLayoutMode) return
         this.activeLayoutMode = detail.layoutMode
-        StorePropsCoordinator.logger.info(`Layout mode → ${detail.layoutMode}; triggering scene rebuild`)
-
-        this.layoutSwitchInProgress = true
+        StorePropsCoordinator.logger.info(`Layout mode → ${detail.layoutMode}; rebuilding scene geometry`)
 
         if (this.shelfLayoutCoordinator) {
             this.shelfLayoutCoordinator.layoutMode = detail.layoutMode
         }
         this.lastTotalBatches = 0
 
-        // GPU owner must be fully torn down — InstancedMesh slots can't be partially reused
+        // GPU owner must be fully torn down — InstancedMesh slots can’t be partially reused
         this.instancedShelfRenderer?.dispose()
         this.instancedShelfRenderer = null
+
+        // Notify subsystems to clear geometry/placement state only — game data is unchanged.
+        // GameBoxSpawner will clear placements but keep its renderer and prefetch cache.
+        this.eventManager.emit<StorePropsClearRequestEvent>(StorePropsEventTypes.ClearRequest, {
+            reason: 'layout-switch',
+        })
 
         this.eventManager.emit<StorePropsSetupRequestEvent>(StorePropsEventTypes.SetupRequest, {
             source: EventSource.System,
         })
 
-        const userInput = DataManager.getInstance().get<string>('steam.userInput')
-        this.eventManager.emit<SteamLoadLibraryEvent>(SteamEventTypes.LoadLibrary, {
-            userInput: userInput ?? undefined,
-            forceUpdate: false,
-        })
-
-        this.layoutSwitchInProgress = false
+        // Re-trigger arrangement pipeline from DataManager — no Steam API hit needed.
+        // GameSorter listens to GameDataReady and will re-emit SectionsReady,
+        // driving ShelfLayoutCoordinator and GameBoxSpawner with the new layout mode.
+        const games = DataManager.getInstance().get<unknown[]>('steam.games') ?? []
+        if (games.length > 0) {
+            this.eventManager.emit<GameDataReadyEvent>(GameEventTypes.GameDataReady, {
+                totalGames: games.length,
+                totalBatches: this.lastTotalBatches,
+            })
+        }
     }
 
     public dispose(): void {

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -13,7 +13,8 @@ import {
     type ShelfLayoutDeterminedEvent,
     type GamesPlacedEvent,
 } from '../../types/InteractionEvents'
-import type { SectionsReadyEvent } from '../../types/EnvironmentEvents'
+import type { SectionsReadyEvent, GameDataReadyEvent } from '../../types/EnvironmentEvents'
+import type { StorePropsClearRequestEvent } from '../props/PropsEvents'
 import { Logger } from '../../utils/Logger'
 import type { StockSurface } from '../../types/LayoutTypes'
 
@@ -63,10 +64,9 @@ type PrefetchResult = 'prefetched' | 'cached' | 'permanent-failure' | 'error'
 export class GameBoxSpawner {
     private static readonly logger = Logger.createLogFunctions(GameBoxSpawner.name)
 
-    // Owned renderer — constructed when sections are known (total game count drives allocation)
+    // Owned renderer — initialized on GameDataReady (sized to full library), lives for library lifetime.
+    // Cleared but NOT disposed on layout/group/sort switches.
     private renderer: GpuGameBoxRenderer | null = null
-    // Capacity the renderer was built for — tracked here so GpuGameBoxRenderer stays clean
-    private rendererCapacity = 0
 
     // Shelf world positions indexed by shelfIndex, grouped by sectionIndex
     private shelfPositions: Map<number, ShelfPosition & { sectionIndex: number }> = new Map()
@@ -111,23 +111,62 @@ export class GameBoxSpawner {
             (e: CustomEvent<SectionsReadyEvent>) => this.handleSectionsReady(e)
         )
         EventManager.getInstance().registerEventHandler(
+            GameEventTypes.GameDataReady,
+            (e: CustomEvent<GameDataReadyEvent>) => this.handleGameDataReady(e)
+        )
+        EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.ClearRequest,
-            () => this.reset()
+            (e: CustomEvent<StorePropsClearRequestEvent>) => this.handleClearRequest(e)
         )
 
         GameBoxSpawner.logger.debug('Constructed')
     }
 
-    private reset(): void {
+    /**
+     * Full teardown — only on library reload (new user, force-refresh).
+     * Disposes the renderer and clears all prefetch state.
+     */
+    private fullReset(): void {
         this.renderer?.dispose()
         this.renderer = null
-        this.rendererCapacity = 0
         this.stockStrategy = null
         this.pendingSections = null
         this.shelfPositions.clear()
         this.prefetchResults.clear()
         this.placementIntents.clear()
-        GameBoxSpawner.logger.debug('Reset')
+        GameBoxSpawner.logger.debug('Full reset (library reload)')
+    }
+
+    /**
+     * Geometry reset — on layout/group/sort switches.
+     * Keeps the renderer and prefetch cache; only clears placement state.
+     */
+    private geometryReset(): void {
+        this.renderer?.clearPlacements()
+        this.stockStrategy = null
+        this.pendingSections = null
+        this.shelfPositions.clear()
+        this.placementIntents.clear()
+        GameBoxSpawner.logger.debug('Geometry reset (layout switch)')
+    }
+
+    private handleClearRequest(event: CustomEvent<StorePropsClearRequestEvent>): void {
+        if (event.detail.reason === 'library-reload') {
+            this.fullReset()
+        } else {
+            this.geometryReset()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Initialize renderer at library load time (sized to full library)
+
+    private handleGameDataReady(event: CustomEvent<GameDataReadyEvent>): void {
+        const { totalGames } = event.detail
+        if (!this.renderer) {
+            this.renderer = new GpuGameBoxRenderer(totalGames + 100)
+            GameBoxSpawner.logger.debug(`Renderer initialized: capacity ${totalGames + 100}`)
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -150,18 +189,17 @@ export class GameBoxSpawner {
     private handleBatchReadyForPlacement(event: CustomEvent<BatchReadyForPlacementEvent>): void {
         const { games, batchIndex, totalBatches } = event.detail
 
-        // Construct renderer on first batch using total game estimate.
-        // Renderer is replaced if batch count changes (library reload).
-        const requiredCapacity = totalBatches * 18 + 100
-        if (!this.renderer || requiredCapacity > this.rendererCapacity) {
-            this.renderer?.dispose()
-            this.renderer = new GpuGameBoxRenderer(requiredCapacity)
-            this.rendererCapacity = requiredCapacity
-        }
-
         GameBoxSpawner.logger.debug(
             `BatchReadyForPlacement: batch ${batchIndex + 1}/${totalBatches}, ${games.length} games — prewarming artwork`
         )
+
+        if (!this.renderer) {
+            // Renderer should have been initialized by GameDataReady before batches arrive.
+            // Construct defensively here with batch-based estimate if it hasn't been.
+            const estimatedCapacity = totalBatches * 18 + 100
+            this.renderer = new GpuGameBoxRenderer(estimatedCapacity)
+            GameBoxSpawner.logger.warn(`Renderer not yet initialized via GameDataReady — fallback capacity ${estimatedCapacity}`)
+        }
 
         for (const game of games) {
             const appid = typeof game.appid === 'number' ? game.appid : 0
@@ -228,19 +266,6 @@ export class GameBoxSpawner {
         if (!this.renderer) {
             GameBoxSpawner.logger.warn('placeSections: renderer not yet constructed')
             return
-        }
-
-        // Guard: if the renderer was created for a smaller layout (e.g. Spoke with few
-        // visible games), it may not have capacity for the full library. Recreate it
-        // using the total known prefetched game count so the label atlas can hold all labels.
-        const requiredCapacity = this.prefetchResults.size
-        if (requiredCapacity > this.rendererCapacity) {
-            GameBoxSpawner.logger.debug(
-                `Renderer capacity ${this.rendererCapacity} < required ${requiredCapacity} — recreating`
-            )
-            this.renderer.dispose()
-            this.renderer = new GpuGameBoxRenderer(requiredCapacity + 100)
-            this.rendererCapacity = requiredCapacity + 100
         }
 
         if (!this.stockStrategy) {

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -196,6 +196,7 @@ export class GameBoxSpawner {
         if (!this.renderer) {
             // Renderer should have been initialized by GameDataReady before batches arrive.
             // Construct defensively here with batch-based estimate if it hasn't been.
+            // TD: we probably don't actually need this extra capacity, let's use the right numbers (everywhere in this file)
             const estimatedCapacity = totalBatches * 18 + 100
             this.renderer = new GpuGameBoxRenderer(estimatedCapacity)
             GameBoxSpawner.logger.warn(`Renderer not yet initialized via GameDataReady — fallback capacity ${estimatedCapacity}`)

--- a/client/src/steam-integration/SteamIntegration.ts
+++ b/client/src/steam-integration/SteamIntegration.ts
@@ -22,6 +22,7 @@ import { AppSettings } from '../core/AppSettings'
 import { DataManager, DataDomain } from '../core/data'
 import { sortByNumericField } from '../scene/categorization/GameSortFunctions'
 import { StorePropsEventTypes } from '../scene/props/PropsEvents'
+import type { StorePropsClearRequestEvent } from '../scene/props/PropsEvents'
 
 export interface SteamIntegrationConfig {
     apiBaseUrl?: string
@@ -267,7 +268,7 @@ export class SteamIntegration {
         try {
             // If a store is already loaded, clear it before the new user's data arrives.
             if (this.gameLibrary.getState().userData?.games?.length) {
-                this.eventManager.emit(StorePropsEventTypes.ClearRequest, {})
+                this.eventManager.emit<StorePropsClearRequestEvent>(StorePropsEventTypes.ClearRequest, { reason: 'library-reload' })
                 SteamIntegration.logger.info('Emitted ClearRequest before library load')
             }
 

--- a/client/test/unit/scene/instancing/InstancedShelfRenderer.test.ts
+++ b/client/test/unit/scene/instancing/InstancedShelfRenderer.test.ts
@@ -17,6 +17,7 @@ import { SharedMaterialManager, MaterialType } from '../../../../src/utils/Share
 import { DataManager } from '../../../../src/core/data/DataManager'
 import { EventManager } from '../../../../src/core/EventManager'
 import { SystemCapabilitiesDetector } from '../../../../src/utils/SystemCapabilities'
+import { GameEventTypes } from '../../../../src/types/InteractionEvents'
 
 // Mock dependencies to isolate unit under test
 vi.mock('../../../../src/utils/SharedMaterialManager')
@@ -57,6 +58,7 @@ describe('InstancedShelfRenderer', () => {
         // Setup mock event manager
         mockEventManager = {
             registerEventHandler: vi.fn(),
+            deregisterEventHandler: vi.fn(),
             emit: vi.fn()
         }
         vi.mocked(EventManager.getInstance).mockReturnValue(mockEventManager)
@@ -369,6 +371,33 @@ describe('InstancedShelfRenderer', () => {
             // Valid instances should still be tracked
             const stats = renderer.getStats()
             expect(stats.activeInstances).toBe(1)
+        })
+    })
+
+    describe('Layout Switch Regression Guard', () => {
+        it('should flush GPU updates when ShelfLayoutDetermined is emitted', async () => {
+            renderer = new InstancedShelfRenderer()
+            await renderer.initialize()
+
+            const updateSpy = vi.spyOn(renderer, 'updateGPU')
+            const registrations = mockEventManager.registerEventHandler.mock.calls as Array<[string, (...args: any[]) => void]>
+            const layoutDeterminedRegistration = registrations.find(([eventType]) => eventType === GameEventTypes.ShelfLayoutDetermined)
+
+            expect(layoutDeterminedRegistration).toBeDefined()
+            if (!layoutDeterminedRegistration) {
+                throw new Error('ShelfLayoutDetermined handler was not registered')
+            }
+
+            const [, handler] = layoutDeterminedRegistration
+            handler(new CustomEvent(GameEventTypes.ShelfLayoutDetermined, {
+                detail: {
+                    shelfBounds: { minX: -1, maxX: 1, minZ: -1, maxZ: 1 },
+                    shelfLayout: { rows: 1 },
+                    stockStrategy: { order: () => [] },
+                },
+            }))
+
+            expect(updateSpy).toHaveBeenCalledTimes(1)
         })
     })
 

--- a/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
@@ -23,7 +23,8 @@ import {
     type ShelfLayoutDeterminedEvent,
     type GamesPlacedEvent,
 } from '../../../../src/types/InteractionEvents'
-import type { SectionsReadyEvent } from '../../../../src/types/EnvironmentEvents'
+import type { SectionsReadyEvent, GameDataReadyEvent } from '../../../../src/types/EnvironmentEvents'
+import type { StorePropsClearRequestEvent } from '../../../../src/scene/props/PropsEvents'
 import type { SteamGame } from '../../../../src/steam'
 
 // Mock GpuGameBoxRenderer so the spawner never touches real GPU code
@@ -356,8 +357,11 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
     // reset() and setRenderer()
 
     describe('reset()', () => {
-        it('clears pending games, shelf positions, and disposes renderer', async () => {
+        it('clears pending games, shelf positions, and disposes renderer on library reload', async () => {
             const games = createMockGamesWithArtwork(5, 0) as any[]
+
+            // Initialize renderer via GameDataReady first
+            eventManager.emit<GameDataReadyEvent>(GameEventTypes.GameDataReady, { totalGames: 5, totalBatches: 1 })
 
             eventManager.emit<BatchReadyForPlacementEvent>(
                 StorePropsEventTypes.BatchReadyForPlacement,
@@ -366,24 +370,42 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
             eventManager.emit<ShelfReadyEvent>(StorePropsEventTypes.ShelfReady, makeShelfReady(0))
             await Promise.resolve()
 
-            eventManager.emit(StorePropsEventTypes.ClearRequest, {})
+            eventManager.emit<StorePropsClearRequestEvent>(StorePropsEventTypes.ClearRequest, { reason: 'library-reload' })
             expect(mockRendererDispose).toHaveBeenCalled()
 
-            // After reset, SectionsReady should not use old shelf positions (renderer gone)
+            // After full reset, SectionsReady should not place (renderer gone, no prefetch results)
             eventManager.emit<SectionsReadyEvent>(GameEventTypes.SectionsReady, { sections: [{ name: 'Test', games, groupMode: 'by-recency', sortMode: 'by-last-played' }], groupMode: 'by-recency', sortMode: 'by-last-played' })
             expect(mockPlaceGame).not.toHaveBeenCalled()
         })
     })
 
+    describe('layout-switch ClearRequest', () => {
+        it('clears placements but keeps renderer alive', async () => {
+            const games = createMockGamesWithArtwork(5, 0) as any[]
+
+            eventManager.emit<GameDataReadyEvent>(GameEventTypes.GameDataReady, { totalGames: 5, totalBatches: 1 })
+            eventManager.emit<BatchReadyForPlacementEvent>(
+                StorePropsEventTypes.BatchReadyForPlacement,
+                { games, batchIndex: 0, totalBatches: 1 }
+            )
+            await Promise.resolve()
+
+            eventManager.emit<StorePropsClearRequestEvent>(StorePropsEventTypes.ClearRequest, { reason: 'layout-switch' })
+            expect(mockRendererDispose).not.toHaveBeenCalled()
+            expect(mockClearPlacements).toHaveBeenCalled()
+        })
+    })
+
     describe('setRenderer(null)', () => {
         it('does not throw when renderer is cleared and GamesSort fires', () => {
+            eventManager.emit<GameDataReadyEvent>(GameEventTypes.GameDataReady, { totalGames: 2, totalBatches: 1 })
             eventManager.emit<BatchReadyForPlacementEvent>(
                 StorePropsEventTypes.BatchReadyForPlacement,
                 { games: createMockGamesWithArtwork(2, 0), batchIndex: 0, totalBatches: 1 }
             )
             eventManager.emit<ShelfReadyEvent>(StorePropsEventTypes.ShelfReady, makeShelfReady(0))
 
-            eventManager.emit(StorePropsEventTypes.ClearRequest, {})
+            eventManager.emit<StorePropsClearRequestEvent>(StorePropsEventTypes.ClearRequest, { reason: 'library-reload' })
             expect(mockRendererDispose).toHaveBeenCalled()
 
             expect(() => {

--- a/docs/acts/act4-encore-someday-maybe.md
+++ b/docs/acts/act4-encore-someday-maybe.md
@@ -4,11 +4,14 @@
 > 
 > Some items here have feature docs already — they're listed here as stretch goals within those features. Check the feature doc for context before pulling forward.
 
+The main thing we'll want to check in this "encore" act is: Can we embed an audio-video stream from another source? Can we sample other desktop windows? What if we were a desktop program ourselves? Can we drum up webpage views? Could we capture/replay with the help of a tray app...?
+
 ## Visual / Atmosphere
 
 - **Architectural columns & decorative variants** — optional in-room columns (Roman/Corinthian style) to break up wall runs and frame aisles
 - **Waist-height counter area** — service counter / check-out zone near front-of-store; strong video-store vibe anchor
 - **Working analog wall clock** — in-world prop with real-time hand movement; ambient polish
+- Fill the camera up with steam after launching a game, so the effect of the frozen frame in application is .. steamy.
 - **Room variant — cozy basement** — see [Room Variants](../features/room-variants.md); Encore stretch beyond the Act 2 best-effort
 - **Poster walls from user media** — wall posters sourced from user-owned public screenshots/artwork, rotating by category/zone (needs rights/privacy review)
 - **Blacklight room atmosphere** — UV-style ambient with glowing accent colors; pairs naturally with basement variant; add to lighting preset system when room variants exist

--- a/docs/features/layout-variations.md
+++ b/docs/features/layout-variations.md
@@ -67,6 +67,15 @@ Games ascend in sort order along the right side of the spoke, and descend along 
 **`SpokeStockStrategy`:**
 A third `IStockStrategy` implementation alongside `ArcStockStrategy` and `RowStockStrategy`. Near-only per unit — the Far face of each spoke shelf faces away from the aisle and is unused. Cross-row interleaving (left pos 0, right pos 0, left pos 1, …) is a layout-level concern driven by the order in which `ShelfLayoutCoordinator` emits `ShelfReady` events, not by the strategy itself.
 
+## Alternating Sections
+- The "toe-out" description is meant to describe an alternation approach for shelves arranged in rows.
+- In arcs, the alternation would be meant to start the next concentric ring after the end of this one. 
+Each arc/row should be separated from the other by our comfortable walking distance.
+but rather than "centering" the arcs, or aligning the middle of their rows,
+let's try having each ring begin with its first shelf, a short walking distance away from the last shelf in the previous row
+creating a small clearing between them
+and alternating the direction (ascending/descending) of the arc/rows
+
 ## Stock Strategy Abstraction
 
 Landed in PR #81 (`openclaw/feat-stock-strategy`). `IStockStrategy` in `StockStrategy.ts` defines the interface; current implementations:

--- a/docs/plans/layout-variations-next-steps.md
+++ b/docs/plans/layout-variations-next-steps.md
@@ -137,6 +137,14 @@ Follows the same `SectionsPlanned` pattern as Spoke.
 Right side ascending, left descending — continuous loop. Config option on
 `SpokeLayoutConfig.mirrorWalkOrder`. Requires section-aware placement first.
 
+### Arc + genre overflow follow-up (2026-04-21)
+1. **Back-row squish when grouping by genre in Arc layout**
+   - Symptom: in Arc + `By Genre`, non-dominant genres can appear visually compressed in the back row.
+   - Why: `computeStoreArcShelfLayout` uses fixed counts for rows 0–3, then dumps all remaining shelves into row 4 (`totalShelves - 32`).
+     Row 4 intentionally relaxes `minShelfGap` enforcement (`row < cfg.rows - 1` check), so overflow can be densely packed.
+   - Status: acknowledged/deferred. This is expected to disappear once section-aware shelf distribution owns per-section shelf budgets instead of global overflow.
+   - Suggested interim guardrail (optional): cap row-4 density and spill into additional rows before section-aware distribution lands.
+
 ### Spoke follow-ups from live validation (2026-04-20)
 1. **Inside/outside flip**
    - Current spoke stocking appears on the outer faces relative to aisle flow.


### PR DESCRIPTION
…am reload

- ClearRequest now carries reason: 'library-reload' | 'layout-switch' SteamIntegration emits 'library-reload'; StorePropsCoordinator emits 'layout-switch' — consumers can differentiate full teardown from geometry reset.

- GpuGameBoxRenderer initialized once on GameDataReady (sized to full library), survives layout/group/sort switches. On layout-switch ClearRequest: clearPlacements() only — prefetch cache preserved. On library-reload ClearRequest: dispose() + null — full teardown.

- StorePropsCoordinator.handleLayoutRequested no longer emits LoadLibrary. Rebuilds scene geometry by emitting ClearRequest + SetupRequest + GameDataReady from DataManager. No Steam API hit on layout switch.

- Removed all capacity checks from GameBoxSpawner — they only existed because the renderer was sized per-layout rather than per-library.

- Tests: updated two existing tests to use reason: 'library-reload'; added new 'layout-switch ClearRequest' test to verify renderer survives the switch.