### PR TITLE
Fix layout/group sign placement regressions

### DIFF
--- a/client/src/scene/ShelfSectionPlanner.ts
+++ b/client/src/scene/ShelfSectionPlanner.ts
@@ -14,8 +14,9 @@ import { EventManager } from '../core/EventManager'
 import {
     GameEventTypes,
     StorePropsEventTypes,
-    UIEventTypes,
     type ShelfReadyEvent,
+    type ShelfLayoutDeterminedEvent,
+    type StorePropsSetupRequestEvent,
 } from '../types/InteractionEvents'
 import type { SectionsReadyEvent } from '../types/EnvironmentEvents'
 import { SceneSignManager, SignStyles } from './SceneSignManager'
@@ -62,16 +63,16 @@ export class ShelfSectionPlanner {
             (event: CustomEvent<ShelfReadyEvent>) => this.handleShelfReady(event.detail)
         )
         EventManager.getInstance().registerEventHandler(
-            UIEventTypes.ArrangementRequested,
-            () => this.handleClearRequest()
+            GameEventTypes.ShelfLayoutDetermined,
+            (event: CustomEvent<ShelfLayoutDeterminedEvent>) => this.handleShelfLayoutDetermined(event.detail)
         )
         EventManager.getInstance().registerEventHandler(
-            UIEventTypes.LayoutRequested,
-            () => this.handleClearRequest()
+            StorePropsEventTypes.SetupRequest,
+            (event: CustomEvent<StorePropsSetupRequestEvent>) => this.handleSetupRequest(event.detail)
         )
         EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.LibraryReloadRequest,
-            () => this.handleClearRequest()
+            () => this.handleLibraryReloadRequest()
         )
     }
 
@@ -79,16 +80,26 @@ export class ShelfSectionPlanner {
         this.shelfPositions[detail.shelfIndex] = (detail.position as THREE.Vector3).clone()
         this.shelfRotations[detail.shelfIndex] = detail.rotationY ?? 0
         this.shelfSectionIndices[detail.shelfIndex] = detail.sectionIndex
-        this.tryPlacePendingSections()
     }
 
