### PR TITLE
Refactor render placement to event-driven intent rendezvous

### DIFF
--- a/client/src/scene/categorization/GameSortFunctions.ts
+++ b/client/src/scene/categorization/GameSortFunctions.ts
@@ -62,11 +62,37 @@ export function primaryGenre(game: SteamGameData): string {
 }
 
 /**
- * Group a flat game list by primary genre.
+ * Extract all canonical, recognised genres for grouping.
+ * Falls back to ['Other'] only when no recognised genre exists.
+ */
+export function groupingGenres(game: SteamGameData): string[] {
+    const genres = game.genres
+        ?.map((genre) => genre.description)
+        .filter((description): description is string => Boolean(description))
+        .map(resolveGenre)
+        .filter((genre) => genre !== 'Other') ?? []
+
+    const uniqueGenres = [...new Set(genres)]
+    return uniqueGenres.length > 0 ? uniqueGenres : ['Other']
+}
+
+/**
+ * Group a flat game list by all recognised genres.
+ * A game may appear in multiple genre buckets; if none are recognised, it falls into Other.
  * Returns a Map<string, SteamGameData[]>.
  */
 export function groupByGenre(games: readonly SteamGameData[]): Map<string, SteamGameData[]> {
-    return groupByKey(games, primaryGenre)
+    const grouped = new Map<string, SteamGameData[]>()
+
+    for (const game of games) {
+        for (const genre of groupingGenres(game)) {
+            const bucket = grouped.get(genre) ?? []
+            bucket.push(game)
+            grouped.set(genre, bucket)
+        }
+    }
+
+    return grouped
 }
 
 // ─── Comparator factories ──────────────────────────────────────────────────────

--- a/client/src/scene/game-box/GpuGameBoxRenderer.ts
+++ b/client/src/scene/game-box/GpuGameBoxRenderer.ts
@@ -14,7 +14,7 @@
  * 
  * RECEIVES:
  * - prefetchArtwork(appid, url, name) → Phase 1: load texture into atlas
- * - placeGame(game, position, rotation) → unified placement (artwork or label fallback)
+ * - PlacementResolved events → unified placement (artwork or label fallback)
  * - clearPlacements() → wipe all GPU instances before re-sort
  * - addToScene(scene) → Attaches instanced meshes to scene
  * - updateLODForCamera(camera) → Adjusts detail levels based on distance
@@ -46,6 +46,8 @@ import { LodArtworkOrchestratorDebug } from './instancing/LodArtworkOrchestrator
 import type { IGameArtworkPipeline } from './instancing/IGameArtworkPipeline'
 import { RenderIntentCoordinator } from './RenderIntentCoordinator'
 import { Logger } from '../../utils/Logger'
