### PR TITLE
Refactor split: move prewarm ownership to renderer lifecycle

### DIFF
--- a/client/src/scene/game-box/GpuGameBoxRenderer.ts
+++ b/client/src/scene/game-box/GpuGameBoxRenderer.ts
@@ -11,6 +11,7 @@
  * - LOD artwork orchestrator for texture management
  * - LOD distance manager for camera-based detail switching
  * - Box instance state (positions, orientations, LOD levels)
+ * - ArtworkPrefetchCoordinator for batch-time artwork prewarm
  * 
  * RECEIVES:
  * - prefetchArtwork(appid, url, name) → Phase 1: load texture into atlas
@@ -29,10 +30,10 @@
  * - LodDistanceManagerDebug: Camera distance calculations, LOD distribution diagnostics
  * 
  * DOES NOT:
+ * DOES NOT:
  * - Know about shelves or layout (receives positions)
  * - Decide which games to display (told what to render)
- * - Select or construct artwork URLs from game metadata
- * - Handle batch processing (receives individual requests)
+ * - Handle section/placement ordering (that's GameBoxSpawner)
  * 
  * RELATED:
  * - GameBoxSpawner: Coordinates game placement and calls this renderer
@@ -45,6 +46,7 @@ import { InstancedLabelRenderer } from './instancing/InstancedLabelRenderer'
 import { LodArtworkOrchestratorDebug } from './instancing/LodArtworkOrchestratorDebug'
 import type { IGameArtworkPipeline } from './instancing/IGameArtworkPipeline'
 import { RenderIntentCoordinator } from './RenderIntentCoordinator'
+import { ArtworkPrefetchCoordinator } from '../spawning/ArtworkPrefetchCoordinator'
 import { Logger } from '../../utils/Logger'
 import { EventManager } from '../../core/EventManager'
 import { GameRenderEventTypes, type PlacementResolvedEvent } from '../../types/InteractionEvents'
@@ -55,12 +57,14 @@ export class GpuGameBoxRenderer {
     private readonly instancedLabelRenderer: InstancedLabelRenderer
     private readonly lodArtworkRenderer: IGameArtworkPipeline
     private readonly renderIntentCoordinator: RenderIntentCoordinator
+    private readonly artworkPrefetchCoordinator: ArtworkPrefetchCoordinator
     private readonly boundHandlePlacementResolved: (event: CustomEvent<PlacementResolvedEvent>) => void
 
     constructor(maxGames: number = 2000) {
         this.instancedLabelRenderer = new InstancedLabelRenderer({ maxInstances: maxGames })
         this.lodArtworkRenderer = LodArtworkOrchestratorDebug.fromAppSettings(maxGames)
         this.renderIntentCoordinator = new RenderIntentCoordinator()
+        this.artworkPrefetchCoordinator = new ArtworkPrefetchCoordinator({ renderer: this })
         this.boundHandlePlacementResolved = this.handlePlacementResolved.bind(this)
 
         EventManager.getInstance().registerEventHandler(
@@ -142,6 +146,7 @@ export class GpuGameBoxRenderer {
             this.boundHandlePlacementResolved
         )
         this.renderIntentCoordinator.dispose()
+        this.artworkPrefetchCoordinator.dispose()
         this.instancedLabelRenderer.dispose()
         this.lodArtworkRenderer.dispose()
         GpuGameBoxRenderer.logger.lifecycle('Disposed')

--- a/client/src/scene/game-box/RenderIntentCoordinator.ts
+++ b/client/src/scene/game-box/RenderIntentCoordinator.ts
@@ -1,12 +1,10 @@
 import { EventManager } from '../../core/EventManager'
 import {
-    GameEventTypes,
     GameRenderEventTypes,
     type ArtworkIntentSettledEvent,
     type PlacementResolvedEvent,
     type PlacementIntentReadyEvent,
 } from '../../types/InteractionEvents'
-import type { SectionsReadyEvent } from '../../types/EnvironmentEvents'
 
 /**
  * Renderer-side rendezvous for placement intents and artwork outcomes.
@@ -18,12 +16,10 @@ export class RenderIntentCoordinator {
 
     private readonly boundHandleArtworkIntentSettled: (event: CustomEvent<ArtworkIntentSettledEvent>) => void
     private readonly boundHandlePlacementIntentReady: (event: CustomEvent<PlacementIntentReadyEvent>) => void
-    private readonly boundHandleSectionsReady: (event: CustomEvent<SectionsReadyEvent>) => void
 
     public constructor() {
         this.boundHandleArtworkIntentSettled = this.handleArtworkIntentSettled.bind(this)
         this.boundHandlePlacementIntentReady = this.handlePlacementIntentReady.bind(this)
-        this.boundHandleSectionsReady = this.handleSectionsReady.bind(this)
 
         EventManager.getInstance().registerEventHandler(
             GameRenderEventTypes.ArtworkIntentSettled,
@@ -32,10 +28,6 @@ export class RenderIntentCoordinator {
         EventManager.getInstance().registerEventHandler(
             GameRenderEventTypes.PlacementIntentReady,
             this.boundHandlePlacementIntentReady
-        )
-        EventManager.getInstance().registerEventHandler(
-            GameEventTypes.SectionsReady,
-            this.boundHandleSectionsReady
         )
     }
 
@@ -52,17 +44,9 @@ export class RenderIntentCoordinator {
             GameRenderEventTypes.PlacementIntentReady,
             this.boundHandlePlacementIntentReady
         )
-        EventManager.getInstance().deregisterEventHandler(
-            GameEventTypes.SectionsReady,
-            this.boundHandleSectionsReady
-        )
 
         this.pendingPlacementIntents.clear()
         this.settledAppIds.clear()
-    }
-
-    private handleSectionsReady(_event: CustomEvent<SectionsReadyEvent>): void {
-        this.clearPendingPlacementIntents()
     }
 
     private handleArtworkIntentSettled(event: CustomEvent<ArtworkIntentSettledEvent>): void {

--- a/client/src/scene/spawning/ArtworkPrefetchCoordinator.ts
+++ b/client/src/scene/spawning/ArtworkPrefetchCoordinator.ts
@@ -7,13 +7,16 @@ import {
     type ArtworkIntentSettledEvent,
     type BatchReadyForPlacementEvent,
 } from '../../types/InteractionEvents'
-import { GpuGameBoxRenderer } from '../game-box/GpuGameBoxRenderer'
 import type { SteamGameData } from '../game-box/types/GameData'
+
+interface IArtworkPrewarmer {
+    prefetchArtwork(appid: number, url: string, name: string): Promise<PrefetchResult>
+}
 
 export type PrefetchResult = 'prefetched' | 'cached' | 'permanent-failure' | 'error'
 
 interface ArtworkPrefetchCoordinatorOptions {
-    renderer?: GpuGameBoxRenderer | null
+    renderer?: IArtworkPrewarmer | null
 }
 
 /**
@@ -22,7 +25,7 @@ interface ArtworkPrefetchCoordinatorOptions {
  */
 export class ArtworkPrefetchCoordinator {
     private readonly logger = Logger.createLogFunctions(ArtworkPrefetchCoordinator.name)
-    private readonly renderer: GpuGameBoxRenderer | null
+    private readonly renderer: IArtworkPrewarmer | null
     private readonly boundHandleArtworkSettled: () => void
     private readonly boundHandleBatchReadyForPlacement: (event: CustomEvent<BatchReadyForPlacementEvent>) => void
 
@@ -65,7 +68,7 @@ export class ArtworkPrefetchCoordinator {
 
     public prefetchBatch(
         games: ReadonlyArray<SteamGameData>,
-        renderer: GpuGameBoxRenderer
+        renderer: IArtworkPrewarmer
     ): void {
         for (const game of games) {
             const appid = typeof game.appid === 'number' ? game.appid : 0

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -165,7 +165,7 @@ export class GameBoxSpawner {
         this.layoutDeterminedCount++
         GameBoxSpawner.logger.debug('Stock strategy received from ShelfLayoutDetermined')
 
-        this.tryPlacePendingSections('ShelfLayoutDetermined')
+        this.tryPlacePendingSections()
     }
 
     // -------------------------------------------------------------------------
@@ -203,28 +203,40 @@ export class GameBoxSpawner {
         this.pendingSections = event.detail
         GameBoxSpawner.logger.debug('SectionsReady: cached sections for placement attempt')
 
-        if (this.layoutDeterminedCount >= this.sectionsReadyCount) {
-            this.tryPlacePendingSections('SectionsReady (layout already known)')
+        if (this.isLayoutReadyForPendingSections()) {
+            this.tryPlacePendingSections()
         }
     }
 
-    private tryPlacePendingSections(reason: string): void {
+    private isLayoutReadyForPendingSections(): boolean {
+        return this.layoutDeterminedCount >= this.sectionsReadyCount
+    }
+
+    private canPlacePendingSections(): boolean {
         if (!this.pendingSections) {
-            return
+            return false
         }
 
         if (!this.renderer) {
-            GameBoxSpawner.logger.warn(`tryPlacePendingSections: renderer not yet constructed (${reason})`)
-            return
+            GameBoxSpawner.logger.warn('tryPlacePendingSections: renderer not yet constructed')
+            return false
         }
 
         if (!this.stockStrategy) {
-            GameBoxSpawner.logger.warn(`tryPlacePendingSections: no stock strategy (${reason})`)
-            return
+            GameBoxSpawner.logger.warn('tryPlacePendingSections: no stock strategy')
+            return false
         }
 
         if (this.shelfPositions.size === 0) {
-            GameBoxSpawner.logger.debug(`tryPlacePendingSections: waiting for shelf positions (${reason})`)
+            GameBoxSpawner.logger.debug('tryPlacePendingSections: waiting for shelf positions')
+            return false
+        }
+
+        return true
+    }
+
+    private tryPlacePendingSections(): void {
+        if (!this.canPlacePendingSections()) {
             return
         }
 

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -22,7 +22,6 @@ import type {
 } from '../props/PropsEvents'
 import { Logger } from '../../utils/Logger'
 import type { StockSurface } from '../../types/LayoutTypes'
-import { ArtworkPrefetchCoordinator } from './ArtworkPrefetchCoordinator'
 
 interface ShelfPosition {
     position: THREE.Vector3
@@ -35,7 +34,8 @@ interface ShelfPosition {
  * Owns the GpuGameBoxRenderer lifecycle and coordinates the two-phase load/place split:
  *
  * Phase 1 — Prewarm (BatchReadyForPlacement):
- *   Triggers artwork prefetch for each game — no GPU instances placed yet.
+ *   GpuGameBoxRenderer (via ArtworkPrefetchCoordinator) handles artwork prefetch.
+ *   GameBoxSpawner does not participate in Phase 1.
  *
  * Phase 2 — Place (SectionsReady):
  *   Clears all existing placements and emits placement intents in sorted order
@@ -47,11 +47,6 @@ interface ShelfPosition {
  *
  * The artwork/label decision is NOT made here. GameBoxSpawner only emits
  * world-space placement intents ("game X goes at position Y").
- *
- * TD: This class conflates two concerns — artwork prefetch/prewarm (Phase 1) and
- * geometry-driven placement (Phase 2). They share only the renderer reference.
- * Consider splitting into ArtworkPrewarmer and GamePlacementCoordinator once
- * section-per-layout work settles the placement interface.
  */
 export class GameBoxSpawner {
     private static readonly logger = Logger.createLogFunctions(GameBoxSpawner.name)
@@ -66,7 +61,6 @@ export class GameBoxSpawner {
     // Cached sections from last SectionsReady — consumed when ShelfLayoutDetermined fires
     private pendingSections: SectionsReadyEvent | null = null
 
-    private artworkPrefetch: ArtworkPrefetchCoordinator | null = null
     private stockStrategy: IStockStrategy | null = null
 
     /** Expose the current renderer for external consumers (e.g. addToScene, updateLODForCamera). */
@@ -115,8 +109,6 @@ export class GameBoxSpawner {
      * Disposes the renderer and clears all prefetch state.
      */
     private fullReset(): void {
-        this.artworkPrefetch?.dispose()
-        this.artworkPrefetch = null
         this.renderer?.dispose()
         this.renderer = null
         this.stockStrategy = null
@@ -152,19 +144,6 @@ export class GameBoxSpawner {
         const rendererCapacity = Math.max(totalGames, 1) + 100
         this.renderer = new GpuGameBoxRenderer(rendererCapacity)
         GameBoxSpawner.logger.debug(`Renderer initialized: capacity ${rendererCapacity}`)
-        
-        this.initializeArtworkPrefetch()
-    }
-
-    private initializeArtworkPrefetch(): void {
-        if (!this.renderer) {
-            return
-        }
-
-        this.artworkPrefetch?.dispose()
-        this.artworkPrefetch = new ArtworkPrefetchCoordinator({
-            renderer: this.renderer,
-        })
     }
 
     private handleLibraryManifestReady(event: CustomEvent<SteamLibraryManifestReadyEvent>): void {

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -62,6 +62,8 @@ export class GameBoxSpawner {
     private pendingSections: SectionsReadyEvent | null = null
 
     private stockStrategy: IStockStrategy | null = null
+    private sectionsReadyCount = 0
+    private layoutDeterminedCount = 0
 
     /** Expose the current renderer for external consumers (e.g. addToScene, updateLODForCamera). */
     public getRenderer(): GpuGameBoxRenderer | null {
@@ -113,6 +115,8 @@ export class GameBoxSpawner {
         this.renderer = null
         this.stockStrategy = null
         this.pendingSections = null
+        this.sectionsReadyCount = 0
+        this.layoutDeterminedCount = 0
         this.shelfPositions.clear()
         GameBoxSpawner.logger.debug('Full reset (library reload)')
     }
@@ -125,6 +129,8 @@ export class GameBoxSpawner {
         this.renderer?.clearPlacements()
         this.stockStrategy = null
         this.pendingSections = null
+        this.sectionsReadyCount = 0
+        this.layoutDeterminedCount = 0
         this.shelfPositions.clear()
         GameBoxSpawner.logger.debug('Geometry reset (layout switch)')
     }
@@ -156,13 +162,10 @@ export class GameBoxSpawner {
 
     private handleLayoutDetermined(event: CustomEvent<ShelfLayoutDeterminedEvent>): void {
         this.stockStrategy = event.detail.stockStrategy
+        this.layoutDeterminedCount++
         GameBoxSpawner.logger.debug('Stock strategy received from ShelfLayoutDetermined')
 
-        // If SectionsReady already arrived, place now
-        if (this.pendingSections) {
-            this.placeSections(this.pendingSections)
-            this.pendingSections = null
-        }
+        this.tryPlacePendingSections('ShelfLayoutDetermined')
     }
 
     // -------------------------------------------------------------------------
@@ -170,6 +173,14 @@ export class GameBoxSpawner {
 
     private handleShelfReady(event: CustomEvent<ShelfReadyEvent>): void {
         const { shelfIndex, sectionIndex, position, rotationY } = event.detail
+
+        // ShelfLayoutCoordinator emits a contiguous shelf wave per run starting at index 0.
+        // Clearing on the first shelf keeps only current-run positions regardless of
+        // whether this spawner's SectionsReady handler runs before or after that wave.
+        if (shelfIndex === 0) {
+            this.shelfPositions.clear()
+        }
+
         this.shelfPositions.set(shelfIndex, {
             position: (position as THREE.Vector3).clone(),
             rotationY,
@@ -185,14 +196,40 @@ export class GameBoxSpawner {
     // Phase 2: cache sections, place when strategy is available
 
     private handleSectionsReady(event: CustomEvent<SectionsReadyEvent>): void {
-        // Start-of-run reset: this is deterministic regardless of listener order on
-        // UI-triggering events (layout/group/sort changes).
-        this.shelfPositions.clear()
+        this.sectionsReadyCount++
 
-        // Cache sections for placement. Placement is deferred to handleLayoutDetermined,
-        // which runs after ShelfReady has repopulated fresh shelf positions.
+        // Cache sections for placement. Placement can be triggered by either
+        // ShelfLayoutDetermined (normal order) or SectionsReady (if layout already arrived).
         this.pendingSections = event.detail
-        GameBoxSpawner.logger.debug('SectionsReady: cleared stale positions, waiting for ShelfLayoutDetermined')
+        GameBoxSpawner.logger.debug('SectionsReady: cached sections for placement attempt')
+
+        if (this.layoutDeterminedCount >= this.sectionsReadyCount) {
+            this.tryPlacePendingSections('SectionsReady (layout already known)')
+        }
+    }
+
+    private tryPlacePendingSections(reason: string): void {
+        if (!this.pendingSections) {
+            return
+        }
+
+        if (!this.renderer) {
+            GameBoxSpawner.logger.warn(`tryPlacePendingSections: renderer not yet constructed (${reason})`)
+            return
+        }
+
+        if (!this.stockStrategy) {
+            GameBoxSpawner.logger.warn(`tryPlacePendingSections: no stock strategy (${reason})`)
+            return
+        }
+
+        if (this.shelfPositions.size === 0) {
+            GameBoxSpawner.logger.debug(`tryPlacePendingSections: waiting for shelf positions (${reason})`)
+            return
+        }
+
+        this.placeSections(this.pendingSections)
+        this.pendingSections = null
     }
 
     private placeSections(detail: SectionsReadyEvent): void {

--- a/client/test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts
@@ -38,16 +38,23 @@ const mockPlaceGame = vi.fn()
 const mockClearPlacements = vi.fn()
 const mockRendererDispose = vi.fn()
 
-vi.mock('../../../../src/scene/game-box/GpuGameBoxRenderer', () => ({
-    GpuGameBoxRenderer: vi.fn().mockImplementation(function () {
-        this.prefetchArtwork = mockPrefetchArtwork
-        this.placeGame = mockPlaceGame
-        this.clearPlacements = mockClearPlacements
-        this.dispose = mockRendererDispose
-        this.addToScene = vi.fn()
-        this.updateLODForCamera = vi.fn()
-    })
-}))
+vi.mock('../../../../src/scene/game-box/GpuGameBoxRenderer', async () => {
+    const { ArtworkPrefetchCoordinator } = await import('../../../../src/scene/spawning/ArtworkPrefetchCoordinator')
+    return {
+        GpuGameBoxRenderer: vi.fn().mockImplementation(function () {
+            this.prefetchArtwork = mockPrefetchArtwork
+            this.placeGame = mockPlaceGame
+            this.clearPlacements = mockClearPlacements
+            this.addToScene = vi.fn()
+            this.updateLODForCamera = vi.fn()
+            const coordinator = new ArtworkPrefetchCoordinator({ renderer: this })
+            this.dispose = vi.fn(() => {
+                mockRendererDispose()
+                coordinator.dispose()
+            })
+        })
+    }
+})
 
 vi.mock('../../../../src/core/AppSettings', () => {
     const Setting = { EnableLabels: 'enableLabels' }

--- a/client/test/unit/scene/spawning/GameBoxSpawner-stale-positions.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner-stale-positions.test.ts
@@ -40,16 +40,23 @@ const mockPlaceGame = vi.fn()
 const mockClearPlacements = vi.fn()
 const mockRendererDispose = vi.fn()
 
-vi.mock('../../../../src/scene/game-box/GpuGameBoxRenderer', () => ({
-    GpuGameBoxRenderer: vi.fn().mockImplementation(function () {
-        this.prefetchArtwork = mockPrefetchArtwork
-        this.placeGame = mockPlaceGame
-        this.clearPlacements = mockClearPlacements
-        this.dispose = mockRendererDispose
-        this.addToScene = vi.fn()
-        this.updateLODForCamera = vi.fn()
-    }),
-}))
+vi.mock('../../../../src/scene/game-box/GpuGameBoxRenderer', async () => {
+    const { ArtworkPrefetchCoordinator } = await import('../../../../src/scene/spawning/ArtworkPrefetchCoordinator')
+    return {
+        GpuGameBoxRenderer: vi.fn().mockImplementation(function () {
+            this.prefetchArtwork = mockPrefetchArtwork
+            this.placeGame = mockPlaceGame
+            this.clearPlacements = mockClearPlacements
+            this.addToScene = vi.fn()
+            this.updateLODForCamera = vi.fn()
+            const coordinator = new ArtworkPrefetchCoordinator({ renderer: this })
+            this.dispose = vi.fn(() => {
+                mockRendererDispose()
+                coordinator.dispose()
+            })
+        }),
+    }
+})
 
 vi.mock('../../../../src/core/AppSettings', () => {
     const Setting = { EnableLabels: 'enableLabels' }

--- a/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
@@ -324,6 +324,35 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
             expect(mockPlaceGame).toHaveBeenCalledTimes(6)
         })
 
+        it('places games when SectionsReady arrives after ShelfLayoutDetermined', async () => {
+            const games = createMockGamesWithArtwork(4, 0) as any[]
+
+            eventManager.emit<BatchReadyForPlacementEvent>(
+                StorePropsEventTypes.BatchReadyForPlacement,
+                { games, batchIndex: 0, totalBatches: 1 }
+            )
+            await Promise.resolve()
+
+            eventManager.emit<ShelfReadyEvent>(
+                StorePropsEventTypes.ShelfReady,
+                makeShelfReady(0, new THREE.Vector3(0, 0, 0))
+            )
+            eventManager.emit<ShelfReadyEvent>(
+                StorePropsEventTypes.ShelfReady,
+                makeShelfReady(1, new THREE.Vector3(3, 0, 0))
+            )
+            emitShelfLayoutDetermined(eventManager)
+
+            eventManager.emit<SectionsReadyEvent>(GameEventTypes.SectionsReady, {
+                sections: [{ name: 'Test', games, groupMode: 'by-recency', sortMode: 'by-last-played' }],
+                groupMode: 'by-recency',
+                sortMode: 'by-last-played',
+            })
+
+            expect(mockClearPlacements).toHaveBeenCalledTimes(1)
+            expect(mockPlaceGame).toHaveBeenCalledTimes(4)
+        })
+
         it('skips prefetchArtwork for games with no appid and no artwork metadata', async () => {
             // Only games with no appid AND no artwork metadata get no URL at all.
             const games = [{ appid: 0, name: 'No ID Game', playtime_forever: 0, img_icon_url: '', img_logo_url: '', artwork: undefined }]

--- a/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
@@ -2,7 +2,7 @@
  * Unit Tests: GameBoxSpawner — Two-Phase Load/Place
  *
  * Tests verify the refactored GameBoxSpawner correctly:
- * 1. Phase 1 (BatchReadyForPlacement): calls renderer.prefetchArtwork() for each game with a URL
+ * 1. Phase 1 (BatchReadyForPlacement): renderer-owned prewarm pipeline stays active
  * 2. ShelfReady: caches shelf positions for later use by GamesSort
  * 3. Phase 2 (GamesSort): calls clearPlacements() + placeArtworkInstance()/placeLabelBox() in sorted order
  * 4. Emits GamesPlaced events on GamesSort
@@ -41,16 +41,23 @@ const mockPlaceGame = vi.fn()
 const mockClearPlacements = vi.fn()
 const mockRendererDispose = vi.fn()
 
-vi.mock('../../../../src/scene/game-box/GpuGameBoxRenderer', () => ({
-    GpuGameBoxRenderer: vi.fn().mockImplementation(function() {
-        this.prefetchArtwork = mockPrefetchArtwork
-        this.placeGame = mockPlaceGame
-        this.clearPlacements = mockClearPlacements
-        this.dispose = mockRendererDispose
-        this.addToScene = vi.fn()
-        this.updateLODForCamera = vi.fn()
-    })
-}))
+vi.mock('../../../../src/scene/game-box/GpuGameBoxRenderer', async () => {
+    const { ArtworkPrefetchCoordinator } = await import('../../../../src/scene/spawning/ArtworkPrefetchCoordinator')
+    return {
+        GpuGameBoxRenderer: vi.fn().mockImplementation(function() {
+            this.prefetchArtwork = mockPrefetchArtwork
+            this.placeGame = mockPlaceGame
+            this.clearPlacements = mockClearPlacements
+            this.addToScene = vi.fn()
+            this.updateLODForCamera = vi.fn()
+            const coordinator = new ArtworkPrefetchCoordinator({ renderer: this })
+            this.dispose = vi.fn(() => {
+                mockRendererDispose()
+                coordinator.dispose()
+            })
+        })
+    }
+})
 
 // Mock AppSettings so GameBoxSpawner can read EnableLabels at construction
 vi.mock('../../../../src/core/AppSettings', () => {
@@ -221,7 +228,7 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
     // -------------------------------------------------------------------------
     // Phase 1: Prewarm
 
-    describe('Phase 1 — BatchReadyForPlacement → prefetchArtwork()', () => {
+    describe('Phase 1 — BatchReadyForPlacement prewarm pipeline', () => {
         it('calls prefetchArtwork for each game that has an artwork URL', async () => {
             const games = createMockGamesWithArtwork(5, 0)
 
@@ -500,7 +507,7 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
             expect(earlySpawner).toBeDefined()
         })
 
-        it('reinitializes artwork prefetch once after reload without duplicate batch listeners', async () => {
+        it('reinitializes renderer-owned prefetch listeners once after reload without duplicates', async () => {
             const games = createMockGamesWithArtwork(2, 0) as any[]
 
             eventManager.emit<BatchReadyForPlacementEvent>(


### PR DESCRIPTION
## Summary
This slice extracts artwork prewarm ownership out of `GameBoxSpawner` and ties it directly to `GpuGameBoxRenderer` lifecycle.

## What Changed
- `GpuGameBoxRenderer` now owns `ArtworkPrefetchCoordinator` and disposes it with renderer teardown.
- `GameBoxSpawner` no longer manages prefetch coordinator initialization/disposal; it remains focused on placement coordination.
- `ArtworkPrefetchCoordinator` now depends on a narrow prewarmer interface instead of the concrete renderer type to avoid circular import/runtime coupling.
- Updated spawner-related tests to preserve prewarm behavior through renderer-owned lifecycle.

## Files Updated
- `client/src/scene/game-box/GpuGameBoxRenderer.ts`
- `client/src/scene/spawning/ArtworkPrefetchCoordinator.ts`
- `client/src/scene/spawning/GameBoxSpawner.ts`
- `client/test/unit/scene/spawning/GameBoxSpawner.test.ts`
- `client/test/unit/scene/spawning/GameBoxSpawner-stale-positions.test.ts`
- `client/test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts`

## Validation
- `yarn tsc --noEmit`
- `yarn vitest run test/unit/scene/game-box/GpuGameBoxRenderer.test.ts test/unit/scene/spawning/ArtworkPrefetchCoordinator.test.ts test/unit/scene/spawning/GameBoxSpawner.test.ts test/unit/scene/spawning/GameBoxSpawner-stale-positions.test.ts test/unit/scene/spawning/GameBoxSpawner-prefetch-race.test.ts`

## Context
This is the planned "next split" after texture/placement step 7: prewarm extraction first, then narrowing and potential rename of placement coordinator boundaries.