### PR TITLE
Fix spoke shelf rotation to keep Near faces aisle

### DIFF
--- a/client/src/scene/props/shared/SpokeLayoutUtils.ts
+++ b/client/src/scene/props/shared/SpokeLayoutUtils.ts
@@ -155,10 +155,10 @@ export function computeSpokeShelfLayout(
 
                 // Shelf Near face must face the aisle (toward centreline).
                 // Left row faces right (-perpDir), right row faces left (+perpDir).
-                // atan2(x, z) gives the angle that makes the +Z axis point in facingDir.
-                // Add PI to flip so the shelf model's -Z front faces the aisle.
+                // atan2(x, z) gives the angle that makes the shelf's local +Z axis
+                // (Near surface in our board model) point in facingDir.
                 const facingDir = perpDir.clone().multiplyScalar(-lateralSign)
-                const rotationY = Math.atan2(facingDir.x, facingDir.z) + Math.PI
+                const rotationY = Math.atan2(facingDir.x, facingDir.z)
 
                 result.push({
                     position: shelfCentre.clone(),


### PR DESCRIPTION
## Summary
This fixes spoke shelf orientation so the model's Near face points toward the aisle as intended.

## What changed
- Removed the extra `+ Math.PI` flip from spoke shelf `rotationY` calculation.
- Restored Near-surface semantics in spoke layout comments/behavior.

## Why
A previous rotation flip inverted shelf facing, which made games/signs appear on outside faces unless we used a workaround. With this fix, Near/Far semantics are consistent again and existing placement logic works as designed.

## Validation
- Verified TypeScript compile: `yarn tsc --noEmit`
- Manual spoke-layout verification in dev runtime.