+import { EventManager } from '../../core/EventManager'
+import { GameRenderEventTypes, type PlacementResolvedEvent } from '../../types/InteractionEvents'
 
 export class GpuGameBoxRenderer {
     public static logger = Logger.createLogFunctions(GpuGameBoxRenderer.name)
@@ -53,16 +55,25 @@ export class GpuGameBoxRenderer {
     private readonly instancedLabelRenderer: InstancedLabelRenderer
     private readonly lodArtworkRenderer: IGameArtworkPipeline
     private readonly renderIntentCoordinator: RenderIntentCoordinator
+    private readonly boundHandlePlacementResolved: (event: CustomEvent<PlacementResolvedEvent>) => void
 
     constructor(maxGames: number = 2000) {
         this.instancedLabelRenderer = new InstancedLabelRenderer({ maxInstances: maxGames })
         this.lodArtworkRenderer = LodArtworkOrchestratorDebug.fromAppSettings(maxGames)
-        this.renderIntentCoordinator = new RenderIntentCoordinator({
-            placeTexturedGame: (game, position, rotation) => this.placeTexturedGame(game, position, rotation),
-            placeLabelGame: (game, position, rotation) => this.placeLabelBox(game, position, rotation),
-        })
+        this.renderIntentCoordinator = new RenderIntentCoordinator()
+        this.boundHandlePlacementResolved = this.handlePlacementResolved.bind(this)
+
+        EventManager.getInstance().registerEventHandler(
+            GameRenderEventTypes.PlacementResolved,
+            this.boundHandlePlacementResolved
+        )
 
         GpuGameBoxRenderer.logger.lifecycle(`Initialized (max ${maxGames} games)`)
+    }
+
+    private handlePlacementResolved(event: CustomEvent<PlacementResolvedEvent>): void {
+        const { game, position, rotation } = event.detail
+        this.placeResolvedGame(game, position, rotation)
     }
 
     /**
@@ -80,22 +91,7 @@ export class GpuGameBoxRenderer {
         return this.lodArtworkRenderer.prefetchArtwork(appid, artworkUrl, gameName)
     }
 
-    /**
-     * Unified placement: try artwork instance first; fall through to label box on atlas miss.
-     * This is the preferred placement path — callers do not need to know which renderer
-     * handles the game. The artwork/label decision lives here, not upstream.
-     *
-     * rotation encodes both shelf orientation and front/back side — no separate side param needed.
-     */
-    public placeGame(
-        game: SteamGameData,
-        position: THREE.Vector3,
-        rotation: THREE.Quaternion
-    ): void {
-        this.placeTexturedGame(game, position, rotation)
-    }
-
-    private placeTexturedGame(
+    private placeResolvedGame(
         game: SteamGameData,
         position: THREE.Vector3,
         rotation: THREE.Quaternion
@@ -141,6 +137,10 @@ export class GpuGameBoxRenderer {
 
     public dispose(): void {
         GpuGameBoxRenderer.logger.lifecycle('Disposing')
+        EventManager.getInstance().deregisterEventHandler(
+            GameRenderEventTypes.PlacementResolved,
+            this.boundHandlePlacementResolved
+        )
         this.renderIntentCoordinator.dispose()
         this.instancedLabelRenderer.dispose()
         this.lodArtworkRenderer.dispose()

--- a/client/src/scene/game-box/GpuGameBoxRenderer.ts
+++ b/client/src/scene/game-box/GpuGameBoxRenderer.ts
@@ -44,6 +44,7 @@ import type { SteamGameData } from './types/GameData'
 import { InstancedLabelRenderer } from './instancing/InstancedLabelRenderer'
 import { LodArtworkOrchestratorDebug } from './instancing/LodArtworkOrchestratorDebug'
 import type { IGameArtworkPipeline } from './instancing/IGameArtworkPipeline'
+import { RenderIntentCoordinator } from './RenderIntentCoordinator'
 import { Logger } from '../../utils/Logger'
 
 export class GpuGameBoxRenderer {
@@ -51,10 +52,15 @@ export class GpuGameBoxRenderer {
 
     private readonly instancedLabelRenderer: InstancedLabelRenderer
     private readonly lodArtworkRenderer: IGameArtworkPipeline
+    private readonly renderIntentCoordinator: RenderIntentCoordinator
 
     constructor(maxGames: number = 2000) {
         this.instancedLabelRenderer = new InstancedLabelRenderer({ maxInstances: maxGames })
         this.lodArtworkRenderer = LodArtworkOrchestratorDebug.fromAppSettings(maxGames)
+        this.renderIntentCoordinator = new RenderIntentCoordinator({
+            placeTexturedGame: (game, position, rotation) => this.placeTexturedGame(game, position, rotation),
+            placeLabelGame: (game, position, rotation) => this.placeLabelBox(game, position, rotation),
+        })
 
         GpuGameBoxRenderer.logger.lifecycle(`Initialized (max ${maxGames} games)`)
     }
@@ -82,6 +88,14 @@ export class GpuGameBoxRenderer {
      * rotation encodes both shelf orientation and front/back side — no separate side param needed.
      */
     public placeGame(
+        game: SteamGameData,
+        position: THREE.Vector3,
+        rotation: THREE.Quaternion
+    ): void {
+        this.placeTexturedGame(game, position, rotation)
+    }
+
+    private placeTexturedGame(
         game: SteamGameData,
         position: THREE.Vector3,
         rotation: THREE.Quaternion
@@ -120,12 +134,14 @@ export class GpuGameBoxRenderer {
      * Call before re-sorting; follow with placeArtworkInstance()/placeLabelBox() for each game.
      */
     public clearPlacements(): void {
+        this.renderIntentCoordinator.clearPendingPlacementIntents()
         this.lodArtworkRenderer.clearPlacements()
         this.instancedLabelRenderer.clear()
     }
 
     public dispose(): void {
         GpuGameBoxRenderer.logger.lifecycle('Disposing')
+        this.renderIntentCoordinator.dispose()
         this.instancedLabelRenderer.dispose()
         this.lodArtworkRenderer.dispose()
         GpuGameBoxRenderer.logger.lifecycle('Disposed')

--- a/client/src/scene/game-box/RenderIntentCoordinator.ts
+++ b/client/src/scene/game-box/RenderIntentCoordinator.ts
@@ -1,0 +1,105 @@
+import * as THREE from 'three'
+import type { SteamGameData } from './types/GameData'
+import { EventManager } from '../../core/EventManager'
+import {
+    GameRenderEventTypes,
+    type ArtworkIntentSettledEvent,
+    type PlacementIntentReadyEvent,
+} from '../../types/InteractionEvents'
+
+interface RenderIntentCoordinatorOptions {
+    placeTexturedGame: (game: SteamGameData, position: THREE.Vector3, rotation: THREE.Quaternion) => void
+    placeLabelGame: (game: SteamGameData, position: THREE.Vector3, rotation: THREE.Quaternion) => void
+}
+
+/**
+ * Renderer-side rendezvous for placement intents and artwork outcomes.
+ * One settled artwork outcome can satisfy many placement intents.
+ */
+export class RenderIntentCoordinator {
+    private readonly placeTexturedGame: RenderIntentCoordinatorOptions['placeTexturedGame']
+    private readonly placeLabelGame: RenderIntentCoordinatorOptions['placeLabelGame']
+
+    private readonly artworkOutcomes = new Map<number, ArtworkIntentSettledEvent['result']>()
+    private readonly pendingPlacementIntents = new Map<number, PlacementIntentReadyEvent[]>()
+
+    private readonly boundHandleArtworkIntentSettled: (event: CustomEvent<ArtworkIntentSettledEvent>) => void
+    private readonly boundHandlePlacementIntentReady: (event: CustomEvent<PlacementIntentReadyEvent>) => void
+
+    public constructor(options: RenderIntentCoordinatorOptions) {
+        this.placeTexturedGame = options.placeTexturedGame
+        this.placeLabelGame = options.placeLabelGame
+
+        this.boundHandleArtworkIntentSettled = this.handleArtworkIntentSettled.bind(this)
+        this.boundHandlePlacementIntentReady = this.handlePlacementIntentReady.bind(this)
+
+        EventManager.getInstance().registerEventHandler(
+            GameRenderEventTypes.ArtworkIntentSettled,
+            this.boundHandleArtworkIntentSettled
+        )
+        EventManager.getInstance().registerEventHandler(
+            GameRenderEventTypes.PlacementIntentReady,
+            this.boundHandlePlacementIntentReady
+        )
+    }
+
+    public clearPendingPlacementIntents(): void {
+        this.pendingPlacementIntents.clear()
+    }
+
+    public dispose(): void {
+        EventManager.getInstance().deregisterEventHandler(
+            GameRenderEventTypes.ArtworkIntentSettled,
+            this.boundHandleArtworkIntentSettled
+        )
+        EventManager.getInstance().deregisterEventHandler(
+            GameRenderEventTypes.PlacementIntentReady,
+            this.boundHandlePlacementIntentReady
+        )
+
+        this.pendingPlacementIntents.clear()
+        this.artworkOutcomes.clear()
+    }
+
+    private handleArtworkIntentSettled(event: CustomEvent<ArtworkIntentSettledEvent>): void {
+        const { appid, result } = event.detail
+        this.artworkOutcomes.set(appid, result)
+        this.flushReadyPlacements(appid)
+    }
+
+    private handlePlacementIntentReady(event: CustomEvent<PlacementIntentReadyEvent>): void {
+        const { appid } = event.detail
+        const pending = this.pendingPlacementIntents.get(appid) ?? []
+        pending.push(event.detail)
+        this.pendingPlacementIntents.set(appid, pending)
+        this.flushReadyPlacements(appid)
+    }
+
+    private flushReadyPlacements(appid: number): void {
+        const outcome = this.artworkOutcomes.get(appid)
+        if (outcome === undefined) {
+            return
+        }
+
+        const pending = this.pendingPlacementIntents.get(appid)
+        if (!pending || pending.length === 0) {
+            return
+        }
+
+        while (pending.length > 0) {
+            const intent = pending.shift()
+            if (!intent) {
+                break
+            }
+
+            if (outcome === 'permanent-failure' || outcome === 'error') {
+                this.placeLabelGame(intent.game, intent.position, intent.rotation)
+                continue
+            }
+
+            this.placeTexturedGame(intent.game, intent.position, intent.rotation)
+        }
+
+        this.pendingPlacementIntents.delete(appid)
+    }
+}

--- a/client/src/scene/game-box/RenderIntentCoordinator.ts
+++ b/client/src/scene/game-box/RenderIntentCoordinator.ts
@@ -1,35 +1,23 @@
-import * as THREE from 'three'
-import type { SteamGameData } from './types/GameData'
 import { EventManager } from '../../core/EventManager'
 import {
     GameRenderEventTypes,
     type ArtworkIntentSettledEvent,
+    type PlacementResolvedEvent,
     type PlacementIntentReadyEvent,
 } from '../../types/InteractionEvents'
-
-interface RenderIntentCoordinatorOptions {
-    placeTexturedGame: (game: SteamGameData, position: THREE.Vector3, rotation: THREE.Quaternion) => void
-    placeLabelGame: (game: SteamGameData, position: THREE.Vector3, rotation: THREE.Quaternion) => void
-}
 
 /**
  * Renderer-side rendezvous for placement intents and artwork outcomes.
  * One settled artwork outcome can satisfy many placement intents.
  */
 export class RenderIntentCoordinator {
-    private readonly placeTexturedGame: RenderIntentCoordinatorOptions['placeTexturedGame']
-    private readonly placeLabelGame: RenderIntentCoordinatorOptions['placeLabelGame']
-
-    private readonly artworkOutcomes = new Map<number, ArtworkIntentSettledEvent['result']>()
+    private readonly settledAppIds = new Set<number>()
     private readonly pendingPlacementIntents = new Map<number, PlacementIntentReadyEvent[]>()
 
     private readonly boundHandleArtworkIntentSettled: (event: CustomEvent<ArtworkIntentSettledEvent>) => void
     private readonly boundHandlePlacementIntentReady: (event: CustomEvent<PlacementIntentReadyEvent>) => void
 
-    public constructor(options: RenderIntentCoordinatorOptions) {
-        this.placeTexturedGame = options.placeTexturedGame
-        this.placeLabelGame = options.placeLabelGame
-
+    public constructor() {
         this.boundHandleArtworkIntentSettled = this.handleArtworkIntentSettled.bind(this)
         this.boundHandlePlacementIntentReady = this.handlePlacementIntentReady.bind(this)
 
@@ -58,12 +46,12 @@ export class RenderIntentCoordinator {
         )
 
         this.pendingPlacementIntents.clear()
-        this.artworkOutcomes.clear()
+        this.settledAppIds.clear()
     }
 
     private handleArtworkIntentSettled(event: CustomEvent<ArtworkIntentSettledEvent>): void {
-        const { appid, result } = event.detail
-        this.artworkOutcomes.set(appid, result)
+        const { appid } = event.detail
+        this.settledAppIds.add(appid)
         this.flushReadyPlacements(appid)
     }
 
@@ -76,8 +64,7 @@ export class RenderIntentCoordinator {
     }
 
     private flushReadyPlacements(appid: number): void {
-        const outcome = this.artworkOutcomes.get(appid)
-        if (outcome === undefined) {
+        if (!this.settledAppIds.has(appid)) {
             return
         }
 
@@ -91,13 +78,15 @@ export class RenderIntentCoordinator {
             if (!intent) {
                 break
             }
-
-            if (outcome === 'permanent-failure' || outcome === 'error') {
-                this.placeLabelGame(intent.game, intent.position, intent.rotation)
-                continue
-            }
-
-            this.placeTexturedGame(intent.game, intent.position, intent.rotation)
+            EventManager.getInstance().emit<PlacementResolvedEvent>(
+                GameRenderEventTypes.PlacementResolved,
+                {
+                    appid,
+                    game: intent.game,
+                    position: intent.position,
+                    rotation: intent.rotation,
+                }
+            )
         }
 
         this.pendingPlacementIntents.delete(appid)

--- a/client/src/scene/spawning/ArtworkPrefetchCoordinator.ts
+++ b/client/src/scene/spawning/ArtworkPrefetchCoordinator.ts
@@ -13,7 +13,7 @@ import type { SteamGameData } from '../game-box/types/GameData'
 export type PrefetchResult = 'prefetched' | 'cached' | 'permanent-failure' | 'error'
 
 interface ArtworkPrefetchCoordinatorOptions {
-    getRenderer?: () => GpuGameBoxRenderer | null
+    renderer?: GpuGameBoxRenderer | null
 }
 
 /**
@@ -22,7 +22,7 @@ interface ArtworkPrefetchCoordinatorOptions {
  */
 export class ArtworkPrefetchCoordinator {
     private readonly logger = Logger.createLogFunctions(ArtworkPrefetchCoordinator.name)
-    private readonly getRenderer: () => GpuGameBoxRenderer | null
+    private readonly renderer: GpuGameBoxRenderer | null
     private readonly boundHandleArtworkSettled: () => void
     private readonly boundHandleBatchReadyForPlacement: (event: CustomEvent<BatchReadyForPlacementEvent>) => void
 
@@ -31,7 +31,7 @@ export class ArtworkPrefetchCoordinator {
     private hasLoggedExpectedFallbackSummary = false
 
     public constructor(options: ArtworkPrefetchCoordinatorOptions = {}) {
-        this.getRenderer = options.getRenderer ?? (() => null)
+        this.renderer = options.renderer ?? null
         this.boundHandleArtworkSettled = this.logExpectedFallbackSummary.bind(this)
         this.boundHandleBatchReadyForPlacement = this.handleBatchReadyForPlacement.bind(this)
 
@@ -84,15 +84,14 @@ export class ArtworkPrefetchCoordinator {
             `BatchReadyForPlacement: batch ${batchIndex + 1}/${totalBatches}, ${games.length} games — prewarming artwork`
         )
 
-        const renderer = this.getRenderer()
-        if (!renderer) {
+        if (!this.renderer) {
             this.logger.warn(
                 'BatchReadyForPlacement received before GameDataReady initialized renderer — dropping batch prewarm to enforce event ordering'
             )
             return
         }
 
-        this.prefetchBatch(games as SteamGameData[], renderer)
+        this.prefetchBatch(games as SteamGameData[], this.renderer)
     }
 
     private emitArtworkIntentSettled(appid: number, gameName: string): void {

--- a/client/src/scene/spawning/ArtworkPrefetchCoordinator.ts
+++ b/client/src/scene/spawning/ArtworkPrefetchCoordinator.ts
@@ -1,0 +1,95 @@
+import { Logger } from '../../utils/Logger'
+import { GpuGameBoxRenderer } from '../game-box/GpuGameBoxRenderer'
+import type { SteamGameData } from '../game-box/types/GameData'
+
+export type PrefetchResult = 'prefetched' | 'cached' | 'permanent-failure' | 'error'
+
+/**
+ * Owns batch-time artwork prefetch state independently from shelf placement state.
+ * A single artwork prefetch result can later satisfy one or more placement intents.
+ */
+export class ArtworkPrefetchCoordinator {
+    private readonly logger = Logger.createLogFunctions(ArtworkPrefetchCoordinator.name)
+
+    private readonly prefetchResults: Map<number, PrefetchResult> = new Map()
+    private readonly appNamesByAppId: Map<number, string> = new Map()
+    private hasLoggedExpectedFallbackSummary = false
+
+    public reset(): void {
+        this.prefetchResults.clear()
+        this.appNamesByAppId.clear()
+        this.hasLoggedExpectedFallbackSummary = false
+    }
+
+    public getResult(appid: number): PrefetchResult | undefined {
+        return this.prefetchResults.get(appid)
+    }
+
+    public prefetchBatch(
+        games: ReadonlyArray<SteamGameData>,
+        renderer: GpuGameBoxRenderer,
+        onSettled: (appid: number) => void
+    ): void {
+        for (const game of games) {
+            const appid = typeof game.appid === 'number' ? game.appid : 0
+            this.appNamesByAppId.set(appid, game.name)
+            const artworkUrl = this.selectBestArtworkUrl(game)
+
+            if (!artworkUrl) {
+                this.prefetchResults.set(appid, 'permanent-failure')
+                onSettled(appid)
+                continue
+            }
+
+            renderer.prefetchArtwork(appid, artworkUrl, game.name).then((result) => {
+                this.prefetchResults.set(appid, result)
+                onSettled(appid)
+            }).catch((error) => {
+                this.logger.warn(`prefetchArtwork failed for "${game.name}": ${error}`)
+                this.prefetchResults.set(appid, 'error')
+                onSettled(appid)
+            })
+        }
+    }
+
+    public logExpectedFallbackSummary(): void {
+        if (this.hasLoggedExpectedFallbackSummary) {
+            return
+        }
+
+        const fallbackTitles: string[] = []
+        for (const [appid, result] of this.prefetchResults) {
+            if (result !== 'permanent-failure' && result !== 'error') {
+                continue
+            }
+            const title = this.appNamesByAppId.get(appid)
+            if (title) {
+                fallbackTitles.push(title)
+            }
+        }
+
+        if (fallbackTitles.length > 0) {
+            fallbackTitles.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+            const previewLimit = 25
+            const preview = fallbackTitles.slice(0, previewLimit)
+            const remaining = fallbackTitles.length - preview.length
+            const overflowSuffix = remaining > 0 ? ` (+${remaining} more)` : ''
+
+            this.logger.info(
+                `Artwork fallback summary: ${fallbackTitles.length} game(s) will use labels this run: ` +
+                `${preview.join(', ')}${overflowSuffix}`
+            )
+        }
+
+        this.hasLoggedExpectedFallbackSummary = true
+    }
+
+    private selectBestArtworkUrl(game: SteamGameData): string | undefined {
+        if (game.artwork?.library) return game.artwork.library
+        if (game.artwork?.header) return game.artwork.header
+        if (game.appid) {
+            return `https://cdn.akamai.steamstatic.com/steam/apps/${game.appid}/library_600x900.jpg`
+        }
+        return undefined
+    }
+}

--- a/client/src/scene/spawning/ArtworkPrefetchCoordinator.ts
+++ b/client/src/scene/spawning/ArtworkPrefetchCoordinator.ts
@@ -1,8 +1,20 @@
 import { Logger } from '../../utils/Logger'
+import { EventManager } from '../../core/EventManager'
+import {
+    GameEventTypes,
+    GameRenderEventTypes,
+    StorePropsEventTypes,
+    type ArtworkIntentSettledEvent,
+    type BatchReadyForPlacementEvent,
+} from '../../types/InteractionEvents'
 import { GpuGameBoxRenderer } from '../game-box/GpuGameBoxRenderer'
 import type { SteamGameData } from '../game-box/types/GameData'
 
 export type PrefetchResult = 'prefetched' | 'cached' | 'permanent-failure' | 'error'
+
+interface ArtworkPrefetchCoordinatorOptions {
+    getRenderer?: () => GpuGameBoxRenderer | null
+}
 
 /**
  * Owns batch-time artwork prefetch state independently from shelf placement state.
@@ -10,10 +22,28 @@ export type PrefetchResult = 'prefetched' | 'cached' | 'permanent-failure' | 'er
  */
 export class ArtworkPrefetchCoordinator {
     private readonly logger = Logger.createLogFunctions(ArtworkPrefetchCoordinator.name)
+    private readonly getRenderer: () => GpuGameBoxRenderer | null
+    private readonly boundHandleArtworkSettled: () => void
+    private readonly boundHandleBatchReadyForPlacement: (event: CustomEvent<BatchReadyForPlacementEvent>) => void
 
     private readonly prefetchResults: Map<number, PrefetchResult> = new Map()
     private readonly appNamesByAppId: Map<number, string> = new Map()
     private hasLoggedExpectedFallbackSummary = false
+
+    public constructor(options: ArtworkPrefetchCoordinatorOptions = {}) {
+        this.getRenderer = options.getRenderer ?? (() => null)
+        this.boundHandleArtworkSettled = this.logExpectedFallbackSummary.bind(this)
+        this.boundHandleBatchReadyForPlacement = this.handleBatchReadyForPlacement.bind(this)
+
+        EventManager.getInstance().registerEventHandler(
+            GameEventTypes.ArtworkSettled,
+            this.boundHandleArtworkSettled
+        )
+        EventManager.getInstance().registerEventHandler(
+            StorePropsEventTypes.BatchReadyForPlacement,
+            this.boundHandleBatchReadyForPlacement
+        )
+    }
 
     public reset(): void {
         this.prefetchResults.clear()
@@ -21,14 +51,9 @@ export class ArtworkPrefetchCoordinator {
         this.hasLoggedExpectedFallbackSummary = false
     }
 
-    public getResult(appid: number): PrefetchResult | undefined {
-        return this.prefetchResults.get(appid)
-    }
-
     public prefetchBatch(
         games: ReadonlyArray<SteamGameData>,
-        renderer: GpuGameBoxRenderer,
-        onSettled: (appid: number) => void
+        renderer: GpuGameBoxRenderer
     ): void {
         for (const game of games) {
             const appid = typeof game.appid === 'number' ? game.appid : 0
@@ -37,19 +62,48 @@ export class ArtworkPrefetchCoordinator {
 
             if (!artworkUrl) {
                 this.prefetchResults.set(appid, 'permanent-failure')
-                onSettled(appid)
+                this.emitArtworkIntentSettled(appid, game.name, 'permanent-failure')
                 continue
             }
 
             renderer.prefetchArtwork(appid, artworkUrl, game.name).then((result) => {
                 this.prefetchResults.set(appid, result)
-                onSettled(appid)
+                this.emitArtworkIntentSettled(appid, game.name, result)
             }).catch((error) => {
                 this.logger.warn(`prefetchArtwork failed for "${game.name}": ${error}`)
                 this.prefetchResults.set(appid, 'error')
-                onSettled(appid)
+                this.emitArtworkIntentSettled(appid, game.name, 'error')
             })
         }
+    }
+
+    private handleBatchReadyForPlacement(event: CustomEvent<BatchReadyForPlacementEvent>): void {
+        const { games, batchIndex, totalBatches } = event.detail
+
+        this.logger.debug(
+            `BatchReadyForPlacement: batch ${batchIndex + 1}/${totalBatches}, ${games.length} games — prewarming artwork`
+        )
+
+        const renderer = this.getRenderer()
+        if (!renderer) {
+            this.logger.warn(
+                'BatchReadyForPlacement received before GameDataReady initialized renderer — dropping batch prewarm to enforce event ordering'
+            )
+            return
+        }
+
+        this.prefetchBatch(games as SteamGameData[], renderer)
+    }
+
+    private emitArtworkIntentSettled(
+        appid: number,
+        gameName: string,
+        result: ArtworkIntentSettledEvent['result']
+    ): void {
+        EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
+            GameRenderEventTypes.ArtworkIntentSettled,
+            { appid, gameName, result }
+        )
     }
 
     public logExpectedFallbackSummary(): void {

--- a/client/src/scene/spawning/ArtworkPrefetchCoordinator.ts
+++ b/client/src/scene/spawning/ArtworkPrefetchCoordinator.ts
@@ -62,17 +62,17 @@ export class ArtworkPrefetchCoordinator {
 
             if (!artworkUrl) {
                 this.prefetchResults.set(appid, 'permanent-failure')
-                this.emitArtworkIntentSettled(appid, game.name, 'permanent-failure')
+                this.emitArtworkIntentSettled(appid, game.name)
                 continue
             }
 
             renderer.prefetchArtwork(appid, artworkUrl, game.name).then((result) => {
                 this.prefetchResults.set(appid, result)
-                this.emitArtworkIntentSettled(appid, game.name, result)
+                this.emitArtworkIntentSettled(appid, game.name)
             }).catch((error) => {
                 this.logger.warn(`prefetchArtwork failed for "${game.name}": ${error}`)
                 this.prefetchResults.set(appid, 'error')
-                this.emitArtworkIntentSettled(appid, game.name, 'error')
+                this.emitArtworkIntentSettled(appid, game.name)
             })
         }
     }
@@ -95,14 +95,10 @@ export class ArtworkPrefetchCoordinator {
         this.prefetchBatch(games as SteamGameData[], renderer)
     }
 
-    private emitArtworkIntentSettled(
-        appid: number,
-        gameName: string,
-        result: ArtworkIntentSettledEvent['result']
-    ): void {
+    private emitArtworkIntentSettled(appid: number, gameName: string): void {
         EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
             GameRenderEventTypes.ArtworkIntentSettled,
-            { appid, gameName, result }
+            { appid, gameName }
         )
     }
 

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -6,11 +6,12 @@ import { EventManager } from '../../core/EventManager'
 import { AppSettings, Setting } from '../../core/AppSettings'
 import { 
     BatchProcessingStatus,
+    GameRenderEventTypes,
     StorePropsEventTypes, 
     GameEventTypes,
     SteamEventTypes,
     UIEventTypes,
-    type BatchReadyForPlacementEvent,
+    type PlacementIntentReadyEvent,
     type ShelfReadyEvent,
     type ShelfLayoutDeterminedEvent,
     type GamesPlacedEvent,
@@ -29,13 +30,6 @@ interface ShelfPosition {
     rotationY: number
 }
 
-/** Placement intent: where a game should appear once its artwork is ready. */
-interface PlacementIntent {
-    game: SteamGameData
-    position: THREE.Vector3
-    rotation: THREE.Quaternion
-}
-
 /**
  * GameBoxSpawner
  *
@@ -43,21 +37,17 @@ interface PlacementIntent {
  *
  * Phase 1 — Prewarm (BatchReadyForPlacement):
  *   Triggers artwork prefetch for each game — no GPU instances placed yet.
- *   When a prefetch settles, calls tryPlace() which places immediately if a
- *   position intent is already known.
  *
  * Phase 2 — Place (SectionsReady):
- *   Clears all existing placements, populates placement intents in sorted order
- *   across all sections, and calls tryPlace() for any game whose prefetch has
- *   already settled. Games still in-flight are placed by their prefetch .then()
- *   when it resolves.
+ *   Clears all existing placements and emits placement intents in sorted order
+ *   across all sections. Renderer-side rendezvous decides textured vs label
+ *   placement when artwork outcomes settle.
  *
  * ShelfReady:
  *   Caches shelf positions indexed by batchIndex for Phase 2 lookup.
  *
- * The artwork/label decision is NOT made here. GpuGameBoxRenderer.placeGame()
- * checks the atlas and falls through to a label box on miss. GameBoxSpawner
- * only knows "game X goes at position Y".
+ * The artwork/label decision is NOT made here. GameBoxSpawner only emits
+ * world-space placement intents ("game X goes at position Y").
  *
  * TD: This class conflates two concerns — artwork prefetch/prewarm (Phase 1) and
  * geometry-driven placement (Phase 2). They share only the renderer reference.
@@ -77,10 +67,7 @@ export class GameBoxSpawner {
     // Cached sections from last SectionsReady — consumed when ShelfLayoutDetermined fires
     private pendingSections: SectionsReadyEvent | null = null
 
-    private readonly artworkPrefetch = new ArtworkPrefetchCoordinator()
-    // Rendezvous state: placement intents per appid (one game can appear in multiple sections)
-    private placementIntents: Map<number, PlacementIntent[]> = new Map()
-
+    private readonly artworkPrefetch: ArtworkPrefetchCoordinator
     private readonly labelsEnabled: boolean
     private stockStrategy: IStockStrategy | null = null
 
@@ -95,11 +82,10 @@ export class GameBoxSpawner {
 
     private constructor() {
         this.labelsEnabled = AppSettings.get(Setting.EnableLabels)
+        this.artworkPrefetch = new ArtworkPrefetchCoordinator({
+            getRenderer: () => this.renderer,
+        })
 
-        EventManager.getInstance().registerEventHandler(
-            StorePropsEventTypes.BatchReadyForPlacement,
-            (e: CustomEvent<BatchReadyForPlacementEvent>) => this.handleBatchReadyForPlacement(e)
-        )
         EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.ShelfReady,
             (e: CustomEvent<ShelfReadyEvent>) => this.handleShelfReady(e)
@@ -124,10 +110,6 @@ export class GameBoxSpawner {
             StorePropsEventTypes.LibraryReloadRequest,
             (e: CustomEvent<StorePropsLibraryReloadRequestEvent>) => this.handleLibraryReloadRequest(e)
         )
-        EventManager.getInstance().registerEventHandler(
-            GameEventTypes.ArtworkSettled,
-            (event: CustomEvent) => this.handleArtworkSettled(event)
-        )
 
         GameBoxSpawner.logger.debug('Constructed')
     }
@@ -143,7 +125,6 @@ export class GameBoxSpawner {
         this.pendingSections = null
         this.shelfPositions.clear()
         this.artworkPrefetch.reset()
-        this.placementIntents.clear()
         GameBoxSpawner.logger.debug('Full reset (library reload)')
     }
 
@@ -156,7 +137,6 @@ export class GameBoxSpawner {
         this.stockStrategy = null
         this.pendingSections = null
         this.shelfPositions.clear()
-        this.placementIntents.clear()
         GameBoxSpawner.logger.debug('Geometry reset (layout switch)')
     }
 
@@ -197,26 +177,6 @@ export class GameBoxSpawner {
     }
 
     // -------------------------------------------------------------------------
-    // Phase 1: prewarm artwork as batches arrive (independent of shelf layout)
-
-    private handleBatchReadyForPlacement(event: CustomEvent<BatchReadyForPlacementEvent>): void {
-        const { games, batchIndex, totalBatches } = event.detail
-
-        GameBoxSpawner.logger.debug(
-            `BatchReadyForPlacement: batch ${batchIndex + 1}/${totalBatches}, ${games.length} games — prewarming artwork`
-        )
-
-        if (!this.renderer) {
-            GameBoxSpawner.logger.warn(
-                'BatchReadyForPlacement received before GameDataReady initialized renderer — dropping batch prewarm to enforce event ordering'
-            )
-            return
-        }
-
-        this.artworkPrefetch.prefetchBatch(games as SteamGameData[], this.renderer, (appid) => this.tryPlace(appid))
-    }
-
-    // -------------------------------------------------------------------------
     // Cache shelf positions from ShelfReady events
 
     private handleShelfReady(event: CustomEvent<ShelfReadyEvent>): void {
@@ -239,7 +199,6 @@ export class GameBoxSpawner {
         // Start-of-run reset: this is deterministic regardless of listener order on
         // UI-triggering events (layout/group/sort changes).
         this.shelfPositions.clear()
-        this.placementIntents.clear()
 
         // Cache sections for placement. Placement is deferred to handleLayoutDetermined,
         // which runs after ShelfReady has repopulated fresh shelf positions.
@@ -266,7 +225,6 @@ export class GameBoxSpawner {
         }
 
         this.renderer.clearPlacements()
-        this.placementIntents.clear()
 
         const shelfSurfaces = ShelfSurfaceUtils.findShelfSurfaces(null, true)
         if (shelfSurfaces.length === 0) {
@@ -305,53 +263,12 @@ export class GameBoxSpawner {
         }
 
         GameBoxSpawner.logger.debug(
-            `Placement complete: ${this.placementIntents.size} intents across ${shelvesUsed} shelves`
+            `Placement intents emitted across ${shelvesUsed} shelves`
         )
-    }
-
-    /**
-    * Attempt to place a game. Succeeds only when both conditions are met:
-    * - prefetch has settled (result in prefetchResults)
-    * - one or more placement intents exist (positions assigned by section placement)
-     *
-     * Called from both sides of the rendezvous — whichever arrives last wins.
-     */
-    private tryPlace(appid: number): void {
-        if (!this.renderer) return
-        const result = this.artworkPrefetch.getResult(appid)
-        if (result === undefined) return // prefetch not yet settled
-        const intents = this.placementIntents.get(appid)
-        if (!intents || intents.length === 0) return // no position assigned yet
-
-        while (intents.length > 0) {
-            const intent = intents.shift()
-            if (!intent) {
-                break
-            }
-
-            // Expected fallback path: artwork unavailable. Place label directly and
-            // avoid per-title atlas-miss warnings from deep renderer layers.
-            if (result === 'permanent-failure' || result === 'error') {
-                this.renderer.placeLabelBox(intent.game, intent.position, intent.rotation)
-                continue
-            }
-
-            // Invariant path: prefetch says artwork exists/cached, so a miss in
-            // placeGame() is a real ordering/consistency signal and should remain visible.
-            this.renderer.placeGame(intent.game, intent.position, intent.rotation)
-        }
-
-        if (intents.length === 0) {
-            this.placementIntents.delete(appid)
-        }
     }
 
     // -------------------------------------------------------------------------
     // Intent assignment helpers
-
-    private handleArtworkSettled(_event: CustomEvent): void {
-        this.artworkPrefetch.logExpectedFallbackSummary()
-    }
 
     private assignIntentsFromStock(
         stockSurfaces: StockSurface[],
@@ -360,10 +277,10 @@ export class GameBoxSpawner {
         const intents = GameBoxUtils.stockSurfaces(stockSurfaces, games)
         for (const { game, position, rotation } of intents) {
             const appid = typeof game.appid === 'number' ? game.appid : 0
-            const pendingIntents = this.placementIntents.get(appid) ?? []
-            pendingIntents.push({ game, position, rotation })
-            this.placementIntents.set(appid, pendingIntents)
-            this.tryPlace(appid)
+            EventManager.getInstance().emit<PlacementIntentReadyEvent>(
+                GameRenderEventTypes.PlacementIntentReady,
+                { appid, game, position, rotation }
+            )
         }
     }
 

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -22,6 +22,7 @@ import type {
 } from '../props/PropsEvents'
 import { Logger } from '../../utils/Logger'
 import type { StockSurface } from '../../types/LayoutTypes'
+import { ArtworkPrefetchCoordinator } from './ArtworkPrefetchCoordinator'
 
 interface ShelfPosition {
     position: THREE.Vector3
@@ -34,8 +35,6 @@ interface PlacementIntent {
     position: THREE.Vector3
     rotation: THREE.Quaternion
 }
-
-type PrefetchResult = 'prefetched' | 'cached' | 'permanent-failure' | 'error'
 
 /**
  * GameBoxSpawner
@@ -78,12 +77,7 @@ export class GameBoxSpawner {
     // Cached sections from last SectionsReady — consumed when ShelfLayoutDetermined fires
     private pendingSections: SectionsReadyEvent | null = null
 
-    // Rendezvous state: prefetch result per appid (populated when prefetch settles)
-    private prefetchResults: Map<number, PrefetchResult> = new Map()
-    // Keep app name for consolidated fallback diagnostics
-    private appNamesByAppId: Map<number, string> = new Map()
-    // Ensure expected fallback summary logs once per library load
-    private hasLoggedExpectedFallbackSummary = false
+    private readonly artworkPrefetch = new ArtworkPrefetchCoordinator()
     // Rendezvous state: placement intents per appid (one game can appear in multiple sections)
     private placementIntents: Map<number, PlacementIntent[]> = new Map()
 
@@ -148,9 +142,7 @@ export class GameBoxSpawner {
         this.stockStrategy = null
         this.pendingSections = null
         this.shelfPositions.clear()
-        this.prefetchResults.clear()
-        this.appNamesByAppId.clear()
-        this.hasLoggedExpectedFallbackSummary = false
+        this.artworkPrefetch.reset()
         this.placementIntents.clear()
         GameBoxSpawner.logger.debug('Full reset (library reload)')
     }
@@ -221,26 +213,7 @@ export class GameBoxSpawner {
             return
         }
 
-        for (const game of games) {
-            const appid = typeof game.appid === 'number' ? game.appid : 0
-            this.appNamesByAppId.set(appid, game.name)
-            const artworkUrl = this.selectBestArtworkUrl(game as SteamGameData)
-
-            if (!artworkUrl) {
-                this.prefetchResults.set(appid, 'permanent-failure')
-                this.tryPlace(appid)
-                continue
-            }
-
-            this.renderer.prefetchArtwork(appid, artworkUrl, game.name).then((result) => {
-                this.prefetchResults.set(appid, result)
-                this.tryPlace(appid)
-            }).catch((error) => {
-                GameBoxSpawner.logger.warn(`prefetchArtwork failed for "${game.name}": ${error}`)
-                this.prefetchResults.set(appid, 'error')
-                this.tryPlace(appid)
-            })
-        }
+        this.artworkPrefetch.prefetchBatch(games as SteamGameData[], this.renderer, (appid) => this.tryPlace(appid))
     }
 
     // -------------------------------------------------------------------------
@@ -345,7 +318,7 @@ export class GameBoxSpawner {
      */
     private tryPlace(appid: number): void {
         if (!this.renderer) return
-        const result = this.prefetchResults.get(appid)
+        const result = this.artworkPrefetch.getResult(appid)
         if (result === undefined) return // prefetch not yet settled
         const intents = this.placementIntents.get(appid)
         if (!intents || intents.length === 0) return // no position assigned yet
@@ -377,35 +350,7 @@ export class GameBoxSpawner {
     // Intent assignment helpers
 
     private handleArtworkSettled(_event: CustomEvent): void {
-        if (this.hasLoggedExpectedFallbackSummary) {
-            return
-        }
-
-        const fallbackTitles: string[] = []
-        for (const [appid, result] of this.prefetchResults) {
-            if (result !== 'permanent-failure' && result !== 'error') {
-                continue
-            }
-            const title = this.appNamesByAppId.get(appid)
-            if (title) {
-                fallbackTitles.push(title)
-            }
-        }
-
-        if (fallbackTitles.length > 0) {
-            fallbackTitles.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
-            const previewLimit = 25
-            const preview = fallbackTitles.slice(0, previewLimit)
-            const remaining = fallbackTitles.length - preview.length
-            const overflowSuffix = remaining > 0 ? ` (+${remaining} more)` : ''
-
-            GameBoxSpawner.logger.info(
-                `Artwork fallback summary: ${fallbackTitles.length} game(s) will use labels this run: ` +
-                `${preview.join(', ')}${overflowSuffix}`
-            )
-        }
-
-        this.hasLoggedExpectedFallbackSummary = true
+        this.artworkPrefetch.logExpectedFallbackSummary()
     }
 
     private assignIntentsFromStock(
@@ -422,22 +367,6 @@ export class GameBoxSpawner {
         }
     }
 
-    /**
-     * Resolve the best available artwork URL for a game.
-     *
-     * Priority:
-     *  1. Metadata library URL (portrait, ideal for game boxes)
-     *  2. Metadata header URL (landscape, fallback)
-     *  3. Constructed CDN portrait URL (last resort when metadata is absent)
-     */
-    private selectBestArtworkUrl(game: SteamGameData): string | undefined {
-        if (game.artwork?.library) return game.artwork.library
-        if (game.artwork?.header) return game.artwork.header
-        if (game.appid) {
-            return `https://cdn.akamai.steamstatic.com/steam/apps/${game.appid}/library_600x900.jpg`
-        }
-        return undefined
-    }
 }
 
 // Construct at import � registers event handlers for app lifetime.

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -84,8 +84,8 @@ export class GameBoxSpawner {
     private appNamesByAppId: Map<number, string> = new Map()
     // Ensure expected fallback summary logs once per library load
     private hasLoggedExpectedFallbackSummary = false
-    // Rendezvous state: placement intent per appid (populated after shelves + strategy known)
-    private placementIntents: Map<number, PlacementIntent> = new Map()
+    // Rendezvous state: placement intents per appid (one game can appear in multiple sections)
+    private placementIntents: Map<number, PlacementIntent[]> = new Map()
 
     private readonly labelsEnabled: boolean
     private stockStrategy: IStockStrategy | null = null
@@ -337,9 +337,9 @@ export class GameBoxSpawner {
     }
 
     /**
-     * Attempt to place a game. Succeeds only when both conditions are met:
-     * - prefetch has settled (result in prefetchResults)
-     * - a placement intent exists (position assigned by GamesSort)
+    * Attempt to place a game. Succeeds only when both conditions are met:
+    * - prefetch has settled (result in prefetchResults)
+    * - one or more placement intents exist (positions assigned by section placement)
      *
      * Called from both sides of the rendezvous — whichever arrives last wins.
      */
@@ -347,21 +347,30 @@ export class GameBoxSpawner {
         if (!this.renderer) return
         const result = this.prefetchResults.get(appid)
         if (result === undefined) return // prefetch not yet settled
-        const intent = this.placementIntents.get(appid)
-        if (!intent) return // no position assigned yet
+        const intents = this.placementIntents.get(appid)
+        if (!intents || intents.length === 0) return // no position assigned yet
 
-        this.placementIntents.delete(appid) // consume the intent
+        while (intents.length > 0) {
+            const intent = intents.shift()
+            if (!intent) {
+                break
+            }
 
-        // Expected fallback path: artwork unavailable. Place label directly and
-        // avoid per-title atlas-miss warnings from deep renderer layers.
-        if (result === 'permanent-failure' || result === 'error') {
-            this.renderer.placeLabelBox(intent.game, intent.position, intent.rotation)
-            return
+            // Expected fallback path: artwork unavailable. Place label directly and
+            // avoid per-title atlas-miss warnings from deep renderer layers.
+            if (result === 'permanent-failure' || result === 'error') {
+                this.renderer.placeLabelBox(intent.game, intent.position, intent.rotation)
+                continue
+            }
+
+            // Invariant path: prefetch says artwork exists/cached, so a miss in
+            // placeGame() is a real ordering/consistency signal and should remain visible.
+            this.renderer.placeGame(intent.game, intent.position, intent.rotation)
         }
 
-        // Invariant path: prefetch says artwork exists/cached, so a miss in
-        // placeGame() is a real ordering/consistency signal and should remain visible.
-        this.renderer.placeGame(intent.game, intent.position, intent.rotation)
+        if (intents.length === 0) {
+            this.placementIntents.delete(appid)
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -406,7 +415,9 @@ export class GameBoxSpawner {
         const intents = GameBoxUtils.stockSurfaces(stockSurfaces, games)
         for (const { game, position, rotation } of intents) {
             const appid = typeof game.appid === 'number' ? game.appid : 0
-            this.placementIntents.set(appid, { game, position, rotation })
+            const pendingIntents = this.placementIntents.get(appid) ?? []
+            pendingIntents.push({ game, position, rotation })
+            this.placementIntents.set(appid, pendingIntents)
             this.tryPlace(appid)
         }
     }

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -1,9 +1,8 @@
 import * as THREE from 'three'
 import { GpuGameBoxRenderer } from '../game-box/GpuGameBoxRenderer'
 import type { SteamGameData } from '../game-box/types/GameData'
-import { ShelfSurfaceUtils, type ShelfSurface, GameBoxUtils, GameLayoutConstants, type IStockStrategy } from '../props/SharedPropsUtils'
+import { ShelfSurfaceUtils, type ShelfSurface, GameBoxUtils, type IStockStrategy } from '../props/SharedPropsUtils'
 import { EventManager } from '../../core/EventManager'
-import { AppSettings, Setting } from '../../core/AppSettings'
 import { 
     BatchProcessingStatus,
     GameRenderEventTypes,
@@ -68,7 +67,6 @@ export class GameBoxSpawner {
     private pendingSections: SectionsReadyEvent | null = null
 
     private readonly artworkPrefetch: ArtworkPrefetchCoordinator
-    private readonly labelsEnabled: boolean
     private stockStrategy: IStockStrategy | null = null
 
     /** Expose the current renderer for external consumers (e.g. addToScene, updateLODForCamera). */
@@ -81,7 +79,6 @@ export class GameBoxSpawner {
     }
 
     private constructor() {
-        this.labelsEnabled = AppSettings.get(Setting.EnableLabels)
         this.artworkPrefetch = new ArtworkPrefetchCoordinator({
             getRenderer: () => this.renderer,
         })

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -79,9 +79,8 @@ export class GameBoxSpawner {
     }
 
     private constructor() {
-        this.artworkPrefetch = new ArtworkPrefetchCoordinator({
-            getRenderer: () => this.renderer,
-        })
+        // ArtworkPrefetchCoordinator is initialized in initializeArtworkPrefetch()
+        // after the renderer is created
 
         EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.ShelfReady,
@@ -152,6 +151,14 @@ export class GameBoxSpawner {
         const rendererCapacity = Math.max(totalGames, 1) + 100
         this.renderer = new GpuGameBoxRenderer(rendererCapacity)
         GameBoxSpawner.logger.debug(`Renderer initialized: capacity ${rendererCapacity}`)
+        
+        this.initializeArtworkPrefetch()
+    }
+
+    private initializeArtworkPrefetch(): void {
+        this.artworkPrefetch = new ArtworkPrefetchCoordinator({
+            renderer: this.renderer,
+        })
     }
 
     private handleLibraryManifestReady(event: CustomEvent<SteamLibraryManifestReadyEvent>): void {

--- a/client/src/types/InteractionEvents.ts
+++ b/client/src/types/InteractionEvents.ts
@@ -212,10 +212,16 @@ export interface GameSelectedEvent extends BaseInteractionEvent {
 export interface ArtworkIntentSettledEvent extends BaseInteractionEvent {
     appid: number
     gameName: string
-    result: 'prefetched' | 'cached' | 'permanent-failure' | 'error'
 }
 
 export interface PlacementIntentReadyEvent extends BaseInteractionEvent {
+    appid: number
+    game: SteamGameData
+    position: THREE.Vector3
+    rotation: THREE.Quaternion
+}
+
+export interface PlacementResolvedEvent extends BaseInteractionEvent {
     appid: number
     game: SteamGameData
     position: THREE.Vector3
@@ -321,6 +327,7 @@ export const GameEventTypes = {
 export const GameRenderEventTypes = {
     ArtworkIntentSettled: 'game-render:artwork-intent-settled',
     PlacementIntentReady: 'game-render:placement-intent-ready',
+    PlacementResolved: 'game-render:placement-resolved',
 } as const
 
 export const CeilingEventTypes = {

--- a/client/src/types/InteractionEvents.ts
+++ b/client/src/types/InteractionEvents.ts
@@ -209,6 +209,19 @@ export interface GameSelectedEvent extends BaseInteractionEvent {
     appid: number | string
 }
 
+export interface ArtworkIntentSettledEvent extends BaseInteractionEvent {
+    appid: number
+    gameName: string
+    result: 'prefetched' | 'cached' | 'permanent-failure' | 'error'
+}
+
+export interface PlacementIntentReadyEvent extends BaseInteractionEvent {
+    appid: number
+    game: SteamGameData
+    position: THREE.Vector3
+    rotation: THREE.Quaternion
+}
+
 // =============================================================================
 // STORE PROPS EVENTS
 // =============================================================================
@@ -303,6 +316,11 @@ export const GameEventTypes = {
     GamesSort: 'game:games-sort',
     /** Fired after grouping + sorting; carries sections ready for placement. */
     SectionsReady: 'game:sections-ready'
+} as const
+
+export const GameRenderEventTypes = {
+    ArtworkIntentSettled: 'game-render:artwork-intent-settled',
+    PlacementIntentReady: 'game-render:placement-intent-ready',
 } as const
 
 export const CeilingEventTypes = {

--- a/client/test/integration/multi-genre-placement.int.test.ts
+++ b/client/test/integration/multi-genre-placement.int.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as THREE from 'three'
+
+import { EventManager } from '../../src/core/EventManager'
+import { DataDomain, DataKey, DataManager } from '../../src/core/data'
+import { createStorePropsTestHarness, type StorePropsTestHarness } from '../helpers/StorePropsTestHarness'
+import { GameSorter } from '../../src/scene/categorization/GameSorter'
+import {
+    SteamEventTypes,
+    GameEventTypes,
+    type SteamLibraryManifestReadyEvent,
+    type SteamGamesBatchEvent,
+} from '../../src/types/InteractionEvents'
+import type { SteamGame } from '../../src/steam'
+import type { GameDataReadyEvent } from '../../src/types/EnvironmentEvents'
+
+const mockPrefetchArtwork = vi.fn().mockResolvedValue('prefetched')
+const mockPlaceGame = vi.fn()
+const mockClearPlacements = vi.fn()
+const mockDispose = vi.fn()
+
+vi.mock('../../src/scene/game-box/GpuGameBoxRenderer', () => ({
+    GpuGameBoxRenderer: vi.fn().mockImplementation(function () {
+        this.prefetchArtwork = mockPrefetchArtwork
+        this.placeGame = mockPlaceGame
+        this.placeLabelBox = vi.fn()
+        this.clearPlacements = mockClearPlacements
+        this.dispose = mockDispose
+        this.addToScene = vi.fn()
+        this.updateLODForCamera = vi.fn()
+    })
+}))
+
+vi.mock('../../src/utils/TextureManager', async () => {
+    const { MockTextureManager } = await import('../mocks/utils/TextureManager.mock')
+    return {
+        TextureManager: {
+            getInstance: () => MockTextureManager.getInstance(),
+        },
+    }
+})
+
+vi.mock('../../src/steam-integration/SteamIntegration', () => ({
+    SteamIntegration: {
+        getInstance: () => ({
+            isAnonymous: () => true,
+        }),
+    },
+}))
+
+function makeMultiGenreGame(): SteamGame {
+    return {
+        appid: 101,
+        name: 'Shared Genre Game',
+        playtime_forever: 42,
+        img_icon_url: '',
+        img_logo_url: '',
+        artwork: {
+            library: 'https://cdn.akamai.steamstatic.com/steam/apps/101/library_600x900.jpg',
+            header: 'https://cdn.akamai.steamstatic.com/steam/apps/101/header.jpg',
+            icon: '',
+            logo: '',
+        },
+        genres: [
+            { id: '1', description: 'Action' },
+            { id: '2', description: 'RPG' },
+        ],
+    }
+}
+
+describe('multi-genre placement integration', () => {
+    let scene: THREE.Scene
+    let eventManager: EventManager
+    let dataManager: DataManager
+    let harness: StorePropsTestHarness
+
+    beforeEach(() => {
+        scene = new THREE.Scene()
+        eventManager = EventManager.getInstance()
+        eventManager.removeAllListeners()
+        dataManager = DataManager.getInstance()
+        dataManager.clear()
+        dataManager.set(DataKey.MainScene, scene, {
+            domain: DataDomain.Scene,
+            description: 'multi-genre placement integration scene',
+        })
+
+        harness = createStorePropsTestHarness(scene)
+        new GameSorter()
+    })
+
+    afterEach(() => {
+        harness?.dispose()
+        eventManager.removeAllListeners()
+        dataManager.clear()
+        scene.clear()
+        vi.clearAllMocks()
+    })
+
+    it('places the same game once per emitted genre section', async () => {
+        const sharedGame = makeMultiGenreGame()
+        const games = [sharedGame]
+
+        dataManager.set('steam.games', games as any, {
+            domain: DataDomain.SteamIntegration,
+            description: 'multi-genre test games',
+        })
+
+        eventManager.emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
+            totalGames: games.length,
+        })
+
+        eventManager.emit<SteamGamesBatchEvent>(SteamEventTypes.GamesBatchReady, {
+            games,
+            batchIndex: 0,
+            totalBatches: 1,
+        })
+
+        eventManager.emit<GameDataReadyEvent>(GameEventTypes.GameDataReady, {
+            totalGames: games.length,
+            totalBatches: 1,
+        })
+
+        await vi.waitFor(() => {
+            expect(mockPlaceGame).toHaveBeenCalledTimes(2)
+        }, { timeout: 8000, interval: 50 })
+
+        expect(mockPlaceGame.mock.calls[0][0].appid).toBe(sharedGame.appid)
+        expect(mockPlaceGame.mock.calls[1][0].appid).toBe(sharedGame.appid)
+        expect(mockPlaceGame.mock.calls[0][1]).not.toEqual(mockPlaceGame.mock.calls[1][1])
+    })
+})

--- a/client/test/unit/scene/categorization/GameSortFunctions.test.ts
+++ b/client/test/unit/scene/categorization/GameSortFunctions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
     KNOWN_GENRES,
     groupByGenre,
+    groupingGenres,
     sortByGenreThenPlaytime,
     resolveGenre,
     primaryGenre,
@@ -20,7 +21,7 @@ describe('groupByGenre', () => {
         expect(groupByGenre([]).size).toBe(0)
     })
 
-    it('groups games by their primary genre', () => {
+    it('groups games by recognised genres', () => {
         const games: Partial<SteamGameData>[] = [
             { appid: 1, name: 'Game A', genres: [{ id: '1', description: 'Action' }] },
             { appid: 2, name: 'Game B', genres: [{ id: '1', description: 'Action' }] },
@@ -75,13 +76,44 @@ describe('groupByGenre', () => {
         expect([...result.keys()].filter(k => k === 'Other')).toHaveLength(1)
     })
 
-    it('uses genres[0] as the primary category', () => {
+    it('adds the same game to each recognised genre bucket', () => {
         const games: Partial<SteamGameData>[] = [
             { appid: 1, name: 'test', genres: [{ id: '1', description: 'Action' }, { id: '3', description: 'RPG' }] },
         ]
         const result = groupByGenre(games as SteamGameData[])
         expect(result.get('Action')).toHaveLength(1)
-        expect(result.has('RPG')).toBe(false)
+        expect(result.get('RPG')).toHaveLength(1)
+    })
+
+    it('does not duplicate the same game within one genre bucket when synonyms repeat', () => {
+        const games: Partial<SteamGameData>[] = [
+            {
+                appid: 1,
+                name: 'test',
+                genres: [
+                    { id: '1', description: 'Free to Play' },
+                    { id: '2', description: 'FREE TO PLAY' },
+                ],
+            },
+        ]
+        const result = groupByGenre(games as SteamGameData[])
+        expect(result.get('Free to Play')).toHaveLength(1)
+    })
+
+    it('does not add a game to Other when at least one recognised genre exists', () => {
+        const games: Partial<SteamGameData>[] = [
+            {
+                appid: 1,
+                name: 'test',
+                genres: [
+                    { id: '1', description: 'Action' },
+                    { id: '2', description: 'Acción' },
+                ],
+            },
+        ]
+        const result = groupByGenre(games as SteamGameData[])
+        expect(result.get('Action')).toHaveLength(1)
+        expect(result.has('Other')).toBe(false)
     })
 
     it('does not treat Early Access as a shelf genre', () => {
@@ -117,6 +149,27 @@ describe('primaryGenre', () => {
     it('returns "Other" when no genres', () => {
         expect(primaryGenre({} as SteamGameData)).toBe('Other')
         expect(primaryGenre({ genres: [] } as SteamGameData)).toBe('Other')
+    })
+})
+
+describe('groupingGenres', () => {
+    it('returns all recognised genres for a game', () => {
+        const game = {
+            genres: [
+                { id: '1', description: 'Action' },
+                { id: '2', description: 'RPG' },
+            ],
+        } as SteamGameData
+
+        expect(groupingGenres(game)).toEqual(['Action', 'RPG'])
+    })
+
+    it('falls back to Other when no recognised genre exists', () => {
+        const game = {
+            genres: [{ id: '1', description: 'Acción' }],
+        } as SteamGameData
+
+        expect(groupingGenres(game)).toEqual(['Other'])
     })
 })
 

--- a/client/test/unit/scene/categorization/GameSorter.test.ts
+++ b/client/test/unit/scene/categorization/GameSorter.test.ts
@@ -100,6 +100,31 @@ describe('GameSorter', () => {
         expect(totalGames).toBe(2)
     })
 
+    it('duplicates a multi-genre game across each matching genre section', () => {
+        mockIsAnonymous = true
+        mockGames = [
+            {
+                ...makeGame(1, 0, 100),
+                genres: [
+                    { id: '1', description: 'Action' },
+                    { id: '2', description: 'RPG' },
+                ],
+            } as SteamGameData,
+        ]
+
+        new GameSorter()
+        fireGameDataReady()
+
+        const [, payload] = mockEmit.mock.calls[0]
+        const actionSection = payload.sections.find((section: any) => section.name === 'Action')
+        const rpgSection = payload.sections.find((section: any) => section.name === 'RPG')
+
+        expect(actionSection.games).toHaveLength(1)
+        expect(rpgSection.games).toHaveLength(1)
+        expect(actionSection.games[0].appid).toBe(1)
+        expect(rpgSection.games[0].appid).toBe(1)
+    })
+
     it('does NOT emit when there are no games', () => {
         mockGames = []
         new GameSorter()

--- a/client/test/unit/scene/game-box/GpuGameBoxRenderer.test.ts
+++ b/client/test/unit/scene/game-box/GpuGameBoxRenderer.test.ts
@@ -26,6 +26,7 @@ vi.mock('../../../../src/core/EventManager', () => ({
     EventManager: {
         getInstance: () => ({
             registerEventHandler: vi.fn(),
+            deregisterEventHandler: vi.fn(),
             emit: vi.fn(),
         }),
     },

--- a/client/test/unit/scene/game-box/GpuGameBoxRenderer.test.ts
+++ b/client/test/unit/scene/game-box/GpuGameBoxRenderer.test.ts
@@ -14,6 +14,11 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import * as THREE from 'three'
+import { GameRenderEventTypes, type PlacementResolvedEvent } from '../../../../src/types/InteractionEvents'
+
+const mockRegisterEventHandler = vi.fn()
+const mockDeregisterEventHandler = vi.fn()
+const mockEmitEvent = vi.fn()
 
 // ---- mocks ----
 
@@ -25,9 +30,9 @@ vi.mock('../../../../src/core/AppSettings', () => ({
 vi.mock('../../../../src/core/EventManager', () => ({
     EventManager: {
         getInstance: () => ({
-            registerEventHandler: vi.fn(),
-            deregisterEventHandler: vi.fn(),
-            emit: vi.fn(),
+            registerEventHandler: mockRegisterEventHandler,
+            deregisterEventHandler: mockDeregisterEventHandler,
+            emit: mockEmitEvent,
         }),
     },
 }))
@@ -83,16 +88,35 @@ describe('GpuGameBoxRenderer', () => {
         expect(renderer).toBeDefined()
     })
 
-    it('placeGame: uses artwork instance when atlas hit (placeInstance returns ≥ 0)', () => {
+    function emitPlacementResolved(appid: number): void {
+        const registration = mockRegisterEventHandler.mock.calls.find(
+            (call: unknown[]) => call[0] === GameRenderEventTypes.PlacementResolved
+        )
+        expect(registration).toBeTruthy()
+
+        const handler = registration?.[1] as (event: CustomEvent<PlacementResolvedEvent>) => void
+        handler(
+            new CustomEvent(GameRenderEventTypes.PlacementResolved, {
+                detail: {
+                    appid,
+                    game: makeGame(appid) as any,
+                    position: new THREE.Vector3(),
+                    rotation: new THREE.Quaternion(),
+                },
+            })
+        )
+    }
+
+    it('placement hook: uses artwork instance when atlas hit (placeInstance returns ≥ 0)', () => {
         mockPlaceInstance.mockReturnValueOnce(0)
-        renderer.placeGame(makeGame(1) as any, new THREE.Vector3(), new THREE.Quaternion())
+        emitPlacementResolved(1)
         expect(mockPlaceInstance).toHaveBeenCalledTimes(1)
         expect(mockAddLabelInstance).not.toHaveBeenCalled()
     })
 
-    it('placeGame: falls through to label when atlas miss (placeInstance returns -1)', () => {
+    it('placement hook: falls through to label when atlas miss (placeInstance returns -1)', () => {
         mockPlaceInstance.mockReturnValueOnce(-1)
-        renderer.placeGame(makeGame(1) as any, new THREE.Vector3(), new THREE.Quaternion())
+        emitPlacementResolved(1)
         expect(mockPlaceInstance).toHaveBeenCalledTimes(1)
         expect(mockAddLabelInstance).toHaveBeenCalledTimes(1)
     })

--- a/client/test/unit/scene/game-box/RenderIntentCoordinator.test.ts
+++ b/client/test/unit/scene/game-box/RenderIntentCoordinator.test.ts
@@ -6,6 +6,7 @@ import { RenderIntentCoordinator } from '../../../../src/scene/game-box/RenderIn
 import {
     GameRenderEventTypes,
     type ArtworkIntentSettledEvent,
+    type PlacementResolvedEvent,
     type PlacementIntentReadyEvent,
 } from '../../../../src/types/InteractionEvents'
 
@@ -26,18 +27,18 @@ describe('RenderIntentCoordinator', () => {
         EventManager.getInstance().removeAllListeners()
     })
 
-    it('places textured games when artwork settles before placement intent', () => {
-        const placeTexturedGame = vi.fn()
-        const placeLabelGame = vi.fn()
+    it('emits placement-resolved when artwork settles before placement intent', () => {
+        const coordinator = new RenderIntentCoordinator()
+        const resolved: PlacementResolvedEvent[] = []
 
-        const coordinator = new RenderIntentCoordinator({
-            placeTexturedGame,
-            placeLabelGame,
-        })
+        EventManager.getInstance().registerEventHandler(
+            GameRenderEventTypes.PlacementResolved,
+            (event: CustomEvent<PlacementResolvedEvent>) => resolved.push(event.detail)
+        )
 
         EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
             GameRenderEventTypes.ArtworkIntentSettled,
-            { appid: 7, gameName: 'Game 7', result: 'prefetched' }
+            { appid: 7, gameName: 'Game 7' }
         )
         EventManager.getInstance().emit<PlacementIntentReadyEvent>(
             GameRenderEventTypes.PlacementIntentReady,
@@ -49,20 +50,21 @@ describe('RenderIntentCoordinator', () => {
             } as any
         )
 
-        expect(placeTexturedGame).toHaveBeenCalledTimes(1)
-        expect(placeLabelGame).not.toHaveBeenCalled()
+        expect(resolved).toHaveLength(1)
+        expect(resolved[0]?.appid).toBe(7)
+        expect(resolved[0]?.game.name).toBe('Game 7')
 
         coordinator.dispose()
     })
 
-    it('places label boxes for failure outcomes and fans out to multiple intents', () => {
-        const placeTexturedGame = vi.fn()
-        const placeLabelGame = vi.fn()
+    it('fans out one settled signal to multiple placement intents', () => {
+        const coordinator = new RenderIntentCoordinator()
+        const resolved: PlacementResolvedEvent[] = []
 
-        const coordinator = new RenderIntentCoordinator({
-            placeTexturedGame,
-            placeLabelGame,
-        })
+        EventManager.getInstance().registerEventHandler(
+            GameRenderEventTypes.PlacementResolved,
+            (event: CustomEvent<PlacementResolvedEvent>) => resolved.push(event.detail)
+        )
 
         EventManager.getInstance().emit<PlacementIntentReadyEvent>(
             GameRenderEventTypes.PlacementIntentReady,
@@ -85,11 +87,11 @@ describe('RenderIntentCoordinator', () => {
 
         EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
             GameRenderEventTypes.ArtworkIntentSettled,
-            { appid: 42, gameName: 'Shared Game', result: 'permanent-failure' }
+            { appid: 42, gameName: 'Shared Game' }
         )
 
-        expect(placeTexturedGame).not.toHaveBeenCalled()
-        expect(placeLabelGame).toHaveBeenCalledTimes(2)
+        expect(resolved).toHaveLength(2)
+        expect(resolved.every(event => event.appid === 42)).toBe(true)
 
         coordinator.dispose()
     })

--- a/client/test/unit/scene/game-box/RenderIntentCoordinator.test.ts
+++ b/client/test/unit/scene/game-box/RenderIntentCoordinator.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as THREE from 'three'
+
+import { EventManager } from '../../../../src/core/EventManager'
+import { RenderIntentCoordinator } from '../../../../src/scene/game-box/RenderIntentCoordinator'
+import {
+    GameRenderEventTypes,
+    type ArtworkIntentSettledEvent,
+    type PlacementIntentReadyEvent,
+} from '../../../../src/types/InteractionEvents'
+
+const makeGame = (appid: number, name = `Game ${appid}`) => ({
+    appid,
+    name,
+    playtime_forever: 0,
+    img_icon_url: '',
+    img_logo_url: '',
+})
+
+describe('RenderIntentCoordinator', () => {
+    beforeEach(() => {
+        EventManager.getInstance().removeAllListeners()
+    })
+
+    afterEach(() => {
+        EventManager.getInstance().removeAllListeners()
+    })
+
+    it('places textured games when artwork settles before placement intent', () => {
+        const placeTexturedGame = vi.fn()
+        const placeLabelGame = vi.fn()
+
+        const coordinator = new RenderIntentCoordinator({
+            placeTexturedGame,
+            placeLabelGame,
+        })
+
+        EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
+            GameRenderEventTypes.ArtworkIntentSettled,
+            { appid: 7, gameName: 'Game 7', result: 'prefetched' }
+        )
+        EventManager.getInstance().emit<PlacementIntentReadyEvent>(
+            GameRenderEventTypes.PlacementIntentReady,
+            {
+                appid: 7,
+                game: makeGame(7),
+                position: new THREE.Vector3(1, 2, 3),
+                rotation: new THREE.Quaternion(),
+            } as any
+        )
+
+        expect(placeTexturedGame).toHaveBeenCalledTimes(1)
+        expect(placeLabelGame).not.toHaveBeenCalled()
+
+        coordinator.dispose()
+    })
+
+    it('places label boxes for failure outcomes and fans out to multiple intents', () => {
+        const placeTexturedGame = vi.fn()
+        const placeLabelGame = vi.fn()
+
+        const coordinator = new RenderIntentCoordinator({
+            placeTexturedGame,
+            placeLabelGame,
+        })
+
+        EventManager.getInstance().emit<PlacementIntentReadyEvent>(
+            GameRenderEventTypes.PlacementIntentReady,
+            {
+                appid: 42,
+                game: makeGame(42, 'Shared Game'),
+                position: new THREE.Vector3(0, 0, 0),
+                rotation: new THREE.Quaternion(),
+            } as any
+        )
+        EventManager.getInstance().emit<PlacementIntentReadyEvent>(
+            GameRenderEventTypes.PlacementIntentReady,
+            {
+                appid: 42,
+                game: makeGame(42, 'Shared Game'),
+                position: new THREE.Vector3(3, 0, 0),
+                rotation: new THREE.Quaternion(),
+            } as any
+        )
+
+        EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
+            GameRenderEventTypes.ArtworkIntentSettled,
+            { appid: 42, gameName: 'Shared Game', result: 'permanent-failure' }
+        )
+
+        expect(placeTexturedGame).not.toHaveBeenCalled()
+        expect(placeLabelGame).toHaveBeenCalledTimes(2)
+
+        coordinator.dispose()
+    })
+})

--- a/client/test/unit/scene/spawning/ArtworkPrefetchCoordinator.test.ts
+++ b/client/test/unit/scene/spawning/ArtworkPrefetchCoordinator.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+import { EventManager } from '../../../../src/core/EventManager'
+import { ArtworkPrefetchCoordinator } from '../../../../src/scene/spawning/ArtworkPrefetchCoordinator'
+import {
+    GameEventTypes,
+    GameRenderEventTypes,
+    type ArtworkIntentSettledEvent,
+} from '../../../../src/types/InteractionEvents'
+
+const { mockInfo, mockWarn } = vi.hoisted(() => ({
+    mockInfo: vi.fn(),
+    mockWarn: vi.fn(),
+}))
+
+vi.mock('../../../../src/utils/Logger', () => ({
+    Logger: {
+        createLogFunctions: vi.fn(() => ({
+            info: mockInfo,
+            warn: mockWarn,
+            debug: vi.fn(),
+            lifecycle: vi.fn(),
+        })),
+    },
+}))
+
+describe('ArtworkPrefetchCoordinator', () => {
+    beforeEach(() => {
+        EventManager.getInstance().removeAllListeners(GameEventTypes.ArtworkSettled)
+        EventManager.getInstance().removeAllListeners(GameRenderEventTypes.ArtworkIntentSettled)
+        vi.clearAllMocks()
+    })
+
+    it('logs expected fallback summary only once after artwork settled is emitted', async () => {
+        const coordinator = new ArtworkPrefetchCoordinator()
+        const renderer = {
+            prefetchArtwork: vi.fn((appid: number) => {
+                if (appid === 1) {
+                    return Promise.resolve('prefetched')
+                }
+                if (appid === 2) {
+                    return Promise.reject(new Error('404'))
+                }
+                return Promise.resolve('prefetched')
+            }),
+        } as any
+
+        const games = [
+            {
+                appid: 1,
+                name: 'Has Art',
+                artwork: { library: 'https://example.com/1.jpg' },
+            },
+            {
+                appid: 2,
+                name: 'Broken Art',
+                artwork: { library: 'https://example.com/2.jpg' },
+            },
+            {
+                appid: 0,
+                name: 'No Art',
+                artwork: undefined,
+            },
+        ] as any[]
+
+        const settled: number[] = []
+        EventManager.getInstance().registerEventHandler(
+            GameRenderEventTypes.ArtworkIntentSettled,
+            (event: CustomEvent<ArtworkIntentSettledEvent>) => settled.push(event.detail.appid)
+        )
+        coordinator.prefetchBatch(games, renderer)
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(settled.sort((a, b) => a - b)).toEqual([0, 1, 2])
+
+        EventManager.getInstance().emit(GameEventTypes.ArtworkSettled, {})
+        EventManager.getInstance().emit(GameEventTypes.ArtworkSettled, {})
+
+        expect(mockInfo).toHaveBeenCalledTimes(1)
+        expect(mockInfo.mock.calls[0][0]).toContain('Broken Art')
+        expect(mockInfo.mock.calls[0][0]).toContain('No Art')
+    })
+
+    it('does not log fallback summary when all prefetches succeed', async () => {
+        const coordinator = new ArtworkPrefetchCoordinator()
+        const renderer = {
+            prefetchArtwork: vi.fn().mockResolvedValue('prefetched'),
+        } as any
+
+        coordinator.prefetchBatch([
+            {
+                appid: 1,
+                name: 'Has Art',
+                artwork: { library: 'https://example.com/1.jpg' },
+            } as any,
+        ], renderer)
+
+        await Promise.resolve()
+        coordinator.logExpectedFallbackSummary()
+
+        expect(mockInfo).not.toHaveBeenCalled()
+    })
+})

--- a/client/test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts
@@ -18,10 +18,13 @@ import { EventManager } from '../../../../src/core/EventManager'
 import { GameBoxSpawner } from '../../../../src/scene/spawning/GameBoxSpawner'
 
 import {
+    GameRenderEventTypes,
     StorePropsEventTypes,
     GameEventTypes,
     SteamEventTypes,
+    type ArtworkIntentSettledEvent,
     type BatchReadyForPlacementEvent,
+    type PlacementIntentReadyEvent,
     type ShelfReadyEvent,
     type ShelfLayoutDeterminedEvent,
 } from '../../../../src/types/InteractionEvents'
@@ -110,6 +113,47 @@ function emitShelfLayoutDetermined() {
     })
 }
 
+function wireRenderIntentRendezvous(): void {
+    const outcomes = new Map<number, ArtworkIntentSettledEvent['result']>()
+    const pending = new Map<number, PlacementIntentReadyEvent[]>()
+
+    const flush = (appid: number) => {
+        const outcome = outcomes.get(appid)
+        if (outcome === undefined) return
+
+        const intents = pending.get(appid)
+        if (!intents || intents.length === 0) return
+
+        while (intents.length > 0) {
+            const intent = intents.shift()
+            if (!intent) break
+            if (outcome === 'permanent-failure' || outcome === 'error') {
+                continue
+            }
+            mockPlaceGame(intent.game, intent.position, intent.rotation)
+        }
+
+        pending.delete(appid)
+    }
+
+    EventManager.getInstance().registerEventHandler(
+        GameRenderEventTypes.ArtworkIntentSettled,
+        (event: CustomEvent<ArtworkIntentSettledEvent>) => {
+            outcomes.set(event.detail.appid, event.detail.result)
+            flush(event.detail.appid)
+        }
+    )
+    EventManager.getInstance().registerEventHandler(
+        GameRenderEventTypes.PlacementIntentReady,
+        (event: CustomEvent<PlacementIntentReadyEvent>) => {
+            const intents = pending.get(event.detail.appid) ?? []
+            intents.push(event.detail)
+            pending.set(event.detail.appid, intents)
+            flush(event.detail.appid)
+        }
+    )
+}
+
 // --- Tests ---
 
 describe('GameBoxSpawner — prefetch/place rendezvous probe', () => {
@@ -118,6 +162,7 @@ describe('GameBoxSpawner — prefetch/place rendezvous probe', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         EventManager.getInstance().removeAllListeners()
+        wireRenderIntentRendezvous()
         spawner = new (GameBoxSpawner as any)()
 
         emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {

--- a/client/test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts
@@ -178,6 +178,54 @@ describe('GameBoxSpawner — prefetch/place rendezvous probe', () => {
         expect(mockPlaceGame.mock.calls.length).toBe(games.length)
     })
 
+    it('PROBE: duplicate section intents survive until a single prefetch settles', async () => {
+        let resolvePrefetch!: () => void
+        const slowPrefetch = new Promise<'prefetched'>((resolve) => {
+            resolvePrefetch = () => resolve('prefetched')
+        })
+        mockPrefetchArtwork.mockReturnValue(slowPrefetch)
+
+        const sharedGame = makeGame(1, 'Shared Game')
+
+        emit<BatchReadyForPlacementEvent>(StorePropsEventTypes.BatchReadyForPlacement, {
+            games: [sharedGame],
+            batchIndex: 0,
+            totalBatches: 1,
+        })
+
+        emit<SectionsReadyEvent>(GameEventTypes.SectionsReady, {
+            sections: [
+                { name: 'Action', games: [sharedGame], groupMode: 'by-genre', sortMode: 'by-playtime' },
+                { name: 'Indie', games: [sharedGame], groupMode: 'by-genre', sortMode: 'by-playtime' },
+            ],
+            groupMode: 'by-genre',
+            sortMode: 'by-playtime',
+        })
+        emit<ShelfReadyEvent>(StorePropsEventTypes.ShelfReady, {
+            shelfIndex: 0,
+            sectionIndex: 0,
+            position: new THREE.Vector3(0, 0, -5),
+            rotationY: 0,
+        })
+        emit<ShelfReadyEvent>(StorePropsEventTypes.ShelfReady, {
+            shelfIndex: 1,
+            sectionIndex: 1,
+            position: new THREE.Vector3(3, 0, -5),
+            rotationY: 0,
+        })
+        emitShelfLayoutDetermined()
+
+        expect(mockPlaceGame).not.toHaveBeenCalled()
+
+        resolvePrefetch()
+        await slowPrefetch
+        await new Promise(r => setTimeout(r, 0))
+
+        expect(mockPlaceGame).toHaveBeenCalledTimes(2)
+        expect(mockPlaceGame.mock.calls[0][0].appid).toBe(sharedGame.appid)
+        expect(mockPlaceGame.mock.calls[1][0].appid).toBe(sharedGame.appid)
+    })
+
     it('PROBE: prefetch arrives before intent — placeGame fires when GamesSort assigns position', async () => {
         mockPrefetchArtwork.mockResolvedValue('prefetched')
 

--- a/client/test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts
@@ -114,12 +114,11 @@ function emitShelfLayoutDetermined() {
 }
 
 function wireRenderIntentRendezvous(): void {
-    const outcomes = new Map<number, ArtworkIntentSettledEvent['result']>()
+    const settledAppIds = new Set<number>()
     const pending = new Map<number, PlacementIntentReadyEvent[]>()
 
     const flush = (appid: number) => {
-        const outcome = outcomes.get(appid)
-        if (outcome === undefined) return
+        if (!settledAppIds.has(appid)) return
 
         const intents = pending.get(appid)
         if (!intents || intents.length === 0) return
@@ -127,9 +126,6 @@ function wireRenderIntentRendezvous(): void {
         while (intents.length > 0) {
             const intent = intents.shift()
             if (!intent) break
-            if (outcome === 'permanent-failure' || outcome === 'error') {
-                continue
-            }
             mockPlaceGame(intent.game, intent.position, intent.rotation)
         }
 
@@ -139,7 +135,7 @@ function wireRenderIntentRendezvous(): void {
     EventManager.getInstance().registerEventHandler(
         GameRenderEventTypes.ArtworkIntentSettled,
         (event: CustomEvent<ArtworkIntentSettledEvent>) => {
-            outcomes.set(event.detail.appid, event.detail.result)
+            settledAppIds.add(event.detail.appid)
             flush(event.detail.appid)
         }
     )

--- a/client/test/unit/scene/spawning/GameBoxSpawner-stale-positions.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner-stale-positions.test.ts
@@ -19,10 +19,13 @@ import { DataKey, DataDomain } from '../../../../src/core/data/DataTypes'
 import { GameBoxSpawner } from '../../../../src/scene/spawning/GameBoxSpawner'
 
 import {
+    GameRenderEventTypes,
     StorePropsEventTypes,
     GameEventTypes,
     SteamEventTypes,
+    type ArtworkIntentSettledEvent,
     type BatchReadyForPlacementEvent,
+    type PlacementIntentReadyEvent,
     type ShelfReadyEvent,
     type ShelfLayoutDeterminedEvent,
 } from '../../../../src/types/InteractionEvents'
@@ -106,6 +109,48 @@ function wireHandlers(eventManager: EventManager): Map<string, Set<Function>> {
     })
 
     return handlers
+}
+
+function wireRenderIntentRendezvous(eventManager: EventManager): void {
+    const outcomes = new Map<number, ArtworkIntentSettledEvent['result']>()
+    const pending = new Map<number, PlacementIntentReadyEvent[]>()
+
+    const flush = (appid: number) => {
+        const outcome = outcomes.get(appid)
+        if (outcome === undefined) return
+
+        const intents = pending.get(appid)
+        if (!intents || intents.length === 0) return
+
+        while (intents.length > 0) {
+            const intent = intents.shift()
+            if (!intent) break
+            if (outcome === 'permanent-failure' || outcome === 'error') {
+                continue
+            }
+            mockPlaceGame(intent.game, intent.position, intent.rotation)
+        }
+
+        pending.delete(appid)
+    }
+
+    eventManager.registerEventHandler(
+        GameRenderEventTypes.ArtworkIntentSettled,
+        (event: CustomEvent<ArtworkIntentSettledEvent>) => {
+            outcomes.set(event.detail.appid, event.detail.result)
+            flush(event.detail.appid)
+        }
+    )
+
+    eventManager.registerEventHandler(
+        GameRenderEventTypes.PlacementIntentReady,
+        (event: CustomEvent<PlacementIntentReadyEvent>) => {
+            const intents = pending.get(event.detail.appid) ?? []
+            intents.push(event.detail)
+            pending.set(event.detail.appid, intents)
+            flush(event.detail.appid)
+        }
+    )
 }
 
 /**
@@ -204,6 +249,7 @@ describe('GameBoxSpawner â€” stale shelf positions', () => {
         resetEventManager()
         eventManager = EventManager.getInstance()
         wireHandlers(eventManager)
+        wireRenderIntentRendezvous(eventManager)
 
         // Construct spawner â€” registers all event handlers
         spawner = new (GameBoxSpawner as any)()

--- a/client/test/unit/scene/spawning/GameBoxSpawner-stale-positions.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner-stale-positions.test.ts
@@ -112,12 +112,11 @@ function wireHandlers(eventManager: EventManager): Map<string, Set<Function>> {
 }
 
 function wireRenderIntentRendezvous(eventManager: EventManager): void {
-    const outcomes = new Map<number, ArtworkIntentSettledEvent['result']>()
+    const settledAppIds = new Set<number>()
     const pending = new Map<number, PlacementIntentReadyEvent[]>()
 
     const flush = (appid: number) => {
-        const outcome = outcomes.get(appid)
-        if (outcome === undefined) return
+        if (!settledAppIds.has(appid)) return
 
         const intents = pending.get(appid)
         if (!intents || intents.length === 0) return
@@ -125,9 +124,6 @@ function wireRenderIntentRendezvous(eventManager: EventManager): void {
         while (intents.length > 0) {
             const intent = intents.shift()
             if (!intent) break
-            if (outcome === 'permanent-failure' || outcome === 'error') {
-                continue
-            }
             mockPlaceGame(intent.game, intent.position, intent.rotation)
         }
 
@@ -137,7 +133,7 @@ function wireRenderIntentRendezvous(eventManager: EventManager): void {
     eventManager.registerEventHandler(
         GameRenderEventTypes.ArtworkIntentSettled,
         (event: CustomEvent<ArtworkIntentSettledEvent>) => {
-            outcomes.set(event.detail.appid, event.detail.result)
+            settledAppIds.add(event.detail.appid)
             flush(event.detail.appid)
         }
     )

--- a/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
@@ -132,12 +132,11 @@ function emitShelfLayoutDetermined(em: EventManager) {
 }
 
 function wireRenderIntentRendezvous(em: EventManager): void {
-    const artworkOutcomes = new Map<number, ArtworkIntentSettledEvent['result']>()
+    const settledAppIds = new Set<number>()
     const pendingIntents = new Map<number, PlacementIntentReadyEvent[]>()
 
     const flush = (appid: number) => {
-        const outcome = artworkOutcomes.get(appid)
-        if (outcome === undefined) return
+        if (!settledAppIds.has(appid)) return
 
         const intents = pendingIntents.get(appid)
         if (!intents || intents.length === 0) return
@@ -145,9 +144,6 @@ function wireRenderIntentRendezvous(em: EventManager): void {
         while (intents.length > 0) {
             const intent = intents.shift()
             if (!intent) break
-            if (outcome === 'permanent-failure' || outcome === 'error') {
-                continue
-            }
             mockPlaceGame(intent.game, intent.position, intent.rotation)
         }
 
@@ -157,7 +153,7 @@ function wireRenderIntentRendezvous(em: EventManager): void {
     em.registerEventHandler(
         GameRenderEventTypes.ArtworkIntentSettled,
         (event: CustomEvent<ArtworkIntentSettledEvent>) => {
-            artworkOutcomes.set(event.detail.appid, event.detail.result)
+            settledAppIds.add(event.detail.appid)
             flush(event.detail.appid)
         }
     )

--- a/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
@@ -87,8 +87,13 @@ vi.mock('../../../../src/core/EventManager', async (importOriginal) => {
 
 const resetEventManager = () => (EventManager as unknown as { resetInstance: () => void }).resetInstance()
 
-function makeShelfReady(shelfIndex: number, position = new THREE.Vector3(0, 0, 0), rotationY = 0): ShelfReadyEvent {
-    return { shelfIndex, sectionIndex: 0, position, rotationY }
+function makeShelfReady(
+    shelfIndex: number,
+    position = new THREE.Vector3(0, 0, 0),
+    rotationY = 0,
+    sectionIndex = 0
+): ShelfReadyEvent {
+    return { shelfIndex, sectionIndex, position, rotationY }
 }
 
 function createMockGames(count: number, batchIndex: number): readonly SteamGame[] {
@@ -314,6 +319,39 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
 
             expect(mockClearPlacements).toHaveBeenCalledTimes(1)
             expect(mockPlaceGame).toHaveBeenCalledTimes(20)
+        })
+
+        it('places the same prefetched game once per section appearance', async () => {
+            const sharedGame = createMockGamesWithArtwork(1, 0)[0] as any
+
+            eventManager.emit<BatchReadyForPlacementEvent>(
+                StorePropsEventTypes.BatchReadyForPlacement,
+                { games: [sharedGame], batchIndex: 0, totalBatches: 1 }
+            )
+            await Promise.resolve()
+
+            eventManager.emit<SectionsReadyEvent>(GameEventTypes.SectionsReady, {
+                sections: [
+                    { name: 'Action', games: [sharedGame], groupMode: 'by-genre', sortMode: 'by-playtime' },
+                    { name: 'Indie', games: [sharedGame], groupMode: 'by-genre', sortMode: 'by-playtime' },
+                ],
+                groupMode: 'by-genre',
+                sortMode: 'by-playtime',
+            })
+            eventManager.emit<ShelfReadyEvent>(
+                StorePropsEventTypes.ShelfReady,
+                makeShelfReady(0, new THREE.Vector3(0, 0, 0), 0, 0)
+            )
+            eventManager.emit<ShelfReadyEvent>(
+                StorePropsEventTypes.ShelfReady,
+                makeShelfReady(1, new THREE.Vector3(3, 0, 0), 0, 1)
+            )
+            emitShelfLayoutDetermined(eventManager)
+
+            expect(mockPlaceGame).toHaveBeenCalledTimes(2)
+            expect(mockPlaceGame.mock.calls[0][0].appid).toBe(sharedGame.appid)
+            expect(mockPlaceGame.mock.calls[1][0].appid).toBe(sharedGame.appid)
+            expect(mockPlaceGame.mock.calls[0][1]).not.toEqual(mockPlaceGame.mock.calls[1][1])
         })
 
         it('re-sort triggers a fresh clearPlacements call each time', () => {

--- a/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
@@ -16,11 +16,14 @@ import { DataKey, DataDomain } from '../../../../src/core/data/DataTypes'
 import { GameBoxSpawner } from '../../../../src/scene/spawning/GameBoxSpawner'
 
 import {
+    GameRenderEventTypes,
     StorePropsEventTypes,
     SteamEventTypes,
     GameEventTypes,
     UIEventTypes,
+    type ArtworkIntentSettledEvent,
     type BatchReadyForPlacementEvent,
+    type PlacementIntentReadyEvent,
     type ShelfReadyEvent,
     type ShelfLayoutDeterminedEvent,
     type GamesPlacedEvent,
@@ -128,6 +131,48 @@ function emitShelfLayoutDetermined(em: EventManager) {
     })
 }
 
+function wireRenderIntentRendezvous(em: EventManager): void {
+    const artworkOutcomes = new Map<number, ArtworkIntentSettledEvent['result']>()
+    const pendingIntents = new Map<number, PlacementIntentReadyEvent[]>()
+
+    const flush = (appid: number) => {
+        const outcome = artworkOutcomes.get(appid)
+        if (outcome === undefined) return
+
+        const intents = pendingIntents.get(appid)
+        if (!intents || intents.length === 0) return
+
+        while (intents.length > 0) {
+            const intent = intents.shift()
+            if (!intent) break
+            if (outcome === 'permanent-failure' || outcome === 'error') {
+                continue
+            }
+            mockPlaceGame(intent.game, intent.position, intent.rotation)
+        }
+
+        pendingIntents.delete(appid)
+    }
+
+    em.registerEventHandler(
+        GameRenderEventTypes.ArtworkIntentSettled,
+        (event: CustomEvent<ArtworkIntentSettledEvent>) => {
+            artworkOutcomes.set(event.detail.appid, event.detail.result)
+            flush(event.detail.appid)
+        }
+    )
+
+    em.registerEventHandler(
+        GameRenderEventTypes.PlacementIntentReady,
+        (event: CustomEvent<PlacementIntentReadyEvent>) => {
+            const pending = pendingIntents.get(event.detail.appid) ?? []
+            pending.push(event.detail)
+            pendingIntents.set(event.detail.appid, pending)
+            flush(event.detail.appid)
+        }
+    )
+}
+
 describe('GameBoxSpawner — Two-Phase Load/Place', () => {
     let eventManager: EventManager
     let spawner: GameBoxSpawner
@@ -156,6 +201,8 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
             }
             return true
         })
+
+        wireRenderIntentRendezvous(eventManager)
 
         spawner = new (GameBoxSpawner as any)()
         // Ordering contract: renderer is initialized from immutable manifest before any batch prewarm events.

--- a/docs/plans/texture-placement-split-plan.md
+++ b/docs/plans/texture-placement-split-plan.md
@@ -22,73 +22,144 @@ Because texture loading is triggered by position, `GpuGameBoxRenderer.createGame
 
 ## Goal
 
-Separate the lifecycle into two independent phases:
+Separate the lifecycle into two independent signals and let the renderer own the final visual decision:
 
-| Phase | When | What |
-|-------|------|-------|
-| **Texture prefetch** | As batches arrive (no position needed) | Fetch + decode artwork by appId, hold in texture cache |
-| **Instance placement** | On `GamesSort` | Assign mesh instance slots and bind cached textures to positions |
+| Signal | Source | When | What |
+|-------|--------|------|------|
+| **Artwork readiness** | `ArtworkPrefetchCoordinator` | As batches arrive | Resolve a game's artwork outcome (`prefetched`, `cached`, `permanent-failure`, `error`) |
+| **Placement intent** | placement-side coordinator (currently `GameBoxSpawner`) | After sections/shelf layout are known | Publish one or more world-space placement intents for a game |
 
-After this, `GamesSort` becomes the single moment that arranges boxes. A re-sort is a position reassignment only — textures are already loaded.
+The renderer should consume both streams and decide, per intent, whether to place a textured box or a label box.
 
----
-
-## Key Change: Split `setArtworkInstanceFromUrl`
-
-Currently `LodArtworkOrchestrator` has one entry point that takes both position and URL:
-
-```ts
-setArtworkInstanceFromUrl(position, name, url, appid, rotation)
-```
-
-Split into two calls:
-
-```ts
-// Phase 1 — called on batch arrival, no position needed
-prefetchArtwork(appid: number, url: string): Promise<void>
-
-// Phase 2 — called on GamesSort, position now known
-placeInstance(appid: number, position: Vector3, rotation: Quaternion): void
-```
-
-The orchestrator caches decoded textures keyed by `appid`. `placeInstance` looks up the cached texture and writes the GPU instance. If texture is still loading, it queues the placement.
+After this, `GamesSort` remains the single moment that arranges boxes, but the artwork-vs-label arbitration no longer lives in `GameBoxSpawner`. A re-sort becomes a placement-intent rebuild only; artwork state is already cached and independently tracked.
 
 ---
 
-## Downstream Simplifications
+## Key Change: Renderer-Owned Rendezvous
 
-**`GameBoxSpawner`** dissolves or becomes trivial:
-- No more `pendingGames` map
-- No more `handleBatchReadyForPlacement`
-- `queueMicrotask` in `ShelfLayoutCoordinator` can be removed
+Currently the split is only half complete:
 
-**`BatchCoordinator`** emits `AllBatchesComplete` → triggers `GamesSort` → `GamesSort` drives placement. Batch ordering is no longer a concern for the rendering layer.
+- `ArtworkPrefetchCoordinator` owns batch-time prefetch state
+- `GameBoxSpawner` owns placement intents
+- `GameBoxSpawner.tryPlace()` still decides `placeGame()` vs `placeLabelBox()`
 
-**`GpuGameBoxRenderer`** subscribes to:
-- `BatchReadyForPlacement` → `prefetchArtwork()` for each game in the batch
-- `GamesSort` → `placeInstance()` for each game in sorted order
+That last decision should move downstream. The renderer layer should own the rendezvous between:
+
+1. "A placement intent exists for appId X at position Y"
+2. "Artwork for appId X settled with status Z"
+
+`LodArtworkOrchestrator` already exposes the right rendering primitives:
+
+```ts
+prefetchArtwork(appid: number, artworkUrl: string, gameName: string): Promise<PrefetchResult>
+
+placeInstance(appid: number, gameName: string, position: Vector3, rotation: Quaternion): number
+```
+
+What is missing is an event-driven render coordinator that listens for both readiness signals and executes one of two renderer actions:
+
+```ts
+placeInstance(appid, gameName, position, rotation)   // textured path
+placeLabelBox(game, position, rotation)              // fallback path
+```
+
+---
+
+## Proposed Responsibilities
+
+**Placement-side coordinator**
+- Keeps layout math, stock-surface math, and section-to-shelf assignment out of the renderer.
+- Emits placement intents only: `game`, `appid`, `position`, `rotation`.
+- Does not decide artwork vs label.
+
+**`ArtworkPrefetchCoordinator`**
+- Keeps ownership of batch-time artwork resolution and fallback-summary logging.
+- Emits artwork outcomes only: `appid`, `gameName`, `result`.
+- Does not know about world positions.
+
+**Renderer-side rendezvous coordinator**
+- Subscribes to artwork-outcome and placement-intent events.
+- Tracks pending state keyed by `appid`.
+- When both sides are ready, decides textured box vs label box.
+- Supports one artwork outcome satisfying multiple placement intents.
+
+**`GpuGameBoxRenderer`**
+- Remains ignorant of shelf math and grouping.
+- Exposes the two concrete render operations.
+- May itself host the rendezvous state, or a small renderer-adjacent coordinator can own it and call into `GpuGameBoxRenderer`.
 
 **`ShelfReadyEvent`** carries only layout data (position, rotationY, rowIndex) — no game data passes through it.
 
 ---
 
+## Event Shape
+
+Do not make the renderer re-derive placement from `SectionsReady`; that would push layout knowledge into the rendering layer. Prefer explicit readiness events.
+
+Suggested event seams:
+
+```ts
+GameRenderEventTypes.ArtworkIntentSettled
+GameRenderEventTypes.PlacementIntentReady
+```
+
+Suggested payloads:
+
+```ts
+interface ArtworkIntentSettledEvent {
+	appid: number
+	gameName: string
+	result: 'prefetched' | 'cached' | 'permanent-failure' | 'error'
+}
+
+interface PlacementIntentReadyEvent {
+	appid: number
+	game: SteamGameData
+	position: THREE.Vector3
+	rotation: THREE.Quaternion
+}
+```
+
+One settled artwork event may satisfy many placement intents; this directly supports multi-group placement.
+
+---
+
 ## Migration Path
 
-1. Add `prefetchArtwork(appid, url)` to `LodArtworkOrchestrator` — loads and caches texture, no instance slot allocated yet.
-2. Add `placeInstance(appid, position, rotation)` — allocates slot and binds cached texture (or queues if still loading).
-3. Wire `GpuGameBoxRenderer` to call `prefetchArtwork` on `BatchReadyForPlacement`.
-4. Wire `GpuGameBoxRenderer` to call `placeInstance` on `GamesSort`.
-5. Remove `GameBoxSpawner.handleBatchReadyForPlacement` and `pendingGames`.
-6. Remove `queueMicrotask` from `ShelfLayoutCoordinator`.
-7. Delete `GameBoxSpawner` if nothing substantive remains, or keep as a thin coordinator if placement math is still useful to isolate.
+1. Introduce explicit render-intent event types and payloads for artwork outcomes and placement intents.
+2. Make `ArtworkPrefetchCoordinator` emit `ArtworkIntentSettled` when a game's artwork result resolves.
+3. Replace `GameBoxSpawner.tryPlace()` with placement-intent emission only; stop calling `placeGame()` / `placeLabelBox()` directly there.
+4. Add a renderer-side rendezvous coordinator that buffers by `appid`:
+   - artwork outcome: one value per appid
+   - placement intents: many values per appid
+5. When both sides are available, have the rendezvous coordinator call:
+   - `renderer.placeInstance(...)` for `prefetched` / `cached`
+   - `renderer.placeLabelBox(...)` for `permanent-failure` / `error`
+6. Keep `clearPlacements()` and re-sort behavior in the placement flow; add a matching reset for renderer-side pending placement intents on section rebuild.
+7. Once the event-driven rendezvous is stable, decide whether `GameBoxSpawner` should be split into a pure placement coordinator or deleted entirely.
 
 ---
 
 ## Risks / Open Questions
 
-- `LodArtworkOrchestrator` currently ties instance slot allocation to texture loading — separating these requires a slot reservation mechanism (allocate slot by appId without a position, fill position later).
-- Labels (`InstancedLabelRenderer`) follow the same pattern and will need the same split.
-- The `GamesSort` event currently carries sorted game arrays — it would need to include position data too, or `GpuGameBoxRenderer` would need to re-derive positions from shelf layout. Prefer passing positions explicitly to keep rendering ignorant of layout math.
+- The renderer should not subscribe directly to `SectionsReady` unless the event already carries final positions. Re-deriving layout inside rendering would be a regression in ownership.
+- `placeInstance()` currently warns on missing prefetched texture. Once artwork outcomes become explicit, that warning path should become truly exceptional rather than part of normal fallback flow.
+- Labels already live behind `GpuGameBoxRenderer.placeLabelBox()`, which is good; the main migration risk is avoiding duplicate placement when both the old `tryPlace()` path and the new render-intent path coexist.
+- Reset semantics must be clear: a layout/group/sort change should clear pending placement intents and live GPU placements without discarding prefetched artwork outcomes.
+
+---
+
+## Recommended First Slice
+
+Do this in the smallest bisectable step:
+
+1. Add render-intent events.
+2. Keep all existing state owners in place.
+3. Change `ArtworkPrefetchCoordinator` to emit artwork-outcome events.
+4. Change `GameBoxSpawner` to emit placement-intent events instead of placing directly.
+5. Add a small renderer-side coordinator that listens to both and performs the existing `placeGame()` / `placeLabelBox()` calls.
+
+That proves the architecture without simultaneously deleting `GameBoxSpawner` or moving shelf math.
 
 ---
 


### PR DESCRIPTION
## Summary
- adds explicit render-intent events for artwork outcomes and placement intents
- introduces `RenderIntentCoordinator` in renderer layer to rendezvous `appid` readiness and decide textured vs label placement
- updates `ArtworkPrefetchCoordinator` to emit artwork intent settled events
- updates `GameBoxSpawner` to emit placement intent events and remove local texture/label arbitration
- wires `GpuGameBoxRenderer` to own the rendezvous coordinator lifecycle (clear + dispose)
- updates and adds focused unit tests for renderer/spawner intent flow
- updates the texture/placement split plan doc with the new event-driven ownership model

## Why
This is the first slice toward separating art loading from placement while keeping layout math outside rendering. It moves the textured-vs-label decision into the renderer side without forcing the renderer to derive shelf positions.

## Validation
- `yarn vitest run test/unit/scene/game-box/RenderIntentCoordinator.test.ts`
- `yarn vitest run test/unit/scene/game-box/GpuGameBoxRenderer.test.ts`
- `yarn vitest run test/unit/scene/spawning/ArtworkPrefetchCoordinator.test.ts`
- `yarn vitest run test/unit/scene/spawning/GameBoxSpawner.test.ts`
- `yarn vitest run test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts`
- `yarn vitest run test/unit/scene/spawning/GameBoxSpawner-stale-positions.test.ts`
- `yarn tsc --noEmit`