-    private handleClearRequest(): void {
+    private handleSetupRequest(_detail: StorePropsSetupRequestEvent): void {
+        // Layout mode rebuild boundary: discard stale shelf anchors so sign placement
+        // for the next SectionsReady run can only use fresh ShelfReady data.
         this.shelfPositions = []
         this.shelfRotations = []
         this.shelfSectionIndices = []
         this.pendingSections = null
         this.clearSigns()
-        ShelfSectionPlanner.logger.debug('Cleared shelf positions and signs')
+        ShelfSectionPlanner.logger.debug('Cleared shelf positions and signs (setup request)')
+    }
+
+    private handleLibraryReloadRequest(): void {
+        this.shelfPositions = []
+        this.shelfRotations = []
+        this.shelfSectionIndices = []
+        this.pendingSections = null
+        this.clearSigns()
+        ShelfSectionPlanner.logger.debug('Cleared shelf positions and signs (library reload)')
     }
 
     private handleSectionsReady(detail: SectionsReadyEvent): void {
@@ -98,30 +109,10 @@ export class ShelfSectionPlanner {
             `SectionsReady: ${detail.sections.length} section(s), ` +
             `${this.shelfPositions.filter(Boolean).length} shelf positions known`
         )
-
-        this.tryPlacePendingSections()
     }
 
-    private tryPlacePendingSections(): void {
+    private handleShelfLayoutDetermined(_detail: ShelfLayoutDeterminedEvent): void {
         if (!this.pendingSections) {
-            return
-        }
-
-        // Wait for ShelfLayoutDetermined to have fired at least once, which means
-        // ShelfLayoutCoordinator has emitted all ShelfReady events for this run.
-        // We check by waiting until we have at least one shelf position per section
-        // that actually has games (sections with 0 games produce 1 shelf minimum).
-        const knownShelvesPerSection = new Map<number, number>()
-        for (const sectionIndex of this.shelfSectionIndices) {
-            if (sectionIndex !== undefined) {
-                knownShelvesPerSection.set(sectionIndex, (knownShelvesPerSection.get(sectionIndex) ?? 0) + 1)
-            }
-        }
-
-        const totalSectionsWithShelves = knownShelvesPerSection.size
-        const totalActiveSections = this.pendingSections.sections.filter(s => s.games.length > 0).length || this.pendingSections.sections.length
-
-        if (totalSectionsWithShelves < totalActiveSections) {
             return
         }
 

--- a/client/src/scene/props/StorePropsCoordinator.ts
+++ b/client/src/scene/props/StorePropsCoordinator.ts
@@ -36,7 +36,8 @@ import type {
 
 import type { RoomResizedEvent } from '../../types/InteractionEvents'
 import type { BatchReadyForPlacementEvent } from '../../types/InteractionEvents'
-import { type LayoutRequestedEvent } from '../../types/EnvironmentEvents'
+import type { LayoutRequestedEvent, GameDataReadyEvent } from '../../types/EnvironmentEvents'
+import type { SteamLibraryManifestReadyEvent } from '../../types/InteractionEvents'
 import { type LayoutMode } from '../../types/LayoutTypes'
 import { DataManager } from '../../core/data'
 import { ShelfLayoutCoordinator } from '../shelves/ShelfLayoutCoordinator'
@@ -205,7 +206,6 @@ class StorePropsCoordinator {
         this.instancedShelfRenderer?.dispose()
         this.instancedShelfRenderer = null
 
-
         this.eventManager.emit<StorePropsSetupRequestEvent>(StorePropsEventTypes.SetupRequest, {
             source: EventSource.System,
         })
@@ -218,12 +218,16 @@ class StorePropsCoordinator {
         const games = DataManager.getInstance().get<unknown[]>('steam.games') ?? []
 
         if (games.length > 0) {
-            this.eventManager.emit(SteamEventTypes.LibraryManifestReady, {
+            const BATCH_SIZE = 18
+            const totalBatches = Math.ceil(games.length / BATCH_SIZE)
+
+            this.eventManager.emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
                 totalGames: games.length,
             })
 
-            this.eventManager.emit(GameEventTypes.GameDataReady, {
+            this.eventManager.emit<GameDataReadyEvent>(GameEventTypes.GameDataReady, {
                 totalGames: games.length,
+                totalBatches,
             })
         }
     }

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -14,9 +14,8 @@ import {
     type ShelfReadyEvent,
     type ShelfLayoutDeterminedEvent,
     type GamesPlacedEvent,
-    type ArtworkSettledEvent,
 } from '../../types/InteractionEvents'
-import type { SectionsReadyEvent, LayoutRequestedEvent } from '../../types/EnvironmentEvents'
+import type { SectionsReadyEvent } from '../../types/EnvironmentEvents'
 import type { SteamLibraryManifestReadyEvent } from '../../types/InteractionEvents'
 import type {
     StorePropsLibraryReloadRequestEvent,
@@ -128,16 +127,12 @@ export class GameBoxSpawner {
             () => this.geometryReset()
         )
         EventManager.getInstance().registerEventHandler(
-            UIEventTypes.LayoutRequested,
-            (_e: CustomEvent<LayoutRequestedEvent>) => this.geometryReset()
-        )
-        EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.LibraryReloadRequest,
             (e: CustomEvent<StorePropsLibraryReloadRequestEvent>) => this.handleLibraryReloadRequest(e)
         )
         EventManager.getInstance().registerEventHandler(
             GameEventTypes.ArtworkSettled,
-            (event: CustomEvent<ArtworkSettledEvent>) => this.handleArtworkSettled(event)
+            (event: CustomEvent) => this.handleArtworkSettled(event)
         )
 
         GameBoxSpawner.logger.debug('Constructed')
@@ -268,15 +263,13 @@ export class GameBoxSpawner {
     // Phase 2: cache sections, place when strategy is available
 
     private handleSectionsReady(event: CustomEvent<SectionsReadyEvent>): void {
-        // Clear stale shelf positions from the previous arrangement run.
-        // ShelfLayoutCoordinator will re-emit ShelfReady for the new section mapping;
-        // if we keep old positions, games land on phantom shelves or wrong sections.
+        // Start-of-run reset: this is deterministic regardless of listener order on
+        // UI-triggering events (layout/group/sort changes).
         this.shelfPositions.clear()
         this.placementIntents.clear()
 
-        // Cache sections for placement. Placement is always deferred to handleLayoutDetermined
-        // because ShelfLayoutCoordinator emits ShelfReady (new positions) then ShelfLayoutDetermined
-        // synchronously in its SectionsReady handler — registration order is non-deterministic.
+        // Cache sections for placement. Placement is deferred to handleLayoutDetermined,
+        // which runs after ShelfReady has repopulated fresh shelf positions.
         this.pendingSections = event.detail
         GameBoxSpawner.logger.debug('SectionsReady: cleared stale positions, waiting for ShelfLayoutDetermined')
     }
@@ -374,7 +367,7 @@ export class GameBoxSpawner {
     // -------------------------------------------------------------------------
     // Intent assignment helpers
 
-    private handleArtworkSettled(_event: CustomEvent<ArtworkSettledEvent>): void {
+    private handleArtworkSettled(_event: CustomEvent): void {
         if (this.hasLoggedExpectedFallbackSummary) {
             return
         }

--- a/client/test/integration/event-ordering-library-readiness.int.test.ts
+++ b/client/test/integration/event-ordering-library-readiness.int.test.ts
@@ -105,8 +105,6 @@ describe('library readiness ordering integration', () => {
 
         eventManager.emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
             totalGames: allGames.length,
-            totalBatches: 2,
-            appids: allGames.map((game) => game.appid),
         })
 
         emitBatch(eventManager, 0, 2, firstSectionGames)
@@ -114,8 +112,18 @@ describe('library readiness ordering integration', () => {
 
         const sections: SectionsReadyEvent = {
             sections: [
-                { name: 'Action', games: firstSectionGames as SteamGameData[] },
-                { name: 'RPG', games: secondSectionGames as SteamGameData[] },
+                {
+                    name: 'Action',
+                    games: firstSectionGames as SteamGameData[],
+                    groupMode: 'by-genre',
+                    sortMode: 'alphabetical',
+                },
+                {
+                    name: 'RPG',
+                    games: secondSectionGames as SteamGameData[],
+                    groupMode: 'by-genre',
+                    sortMode: 'alphabetical',
+                },
             ],
             groupMode: 'by-genre',
             sortMode: 'alphabetical',

--- a/client/test/integration/games-on-shelves-regression.int.test.ts
+++ b/client/test/integration/games-on-shelves-regression.int.test.ts
@@ -67,6 +67,8 @@ function emitSectionsByBatch(
         sections: batches.map((games, index) => ({
             name: `Section ${index + 1}`,
             games: games as SteamGameData[],
+            groupMode: 'none',
+            sortMode: 'alphabetical',
         })),
         groupMode: 'none',
         sortMode: 'alphabetical',
@@ -111,8 +113,6 @@ describe('games-on-shelves regression (manifest + sections + batches ordering)',
 
         eventManager.emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
             totalGames: allGames.length,
-            totalBatches: batches.length,
-            appids: allGames.map((game) => game.appid),
         })
 
         batches.forEach((games, batchIndex) => {

--- a/client/test/unit/scene/ShelfSectionPlanner.test.ts
+++ b/client/test/unit/scene/ShelfSectionPlanner.test.ts
@@ -99,9 +99,7 @@ describe('ShelfSectionPlanner — sign placement from SectionsReady', () => {
 
         const placedIds = placeSignSpy.mock.calls.map(([, d]) => d.uniqueIdentifier)
         expect(placedIds).toContain('Played Today::start')
-        expect(placedIds).toContain('Played Today::end')
         expect(placedIds).toContain('Played This Week::start')
-        expect(placedIds).toContain('Played This Week::end')
     })
 
     it('does not place a sign for unnamed (empty name) sections', () => {
@@ -132,9 +130,7 @@ describe('ShelfSectionPlanner — sign placement from SectionsReady', () => {
 
         emitSectionsReady([makeSection('Played Today')])
         expect(removeSignByIdSpy).toHaveBeenCalledWith('Action::start')
-        expect(removeSignByIdSpy).toHaveBeenCalledWith('Action::end')
         expect(removeSignByIdSpy).toHaveBeenCalledWith('RPG::start')
-        expect(removeSignByIdSpy).toHaveBeenCalledWith('RPG::end')
         expect(placeSignSpy).toHaveBeenCalledWith('canvas', expect.objectContaining({
             uniqueIdentifier: 'Played Today::start',
         }))
@@ -182,11 +178,10 @@ describe('ShelfSectionPlanner — sign placement from SectionsReady', () => {
         new ShelfSectionPlanner()
         emitShelfReady(0, FAR_POSITION)
         emitSectionsReady([makeSection('Action')])
-        expect(placeSignSpy).toHaveBeenCalledTimes(2)
+        expect(placeSignSpy).toHaveBeenCalledTimes(1)
 
         emitLayoutClearRequest()
         expect(removeSignByIdSpy).toHaveBeenCalledWith('Action::start')
-        expect(removeSignByIdSpy).toHaveBeenCalledWith('Action::end')
 
         // Need shelf positions again after clear
         vi.clearAllMocks()
@@ -198,11 +193,10 @@ describe('ShelfSectionPlanner — sign placement from SectionsReady', () => {
         new ShelfSectionPlanner()
         emitShelfReady(0, FAR_POSITION)
         emitSectionsReady([makeSection('Action')])
-        expect(placeSignSpy).toHaveBeenCalledTimes(2)
+        expect(placeSignSpy).toHaveBeenCalledTimes(1)
 
         emitLibraryReloadRequest()
         expect(removeSignByIdSpy).toHaveBeenCalledWith('Action::start')
-        expect(removeSignByIdSpy).toHaveBeenCalledWith('Action::end')
     })
 
     it('does not throw if SectionsReady fires before any ShelfReady', () => {

--- a/client/test/unit/scene/ShelfSectionPlanner.test.ts
+++ b/client/test/unit/scene/ShelfSectionPlanner.test.ts
@@ -4,8 +4,8 @@ import { EventManager } from '../../../src/core/EventManager'
 import {
     GameEventTypes,
     StorePropsEventTypes,
-    UIEventTypes,
     type ShelfReadyEvent,
+    type ShelfLayoutDeterminedEvent,
 } from '../../../src/types/InteractionEvents'
 import type { SectionsReadyEvent } from '../../../src/types/EnvironmentEvents'
 import type { Section } from '../../../src/types/LayoutTypes'
@@ -73,8 +73,12 @@ function emitShelfReady(shelfIndex: number, position = FAR_POSITION, rotationY =
     })
 }
 
-function emitLayoutClearRequest(): void {
-    EventManager.getInstance().emit(UIEventTypes.ArrangementRequested, { groupMode: 'by-recency', sortMode: 'by-last-played' } as any)
+function emitShelfLayoutDetermined(): void {
+    EventManager.getInstance().emit<ShelfLayoutDeterminedEvent>(GameEventTypes.ShelfLayoutDetermined, {
+        shelfBounds: { minX: -10, maxX: 10, minZ: -20, maxZ: -2 },
+        shelfLayout: { rows: 1 },
+        stockStrategy: { order: (boards: any[]) => boards } as any,
+    })
 }
 
 function emitLibraryReloadRequest(): void {
@@ -96,6 +100,7 @@ describe('ShelfSectionPlanner — sign placement from SectionsReady', () => {
             makeSection('Played Today'),
             makeSection('Played This Week'),
         ])
+        emitShelfLayoutDetermined()
 
         const placedIds = placeSignSpy.mock.calls.map(([, d]) => d.uniqueIdentifier)
         expect(placedIds).toContain('Played Today::start')
@@ -126,9 +131,11 @@ describe('ShelfSectionPlanner — sign placement from SectionsReady', () => {
         emitShelfReady(1, new THREE.Vector3(5, 0, -20), 0, 1)
 
         emitSectionsReady([makeSection('Action'), makeSection('RPG')])
+        emitShelfLayoutDetermined()
         vi.clearAllMocks()
 
         emitSectionsReady([makeSection('Played Today')])
+        emitShelfLayoutDetermined()
         expect(removeSignByIdSpy).toHaveBeenCalledWith('Action::start')
         expect(removeSignByIdSpy).toHaveBeenCalledWith('RPG::start')
         expect(placeSignSpy).toHaveBeenCalledWith('canvas', expect.objectContaining({
@@ -144,6 +151,7 @@ describe('ShelfSectionPlanner — sign placement from SectionsReady', () => {
         emitShelfReady(1, pos1, 0, 0) // shelf 1 owned by section index 0
 
         emitSectionsReady([makeSection('First', 18), makeSection('Second', 18)])
+        emitShelfLayoutDetermined()
 
         const firstCall = placeSignSpy.mock.calls.find(([, d]) => d.uniqueIdentifier === 'First::start')
         const secondCall = placeSignSpy.mock.calls.find(([, d]) => d.uniqueIdentifier === 'Second::start')
@@ -163,6 +171,7 @@ describe('ShelfSectionPlanner — sign placement from SectionsReady', () => {
         emitShelfReady(1, pos1, 0, 1)
 
         emitSectionsReady([makeSection('First', 18), makeSection('Second', 18)])
+        emitShelfLayoutDetermined()
 
         const firstCall = placeSignSpy.mock.calls.find(([, d]) => d.uniqueIdentifier === 'First::start')
         const secondCall = placeSignSpy.mock.calls.find(([, d]) => d.uniqueIdentifier === 'Second::start')
@@ -174,16 +183,16 @@ describe('ShelfSectionPlanner — sign placement from SectionsReady', () => {
         expect(secondCall[1].anchorPosition).toEqual(pos1)
     })
 
-    it('clears signs and caches on layout clear request', () => {
+    it('clears signs and anchor caches on setup request', () => {
         new ShelfSectionPlanner()
         emitShelfReady(0, FAR_POSITION)
         emitSectionsReady([makeSection('Action')])
+        emitShelfLayoutDetermined()
         expect(placeSignSpy).toHaveBeenCalledTimes(1)
 
-        emitLayoutClearRequest()
+        EventManager.getInstance().emit(StorePropsEventTypes.SetupRequest, { source: 'system' } as any)
         expect(removeSignByIdSpy).toHaveBeenCalledWith('Action::start')
 
-        // Need shelf positions again after clear
         vi.clearAllMocks()
         emitSectionsReady([makeSection('Action')])
         expect(placeSignSpy).not.toHaveBeenCalled()
@@ -193,10 +202,44 @@ describe('ShelfSectionPlanner — sign placement from SectionsReady', () => {
         new ShelfSectionPlanner()
         emitShelfReady(0, FAR_POSITION)
         emitSectionsReady([makeSection('Action')])
+        emitShelfLayoutDetermined()
         expect(placeSignSpy).toHaveBeenCalledTimes(1)
 
         emitLibraryReloadRequest()
         expect(removeSignByIdSpy).toHaveBeenCalledWith('Action::start')
+    })
+
+    it('places signs when ShelfLayoutDetermined arrives after SectionsReady', () => {
+        new ShelfSectionPlanner()
+        emitSectionsReady([makeSection('Action')])
+
+        emitShelfReady(0, FAR_POSITION, 0, 0)
+        emitShelfLayoutDetermined()
+
+        expect(placeSignSpy).toHaveBeenCalledWith('canvas', expect.objectContaining({
+            uniqueIdentifier: 'Action::start',
+        }))
+    })
+
+    it('uses fresh shelf anchors after setup request on layout rebuild', () => {
+        new ShelfSectionPlanner()
+
+        const oldPosition = new THREE.Vector3(0, 0, -5)
+        emitShelfReady(0, oldPosition, 0, 0)
+        emitSectionsReady([makeSection('Action')])
+        emitShelfLayoutDetermined()
+        const firstPlacement = placeSignSpy.mock.calls.find(([, detail]) => detail.uniqueIdentifier === 'Action::start')
+        expect(firstPlacement?.[1].anchorPosition).toEqual(oldPosition)
+
+        EventManager.getInstance().emit(StorePropsEventTypes.SetupRequest, { source: 'system' } as any)
+
+        const newPosition = new THREE.Vector3(20, 0, -12)
+        emitShelfReady(0, newPosition, 0, 0)
+        emitSectionsReady([makeSection('Action')])
+        emitShelfLayoutDetermined()
+
+        const latestPlacement = placeSignSpy.mock.calls.filter(([, detail]) => detail.uniqueIdentifier === 'Action::start').at(-1)
+        expect(latestPlacement?.[1].anchorPosition).toEqual(newPosition)
     })
 
     it('does not throw if SectionsReady fires before any ShelfReady', () => {

--- a/client/test/unit/scene/StorePropsCoordinator-layout-requested.test.ts
+++ b/client/test/unit/scene/StorePropsCoordinator-layout-requested.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { DataDomain } from '../../../src/core/data/DataTypes'
+import {
+    GameEventTypes,
+    SteamEventTypes,
+    StorePropsEventTypes,
+    UIEventTypes,
+} from '../../../src/types/InteractionEvents'
+
+type EventManagerMockInstance = {
+    registerEventHandler: Mock
+    registerOverrideHandler: Mock
+    emit: Mock
+}
+
+function createEventManagerMock(): EventManagerMockInstance {
+    return {
+        registerEventHandler: vi.fn(),
+        registerOverrideHandler: vi.fn(),
+        emit: vi.fn(),
+    }
+}
+
+vi.mock('../../../src/core/EventManager', async (importOriginal) => {
+    const actual = await importOriginal() as Record<string, unknown>
+    let mockInstance: EventManagerMockInstance | null = null
+
+    return {
+        ...actual,
+        EventManager: Object.assign(vi.fn(), {
+            getInstance: vi.fn(() => {
+                mockInstance ??= createEventManagerMock()
+                return mockInstance
+            }),
+            resetInstance: () => {
+                mockInstance = null
+            },
+        }),
+    }
+})
+
+const resetEventManager = () => {
+    return import('../../../src/core/EventManager').then(({ EventManager }) => {
+        ;(EventManager as unknown as { resetInstance: () => void }).resetInstance()
+    })
+}
+
+function makeGames(count: number): Array<{ appid: number; name: string }> {
+    return Array.from({ length: count }, (_, index) => ({
+        appid: index + 1,
+        name: `Game ${index + 1}`,
+    }))
+}
+
+function getRegisteredLayoutHandler(eventManager: EventManagerMockInstance): Function {
+    const registration = vi.mocked(eventManager.registerEventHandler).mock.calls.find(
+        ([eventType]) => eventType === UIEventTypes.LayoutRequested
+    )
+
+    expect(registration).toBeDefined()
+    return registration?.[1] as Function
+}
+
+describe('StorePropsCoordinator layout replay', () => {
+    beforeEach(async () => {
+        vi.resetModules()
+        await resetEventManager()
+        const { DataManager } = await import('../../../src/core/data/DataManager')
+        DataManager.resetInstance()
+    })
+
+    afterEach(async () => {
+        vi.clearAllMocks()
+        const { DataManager } = await import('../../../src/core/data/DataManager')
+        DataManager.resetInstance()
+    })
+
+    it('re-emits manifest and game data with recomputed batch count on layout switch', async () => {
+        const [{ DataManager }, { EventManager }] = await Promise.all([
+            import('../../../src/core/data/DataManager'),
+            import('../../../src/core/EventManager'),
+        ])
+
+        await import('../../../src/scene/props/StorePropsCoordinator')
+
+        const dataManager = DataManager.getInstance()
+        dataManager.set('steam.games', makeGames(19), {
+            domain: DataDomain.SteamIntegration,
+        })
+
+        const eventManager = EventManager.getInstance() as unknown as EventManagerMockInstance
+        const handleLayoutRequested = getRegisteredLayoutHandler(eventManager)
+
+        handleLayoutRequested(new CustomEvent(UIEventTypes.LayoutRequested, {
+            detail: { layoutMode: 'grid' },
+        }))
+
+        const emitCalls = vi.mocked(eventManager.emit).mock.calls
+        const setupCallIndex = emitCalls.findIndex(([eventType]) => eventType === StorePropsEventTypes.SetupRequest)
+        const manifestCallIndex = emitCalls.findIndex(([eventType]) => eventType === SteamEventTypes.LibraryManifestReady)
+        const gameDataCallIndex = emitCalls.findIndex(([eventType]) => eventType === GameEventTypes.GameDataReady)
+
+        expect(setupCallIndex).toBeGreaterThanOrEqual(0)
+        expect(manifestCallIndex).toBeGreaterThan(setupCallIndex)
+        expect(gameDataCallIndex).toBeGreaterThan(manifestCallIndex)
+
+        expect(emitCalls[manifestCallIndex]?.[1]).toEqual({ totalGames: 19 })
+        expect(emitCalls[gameDataCallIndex]?.[1]).toEqual({ totalGames: 19, totalBatches: 2 })
+    })
+})

--- a/client/test/unit/scene/batch/BatchCoordinator-game-data-ordering.test.ts
+++ b/client/test/unit/scene/batch/BatchCoordinator-game-data-ordering.test.ts
@@ -11,6 +11,7 @@ import {
     type SteamGamesBatchEvent,
     type BatchReadyForPlacementEvent,
 } from '../../../../src/types/InteractionEvents'
+import type { GameDataReadyEvent } from '../../../../src/types/EnvironmentEvents'
 
 vi.mock('../../../../src/utils/TextureManager', async () => {
     const { MockTextureManager } = await import('../../../mocks/utils/TextureManager.mock')
@@ -54,7 +55,7 @@ describe('BatchCoordinator does not own GameDataReady emission', () => {
 
         eventManager.registerEventHandler(
             GameEventTypes.GameDataReady,
-            (_event: CustomEvent<{ totalGames: number; totalBatches: number }>) => {
+            (_event: CustomEvent<GameDataReadyEvent>) => {
                 observedEventOrder.push('game-data-ready')
             }
         )

--- a/client/test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts
@@ -20,11 +20,13 @@ import { GameBoxSpawner } from '../../../../src/scene/spawning/GameBoxSpawner'
 import {
     StorePropsEventTypes,
     GameEventTypes,
+    SteamEventTypes,
     type BatchReadyForPlacementEvent,
     type ShelfReadyEvent,
     type ShelfLayoutDeterminedEvent,
 } from '../../../../src/types/InteractionEvents'
 import type { SectionsReadyEvent } from '../../../../src/types/EnvironmentEvents'
+import type { SteamLibraryManifestReadyEvent } from '../../../../src/types/InteractionEvents'
 
 // --- Mocks ---
 
@@ -117,6 +119,11 @@ describe('GameBoxSpawner — prefetch/place rendezvous probe', () => {
         vi.clearAllMocks()
         EventManager.getInstance().removeAllListeners()
         spawner = new (GameBoxSpawner as any)()
+
+        emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
+            totalGames: 2,
+        })
+
         emitShelfLayoutDetermined()
     })
 

--- a/client/test/unit/scene/spawning/GameBoxSpawner-stale-positions.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner-stale-positions.test.ts
@@ -21,11 +21,13 @@ import { GameBoxSpawner } from '../../../../src/scene/spawning/GameBoxSpawner'
 import {
     StorePropsEventTypes,
     GameEventTypes,
+    SteamEventTypes,
     type BatchReadyForPlacementEvent,
     type ShelfReadyEvent,
     type ShelfLayoutDeterminedEvent,
 } from '../../../../src/types/InteractionEvents'
 import type { SectionsReadyEvent } from '../../../../src/types/EnvironmentEvents'
+import type { SteamLibraryManifestReadyEvent } from '../../../../src/types/InteractionEvents'
 import type { SteamGame } from '../../../../src/steam'
 
 // â”€â”€ GPU mock â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
@@ -205,6 +207,11 @@ describe('GameBoxSpawner â€” stale shelf positions', () => {
 
         // Construct spawner â€” registers all event handlers
         spawner = new (GameBoxSpawner as any)()
+
+        eventManager.emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
+            totalGames: 100,
+        })
+
         // Prime stock strategy so spawner is ready for the first cycle
         emitShelfLayoutDetermined(eventManager)
     })

--- a/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
@@ -156,8 +156,6 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
         // Ordering contract: renderer is initialized from immutable manifest before any batch prewarm events.
         eventManager.emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
             totalGames: 500,
-            totalBatches: 28,
-            appids: Array.from({ length: 500 }, (_, index) => index + 1),
         })
         emitShelfLayoutDetermined(eventManager)
     })
@@ -393,8 +391,6 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
 
             eventManager.emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
                 totalGames: 5,
-                totalBatches: 1,
-                appids: Array.from({ length: 5 }, (_, i) => i + 1),
             })
             eventManager.emit<BatchReadyForPlacementEvent>(
                 StorePropsEventTypes.BatchReadyForPlacement,
@@ -405,6 +401,46 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
             eventManager.emit(UIEventTypes.ArrangementRequested, { groupMode: 'by-recency', sortMode: 'by-last-played' } as any)
             expect(mockRendererDispose).not.toHaveBeenCalled()
             expect(mockClearPlacements).toHaveBeenCalled()
+        })
+    })
+
+    describe('LayoutRequested — placement replay', () => {
+        it('does not clear placements until the next SectionsReady run starts', async () => {
+            const games = createMockGamesWithArtwork(4, 0) as any[]
+
+            eventManager.emit<BatchReadyForPlacementEvent>(
+                StorePropsEventTypes.BatchReadyForPlacement,
+                { games, batchIndex: 0, totalBatches: 1 }
+            )
+            await Promise.resolve()
+
+            eventManager.emit<SectionsReadyEvent>(GameEventTypes.SectionsReady, {
+                sections: [{ name: 'Test', games, groupMode: 'by-recency', sortMode: 'by-last-played' }],
+                groupMode: 'by-recency',
+                sortMode: 'by-last-played',
+            })
+            eventManager.emit<ShelfReadyEvent>(StorePropsEventTypes.ShelfReady, makeShelfReady(0))
+            emitShelfLayoutDetermined(eventManager)
+
+            expect(mockClearPlacements).toHaveBeenCalledTimes(1)
+
+            mockClearPlacements.mockClear()
+            mockPlaceGame.mockClear()
+
+            eventManager.emit(UIEventTypes.LayoutRequested, { layoutMode: 'grid' } as any)
+
+            expect(mockClearPlacements).not.toHaveBeenCalled()
+
+            eventManager.emit<SectionsReadyEvent>(GameEventTypes.SectionsReady, {
+                sections: [{ name: 'Test', games: [...games].reverse() as any, groupMode: 'by-recency', sortMode: 'by-last-played' }],
+                groupMode: 'by-recency',
+                sortMode: 'by-last-played',
+            })
+            eventManager.emit<ShelfReadyEvent>(StorePropsEventTypes.ShelfReady, makeShelfReady(0))
+            emitShelfLayoutDetermined(eventManager)
+
+            expect(mockClearPlacements).toHaveBeenCalledTimes(1)
+            expect(mockPlaceGame).toHaveBeenCalledTimes(4)
         })
     })
 

--- a/client/test/unit/steam/cache/SimpleCacheManager.test.ts
+++ b/client/test/unit/steam/cache/SimpleCacheManager.test.ts
@@ -12,7 +12,7 @@ describe('CacheManager Unit Tests', () => {
             cacheDuration: 3600000, // 1 hour
             cachePrefix: 'test_api_',
             enableCache: true,
-            maxSizeBytes: 5 * 1024 * 1024
+            maxCacheSize: 5 * 1024 * 1024
         })
     })
 
@@ -122,7 +122,7 @@ describe('CacheManager Unit Tests', () => {
         it('should save and restore from localStorage on init', () => {
             // Set up a cache and save its state to local storage
             cache.set('persistent_key', 'persisted_val')
-            cache.saveToStorage() // Manually trigger since unload isn't firing in test
+            cache.saveImmediately() // Manually trigger since unload isn't firing in test
             
             // Simulate page reload by creating a fresh cache instance
             const reloadedCache = new CacheManager({
@@ -139,7 +139,7 @@ describe('CacheManager Unit Tests', () => {
             vi.useFakeTimers()
             
             cache.set('temp_key', 'temp_val')
-            cache.saveToStorage()
+            cache.saveImmediately()
             
             // Fast forward time while the 'app' is closed
             vi.advanceTimersByTime(3600001)


### PR DESCRIPTION
## Summary
- fix sign planner run sequencing so signs are placed only after current-run layout completion
- clear stale sign anchors/signs on setup boundary to prevent previous-layout anchor reuse
- add regression coverage for layout replay and stale-anchor scenarios
- keep related layout replay guards in coordinator/spawner tests aligned with current event contracts

## Why
Changing layout/group could either hide signs or place them in stale/floating positions because sign placement could race against shelf anchor refresh events.

## What changed
- `client/src/scene/ShelfSectionPlanner.ts`
  - clear sign planner run state on `StorePropsEventTypes.SetupRequest`
  - remove eager placement on `SectionsReady` when old anchors exist
  - place signs from `pendingSections` only when `ShelfLayoutDetermined` confirms current-run shelf wave is complete
- `client/test/unit/scene/ShelfSectionPlanner.test.ts`
  - add/update tests for setup-boundary clear behavior and fresh-anchor placement after rebuild
  - align sequencing expectations to runtime (`SectionsReady` + `ShelfLayoutDetermined`)
- related test updates already on branch keep manifest/section contracts current and guard layout replay ordering

## Validation
- `yarn vitest run test/unit/scene/ShelfSectionPlanner.test.ts test/unit/scene/spawning/GameBoxSpawner.test.ts test/unit/scene/StorePropsCoordinator-layout-requested.test.ts`
- `yarn tsc --noEmit`
