### PR TITLE
Fix layout replay ordering and placement reset semantics

### DIFF
--- a/client/src/scene/game-box/GpuGameBoxRenderer.ts
+++ b/client/src/scene/game-box/GpuGameBoxRenderer.ts
@@ -16,7 +16,7 @@
  * RECEIVES:
  * - prefetchArtwork(appid, url, name) → Phase 1: load texture into atlas
  * - PlacementResolved events → unified placement (artwork or label fallback)
- * - clearPlacements() → wipe all GPU instances before re-sort
+ * - PlacementRunResetRequested → wipe all GPU instances before re-sort
  * - addToScene(scene) → Attaches instanced meshes to scene
  * - updateLODForCamera(camera) → Adjusts detail levels based on distance
  * - dispose() → Cleans up GPU resources
@@ -49,7 +49,10 @@ import { RenderIntentCoordinator } from './RenderIntentCoordinator'
 import { ArtworkPrefetchCoordinator } from '../spawning/ArtworkPrefetchCoordinator'
 import { Logger } from '../../utils/Logger'
 import { EventManager } from '../../core/EventManager'
-import { GameRenderEventTypes, type PlacementResolvedEvent } from '../../types/InteractionEvents'
+import {
+    GameRenderEventTypes,
+    type PlacementResolvedEvent,
+} from '../../types/InteractionEvents'
 
 export class GpuGameBoxRenderer {
     public static logger = Logger.createLogFunctions(GpuGameBoxRenderer.name)
@@ -129,15 +132,6 @@ export class GpuGameBoxRenderer {
         if (!success) {
             GpuGameBoxRenderer.logger.debug(`Failed to add label box for "${game.name}"`)
         }
-    }
-
-    /**
-     * Clear all GPU instance placements without releasing texture atlas slots.
-     * Call before re-sorting; follow with placeArtworkInstance()/placeLabelBox() for each game.
-     */
-    public clearPlacements(): void {
-        this.lodArtworkRenderer.clearPlacements()
-        this.instancedLabelRenderer.clear()
     }
 
     public dispose(): void {

--- a/client/src/scene/game-box/RenderIntentCoordinator.ts
+++ b/client/src/scene/game-box/RenderIntentCoordinator.ts
@@ -1,7 +1,7 @@
 import { EventManager } from '../../core/EventManager'
 import {
     GameRenderEventTypes,
-    UIEventTypes,
+    GameEventTypes,
     StorePropsEventTypes,
     type ArtworkIntentSettledEvent,
     type PlacementResolvedEvent,
@@ -36,11 +36,7 @@ export class RenderIntentCoordinator {
             this.boundHandlePlacementIntentReady
         )
         EventManager.getInstance().registerEventHandler(
-            UIEventTypes.ArrangementRequested,
-            this.boundHandleRunResetRequested
-        )
-        EventManager.getInstance().registerEventHandler(
-            UIEventTypes.LayoutRequested,
+            GameEventTypes.SectionsReady,
             this.boundHandleRunResetRequested
         )
         EventManager.getInstance().registerEventHandler(
@@ -59,11 +55,7 @@ export class RenderIntentCoordinator {
             this.boundHandlePlacementIntentReady
         )
         EventManager.getInstance().deregisterEventHandler(
-            UIEventTypes.ArrangementRequested,
-            this.boundHandleRunResetRequested
-        )
-        EventManager.getInstance().deregisterEventHandler(
-            UIEventTypes.LayoutRequested,
+            GameEventTypes.SectionsReady,
             this.boundHandleRunResetRequested
         )
         EventManager.getInstance().deregisterEventHandler(

--- a/client/src/scene/game-box/RenderIntentCoordinator.ts
+++ b/client/src/scene/game-box/RenderIntentCoordinator.ts
@@ -1,9 +1,9 @@
 import { EventManager } from '../../core/EventManager'
 import {
     GameRenderEventTypes,
-    GameEventTypes,
     StorePropsEventTypes,
     type ArtworkIntentSettledEvent,
+    type PlacementRunResetRequestedEvent,
     type PlacementResolvedEvent,
     type PlacementIntentReadyEvent,
 } from '../../types/InteractionEvents'
@@ -18,7 +18,7 @@ export class RenderIntentCoordinator {
 
     private readonly boundHandleArtworkIntentSettled: (event: CustomEvent<ArtworkIntentSettledEvent>) => void
     private readonly boundHandlePlacementIntentReady: (event: CustomEvent<PlacementIntentReadyEvent>) => void
-    private readonly boundHandleRunResetRequested: (event: CustomEvent<unknown>) => void
+    private readonly boundHandleRunResetRequested: (event: CustomEvent<PlacementRunResetRequestedEvent>) => void
     private readonly boundHandleLibraryReloadRequested: (event: CustomEvent<unknown>) => void
 
     public constructor() {
@@ -36,7 +36,7 @@ export class RenderIntentCoordinator {
             this.boundHandlePlacementIntentReady
         )
         EventManager.getInstance().registerEventHandler(
-            GameEventTypes.SectionsReady,
+            GameRenderEventTypes.PlacementRunResetRequested,
             this.boundHandleRunResetRequested
         )
         EventManager.getInstance().registerEventHandler(
@@ -55,7 +55,7 @@ export class RenderIntentCoordinator {
             this.boundHandlePlacementIntentReady
         )
         EventManager.getInstance().deregisterEventHandler(
-            GameEventTypes.SectionsReady,
+            GameRenderEventTypes.PlacementRunResetRequested,
             this.boundHandleRunResetRequested
         )
         EventManager.getInstance().deregisterEventHandler(
@@ -80,7 +80,7 @@ export class RenderIntentCoordinator {
         this.flushReadyPlacements(appid)
     }
 
-    private handleRunResetRequested(_event: CustomEvent<unknown>): void {
+    private handleRunResetRequested(_event: CustomEvent<PlacementRunResetRequestedEvent>): void {
         this.clearPendingState()
     }
 

--- a/client/src/scene/game-box/RenderIntentCoordinator.ts
+++ b/client/src/scene/game-box/RenderIntentCoordinator.ts
@@ -19,11 +19,13 @@ export class RenderIntentCoordinator {
     private readonly boundHandleArtworkIntentSettled: (event: CustomEvent<ArtworkIntentSettledEvent>) => void
     private readonly boundHandlePlacementIntentReady: (event: CustomEvent<PlacementIntentReadyEvent>) => void
     private readonly boundHandleRunResetRequested: (event: CustomEvent<unknown>) => void
+    private readonly boundHandleLibraryReloadRequested: (event: CustomEvent<unknown>) => void
 
     public constructor() {
         this.boundHandleArtworkIntentSettled = this.handleArtworkIntentSettled.bind(this)
         this.boundHandlePlacementIntentReady = this.handlePlacementIntentReady.bind(this)
         this.boundHandleRunResetRequested = this.handleRunResetRequested.bind(this)
+        this.boundHandleLibraryReloadRequested = this.handleLibraryReloadRequested.bind(this)
 
         EventManager.getInstance().registerEventHandler(
             GameRenderEventTypes.ArtworkIntentSettled,
@@ -43,7 +45,7 @@ export class RenderIntentCoordinator {
         )
         EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.LibraryReloadRequest,
-            this.boundHandleRunResetRequested
+            this.boundHandleLibraryReloadRequested
         )
     }
 
@@ -66,10 +68,10 @@ export class RenderIntentCoordinator {
         )
         EventManager.getInstance().deregisterEventHandler(
             StorePropsEventTypes.LibraryReloadRequest,
-            this.boundHandleRunResetRequested
+            this.boundHandleLibraryReloadRequested
         )
 
-        this.clearRunState()
+        this.clearAllState()
     }
 
     private handleArtworkIntentSettled(event: CustomEvent<ArtworkIntentSettledEvent>): void {
@@ -87,11 +89,19 @@ export class RenderIntentCoordinator {
     }
 
     private handleRunResetRequested(_event: CustomEvent<unknown>): void {
-        this.clearRunState()
+        this.clearPendingState()
     }
 
-    private clearRunState(): void {
+    private handleLibraryReloadRequested(_event: CustomEvent<unknown>): void {
+        this.clearAllState()
+    }
+
+    private clearPendingState(): void {
         this.pendingPlacementIntents.clear()
+    }
+
+    private clearAllState(): void {
+        this.clearPendingState()
         this.settledAppIds.clear()
     }
 

--- a/client/src/scene/game-box/instancing/IGameArtworkPipeline.ts
+++ b/client/src/scene/game-box/instancing/IGameArtworkPipeline.ts
@@ -52,7 +52,5 @@ export interface IGameArtworkPipeline {
         rotation?: THREE.Quaternion
     ): number
 
-    clearPlacements(): void
-
     dispose(): void
 }

--- a/client/src/scene/game-box/instancing/InstancedLabelRenderer.ts
+++ b/client/src/scene/game-box/instancing/InstancedLabelRenderer.ts
@@ -1,7 +1,11 @@
 import * as THREE from 'three'
 import { LabelTextureArrayManager } from './LabelTextureArrayManager'
 import { EventManager } from '../../../core/EventManager'
-import { GameEventTypes } from '../../../types/InteractionEvents'
+import {
+    GameEventTypes,
+    GameRenderEventTypes,
+    type PlacementRunResetRequestedEvent,
+} from '../../../types/InteractionEvents'
 import type { SomeBatchesCompleteEvent } from '../../../types/EnvironmentEvents'
 import { DataManager } from '../../../core/data/DataManager'
 import { DataKey, DataDomain } from '../../../core/data/DataTypes'
@@ -33,6 +37,7 @@ export class InstancedLabelRenderer {
 
     private readonly boundHandleSomeBatchesComplete: (event: CustomEvent<SomeBatchesCompleteEvent>) => void
     private readonly boundHandleArtworkSettled: () => void
+    private readonly boundHandlePlacementRunResetRequested: (event: CustomEvent<PlacementRunResetRequestedEvent>) => void
 
     private static readonly DEFAULT_ROTATION = new THREE.Quaternion()
 
@@ -44,6 +49,7 @@ export class InstancedLabelRenderer {
 
         this.boundHandleSomeBatchesComplete = this.handleSomeBatchesComplete.bind(this)
         this.boundHandleArtworkSettled = this.runCompact.bind(this)
+        this.boundHandlePlacementRunResetRequested = this.handlePlacementRunResetRequested.bind(this)
 
         EventManager.getInstance().registerEventHandler(
             GameEventTypes.SomeBatchesComplete,
@@ -52,6 +58,10 @@ export class InstancedLabelRenderer {
         EventManager.getInstance().registerEventHandler(
             GameEventTypes.ArtworkSettled,
             this.boundHandleArtworkSettled
+        )
+        EventManager.getInstance().registerEventHandler(
+            GameRenderEventTypes.PlacementRunResetRequested,
+            this.boundHandlePlacementRunResetRequested
         )
 
         // Initialise a fresh metadata map so stale entries from a prior load don't
@@ -117,20 +127,6 @@ export class InstancedLabelRenderer {
         return true
     }
 
-    /**
-     * Reset all label instance placements without disposing textures.
-     * Retains the gameNameToTextureIndex map so re-sorts reuse already-baked
-     * texture slots rather than re-allocating them.
-     * Call before re-sorting so new label boxes can be placed in the new order.
-     */
-    public clear(): void {
-        this.currentCount = 0
-        this.nextInstanceIndex = 0
-        if (this.instancedMesh) {
-            this.instancedMesh.count = 0
-        }
-    }
-
     public updateGPU(): void {
         if (!this.isInitialized || !this.instancedMesh || !this.geometry) return
 
@@ -154,6 +150,10 @@ export class InstancedLabelRenderer {
         EventManager.getInstance().deregisterEventHandler(
             GameEventTypes.ArtworkSettled,
             this.boundHandleArtworkSettled
+        )
+        EventManager.getInstance().deregisterEventHandler(
+            GameRenderEventTypes.PlacementRunResetRequested,
+            this.boundHandlePlacementRunResetRequested
         )
 
         if (this.instancedMesh) {
@@ -242,6 +242,14 @@ export class InstancedLabelRenderer {
         if (this.material) {
             this.material.uniforms['textureArray'].value = newTexture
             this.material.needsUpdate = true
+        }
+    }
+
+    private handlePlacementRunResetRequested(_event: CustomEvent<PlacementRunResetRequestedEvent>): void {
+        this.currentCount = 0
+        this.nextInstanceIndex = 0
+        if (this.instancedMesh) {
+            this.instancedMesh.count = 0
         }
     }
 

--- a/client/src/scene/game-box/instancing/LodArtworkOrchestrator.ts
+++ b/client/src/scene/game-box/instancing/LodArtworkOrchestrator.ts
@@ -14,7 +14,12 @@ import * as THREE from 'three'
 import { DataManager } from '../../../core/data/DataManager'
 import { DataKey, DataDomain } from '../../../core/data/DataTypes'
 import { EventManager } from '../../../core/EventManager'
-import { GameEventTypes, AppEventTypes } from '../../../types/InteractionEvents'
+import {
+    GameEventTypes,
+    GameRenderEventTypes,
+    AppEventTypes,
+    type PlacementRunResetRequestedEvent,
+} from '../../../types/InteractionEvents'
 import type { VisibilityChangedEvent } from '../../../types/InteractionEvents'
 import type { SomeBatchesCompleteEvent } from '../../../types/EnvironmentEvents'
 import { Logger } from '../../../utils/Logger'
@@ -175,6 +180,7 @@ export class LodArtworkOrchestrator implements IGameArtworkPipeline {
     private inFlightArtworkCount: number = 0
 
     private readonly onFocusChanged: (e: CustomEvent<VisibilityChangedEvent>) => void
+    private readonly boundHandlePlacementRunResetRequested: (event: CustomEvent<PlacementRunResetRequestedEvent>) => void
 
     constructor(config: LodArtworkConfig = {}) {
         this.maxTextures = config.maxTextures ?? 512
@@ -225,6 +231,7 @@ export class LodArtworkOrchestrator implements IGameArtworkPipeline {
         }
 
         this.renderer = this.createRenderer(rendererConfig)
+        this.boundHandlePlacementRunResetRequested = this.handlePlacementRunResetRequested.bind(this)
 
         // Initialize with texture arrays
         const scene = DataManager.getInstance().get<THREE.Scene>(DataKey.MainScene)
@@ -239,6 +246,10 @@ export class LodArtworkOrchestrator implements IGameArtworkPipeline {
         EventManager.getInstance().registerEventHandler(
             GameEventTypes.AllBatchesComplete,
             this.handleAllBatchesComplete.bind(this)
+        )
+        EventManager.getInstance().registerEventHandler(
+            GameRenderEventTypes.PlacementRunResetRequested,
+            this.boundHandlePlacementRunResetRequested
         )
 
         this.logConfig()
@@ -256,6 +267,12 @@ export class LodArtworkOrchestrator implements IGameArtworkPipeline {
         this.allBatchesComplete = true
         this.compactMidTierAfterLoad()
         this.settleArtwork()
+    }
+
+    private handlePlacementRunResetRequested(_event: CustomEvent<PlacementRunResetRequestedEvent>): void {
+        this.instanceMetadata.clear()
+        this.renderer.clearPlacements()
+        LodArtworkOrchestrator.logger.debug('Cleared instance placements; texture slots retained')
     }
 
     /** Factory method - override in debug subclass */
@@ -400,8 +417,8 @@ export class LodArtworkOrchestrator implements IGameArtworkPipeline {
     /**
      * Phase 2 of the load/place split: assign a world position to a prefetched game.
      * Must be called after prefetchArtwork() has resolved for this game.
-     * On re-sort, call clearPlacements() first, then call placeInstance() for every
-     * game in the new sorted order.
+        * On re-sort, placement reset is handled by PlacementRunResetRequested before
+        * new placement intents are emitted.
      *
      * @returns instanceIndex on success, -1 if texture was not prefetched or slot unavailable.
      */
@@ -431,16 +448,6 @@ export class LodArtworkOrchestrator implements IGameArtworkPipeline {
 
         this.instanceMetadata.set(instanceIndex, { name: gameName, appid, position: position.clone() })
         return instanceIndex
-    }
-
-    /**
-     * Reset all GPU instance placements without releasing texture slots.
-     * Call before re-sorting so placeInstance() can repopulate positions.
-     */
-    public clearPlacements(): void {
-        this.instanceMetadata.clear()
-        this.renderer.clearPlacements()
-        LodArtworkOrchestrator.logger.debug('Cleared instance placements; texture slots retained')
     }
 
     public async setArtworkInstanceFromUrl(
@@ -614,13 +621,13 @@ export class LodArtworkOrchestrator implements IGameArtworkPipeline {
         return result
     }
 
-    public clearFailureCache(): void {
+    // === Protected accessors for debug subclass ===
+
+    protected clearFailureCache(): void {
         this.failedArtwork.clear()
         this.artworkProvider.clearCaches()
         LodArtworkOrchestrator.logger.info('Cleared artwork caches - all URLs will be retried on next load')
     }
-
-    // === Protected accessors for debug subclass ===
 
     protected getTextureManager(): LodTextureArrayManager {
         return this.textureManager
@@ -639,6 +646,10 @@ export class LodArtworkOrchestrator implements IGameArtworkPipeline {
     }
 
     public dispose(): void {
+        EventManager.getInstance().deregisterEventHandler(
+            GameRenderEventTypes.PlacementRunResetRequested,
+            this.boundHandlePlacementRunResetRequested
+        )
         EventManager.getInstance().removeEventListener(
             AppEventTypes.VisibilityChanged,
             this.onFocusChanged

--- a/client/src/scene/props/StorePropsCoordinator.ts
+++ b/client/src/scene/props/StorePropsCoordinator.ts
@@ -221,13 +221,20 @@ class StorePropsCoordinator {
             const BATCH_SIZE = 18
             const totalBatches = Math.ceil(games.length / BATCH_SIZE)
 
-            this.eventManager.emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
-                totalGames: games.length,
-            })
+            // Important ordering: layout-switch replay must happen after all
+            // LayoutRequested handlers complete their reset logic (spawner,
+            // rendezvous coordinator, batch state). Emitting replay events
+            // synchronously here can place games during the same dispatch, then
+            // have later handlers clear that fresh state.
+            queueMicrotask(() => {
+                this.eventManager.emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
+                    totalGames: games.length,
+                })
 
-            this.eventManager.emit<GameDataReadyEvent>(GameEventTypes.GameDataReady, {
-                totalGames: games.length,
-                totalBatches,
+                this.eventManager.emit<GameDataReadyEvent>(GameEventTypes.GameDataReady, {
+                    totalGames: games.length,
+                    totalBatches,
+                })
             })
         }
     }

--- a/client/src/scene/props/StorePropsCoordinator.ts
+++ b/client/src/scene/props/StorePropsCoordinator.ts
@@ -220,21 +220,13 @@ class StorePropsCoordinator {
         if (games.length > 0) {
             const BATCH_SIZE = 18
             const totalBatches = Math.ceil(games.length / BATCH_SIZE)
+            this.eventManager.emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
+                totalGames: games.length,
+            })
 
-            // Important ordering: layout-switch replay must happen after all
-            // LayoutRequested handlers complete their reset logic (spawner,
-            // rendezvous coordinator, batch state). Emitting replay events
-            // synchronously here can place games during the same dispatch, then
-            // have later handlers clear that fresh state.
-            queueMicrotask(() => {
-                this.eventManager.emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
-                    totalGames: games.length,
-                })
-
-                this.eventManager.emit<GameDataReadyEvent>(GameEventTypes.GameDataReady, {
-                    totalGames: games.length,
-                    totalBatches,
-                })
+            this.eventManager.emit<GameDataReadyEvent>(GameEventTypes.GameDataReady, {
+                totalGames: games.length,
+                totalBatches,
             })
         }
     }

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -9,6 +9,7 @@ import {
     StorePropsEventTypes, 
     GameEventTypes,
     SteamEventTypes,
+    type PlacementRunResetRequestedEvent,
     type PlacementIntentReadyEvent,
     type ShelfReadyEvent,
     type ShelfLayoutDeterminedEvent,
@@ -21,45 +22,20 @@ import type {
 } from '../props/PropsEvents'
 import { Logger } from '../../utils/Logger'
 import type { StockSurface } from '../../types/LayoutTypes'
+import type { ShelfSurface } from '../props/shared/SharedPropsTypes'
 
 interface ShelfPosition {
     position: THREE.Vector3
     rotationY: number
+    sectionIndex: number
 }
 
-/**
- * GameBoxSpawner
- *
- * Owns the GpuGameBoxRenderer lifecycle and coordinates the two-phase load/place split:
- *
- * Phase 1 — Prewarm (BatchReadyForPlacement):
- *   GpuGameBoxRenderer (via ArtworkPrefetchCoordinator) handles artwork prefetch.
- *   GameBoxSpawner does not participate in Phase 1.
- *
- * Phase 2 — Place (SectionsReady):
- *   Clears all existing placements and emits placement intents in sorted order
- *   across all sections. Renderer-side rendezvous decides textured vs label
- *   placement when artwork outcomes settle.
- *
- * ShelfReady:
- *   Caches shelf positions indexed by batchIndex for Phase 2 lookup.
- *
- * The artwork/label decision is NOT made here. GameBoxSpawner only emits
- * world-space placement intents ("game X goes at position Y").
- */
 export class GameBoxSpawner {
     private static readonly logger = Logger.createLogFunctions(GameBoxSpawner.name)
 
-    // Owned renderer — initialized on GameDataReady (sized to full library), lives for library lifetime.
-    // Cleared but NOT disposed on layout/group/sort switches.
     private renderer: GpuGameBoxRenderer | null = null
-
-    // Shelf world positions indexed by shelfIndex, grouped by sectionIndex
-    private shelfPositions: Map<number, ShelfPosition & { sectionIndex: number }> = new Map()
-
-    // Cached sections from last SectionsReady until all placement preconditions are satisfied
+    private shelfPositions: Map<number, ShelfPosition> = new Map()
     private pendingSections: SectionsReadyEvent | null = null
-
     private stockStrategy: IStockStrategy | null = null
     private layoutReadyForPlacement = false
     private layoutDeterminedSinceLastSections = false
@@ -93,10 +69,6 @@ export class GameBoxSpawner {
         GameBoxSpawner.logger.debug('Constructed')
     }
 
-    /**
-     * Full teardown — only on library reload (new user, force-refresh).
-     * Disposes the renderer and clears all prefetch state.
-     */
     private fullReset(): void {
         this.renderer?.dispose()
         this.renderer = null
@@ -107,11 +79,6 @@ export class GameBoxSpawner {
         GameBoxSpawner.logger.debug('Full reset (library reload)')
     }
 
-    /**
-     * Clear all placement-related state.
-     * Invoked on run boundaries.
-     * Stock strategy persists across run boundaries until layout changes.
-     */
     private clearPlacementState(): void {
         this.pendingSections = null
         this.shelfPositions.clear()
@@ -121,14 +88,8 @@ export class GameBoxSpawner {
         this.fullReset()
     }
 
-    // -------------------------------------------------------------------------
-    // Initialize renderer at library load time (sized to full library)
-
     private initializeRendererForLibrary(totalGames: number): void {
-        if (this.renderer) {
-            return
-        }
-
+        if (this.renderer) return
         const textureCapacity = Math.max(totalGames, 1) + 100
         const placementCapacity = Math.max(textureCapacity + 100, Math.ceil(textureCapacity * 2))
         this.renderer = new GpuGameBoxRenderer(textureCapacity, placementCapacity)
@@ -138,46 +99,21 @@ export class GameBoxSpawner {
     }
 
     private handleLibraryManifestReady(event: CustomEvent<SteamLibraryManifestReadyEvent>): void {
-        const { totalGames } = event.detail
-        this.initializeRendererForLibrary(totalGames)
+        this.initializeRendererForLibrary(event.detail.totalGames)
     }
-
-    // -------------------------------------------------------------------------
-    // Receive stock strategy + trigger placement once shelves are known
 
     private handleLayoutDetermined(event: CustomEvent<ShelfLayoutDeterminedEvent>): void {
         this.stockStrategy = event.detail.stockStrategy
         this.layoutReadyForPlacement = true
         this.layoutDeterminedSinceLastSections = true
         GameBoxSpawner.logger.debug('Stock strategy received from ShelfLayoutDetermined')
-
         this.tryPlacePendingSections()
     }
 
-    // -------------------------------------------------------------------------
-    // Cache shelf positions from ShelfReady events
-
     private handleShelfReady(event: CustomEvent<ShelfReadyEvent>): void {
         const { shelfIndex, sectionIndex, position, rotationY } = event.detail
-        this.cacheShelfPosition(shelfIndex, sectionIndex, position, rotationY)
-    }
-
-    /**
-     * Cache shelf position for placement lookup.
-     * Clears old positions when a new wave starts (shelfIndex === 0).
-     * Ensures only current-run positions are used regardless of event ordering.
-     */
-    private cacheShelfPosition(
-        shelfIndex: number,
-        sectionIndex: number,
-        position: THREE.Vector3,
-        rotationY: number
-    ): void {
-        // ShelfLayoutCoordinator emits a contiguous shelf wave per run starting at index 0.
-        if (shelfIndex === 0) {
-            this.shelfPositions.clear()
-        }
-
+        // ShelfLayoutCoordinator emits a contiguous wave per run starting at index 0.
+        if (shelfIndex === 0) this.shelfPositions.clear()
         this.shelfPositions.set(shelfIndex, {
             position: (position as THREE.Vector3).clone(),
             rotationY,
@@ -189,84 +125,49 @@ export class GameBoxSpawner {
         )
     }
 
-    // -------------------------------------------------------------------------
-    // Phase 2: cache sections, place when strategy is available
-
     private handleSectionsReady(event: CustomEvent<SectionsReadyEvent>): void {
-        // If SectionsReady arrives before layout computation, clear stale shelf state.
-        // If layout already arrived for this run (alternate ordering), keep the freshly
-        // computed shelf map and place immediately.
-        if (!this.layoutDeterminedSinceLastSections) {
-            this.clearPlacementState()
-        }
-
-        // Cache sections for placement. Placement can be triggered by either
-        // ShelfLayoutDetermined (normal order) or SectionsReady (if layout already arrived).
+        if (!this.layoutDeterminedSinceLastSections) this.clearPlacementState()
         this.pendingSections = event.detail
         this.layoutDeterminedSinceLastSections = false
         GameBoxSpawner.logger.debug('SectionsReady: cached sections for placement attempt')
-
-        if (this.layoutReadyForPlacement) {
-            this.tryPlacePendingSections()
-        }
+        if (this.layoutReadyForPlacement) this.tryPlacePendingSections()
     }
 
     private canPlacePendingSections(): boolean {
-        if (!this.pendingSections) {
-            return false
-        }
-
+        if (!this.pendingSections) return false
         if (!this.renderer) {
             GameBoxSpawner.logger.warn('tryPlacePendingSections: renderer not yet constructed')
             return false
         }
-
         if (!this.stockStrategy) {
             GameBoxSpawner.logger.warn('tryPlacePendingSections: no stock strategy')
             return false
         }
-
         if (this.shelfPositions.size === 0) {
             GameBoxSpawner.logger.debug('tryPlacePendingSections: waiting for shelf positions')
             return false
         }
-
         return true
     }
 
     private tryPlacePendingSections(): void {
-        if (!this.canPlacePendingSections()) {
-            return
-        }
-
-        if (this.placeSections(this.pendingSections)) {
-            this.pendingSections = null
-            this.layoutDeterminedSinceLastSections = false
-        }
+        const sections = this.pendingSections
+        const stockStrategy = this.stockStrategy
+        if (!this.canPlacePendingSections()) return
+        this.placeSections(sections, stockStrategy)
+        this.pendingSections = null
+        this.layoutDeterminedSinceLastSections = false
     }
 
-    private placeSections(detail: SectionsReadyEvent): boolean {
+    private placeSections(
+        detail: SectionsReadyEvent,
+        stockStrategy: IStockStrategy
+    ): void {
         const { sections } = detail
-        const totalGames = sections.reduce((sum, s) => sum + s.games.length, 0)
-
-        GameBoxSpawner.logger.debug(
-            `Placing ${totalGames} games across ${sections.length} section(s)`
-        )
-
-        if (!this.renderer) {
-            GameBoxSpawner.logger.warn('placeSections: renderer not yet constructed')
-            return false
-        }
-
-        if (!this.stockStrategy) {
-            GameBoxSpawner.logger.warn('placeSections: no stock strategy')
-            return false
-        }
-
         const shelfSurfaces = ShelfSurfaceUtils.findShelfSurfaces(null, true)
         if (shelfSurfaces.length === 0) {
             GameBoxSpawner.logger.warn('placeSections: no shelf surfaces found')
-            return false
+            return
         }
 
         const sectionShelvesByIndex = sections.map((_, sectionIndex) =>
@@ -275,61 +176,55 @@ export class GameBoxSpawner {
                 .sort(([a], [b]) => a - b)
         )
 
-        const totalSectionShelves = sectionShelvesByIndex.reduce(
-            (sum, sectionShelves) => sum + sectionShelves.length,
-            0
-        )
-
+        const totalSectionShelves = sectionShelvesByIndex.reduce((sum, s) => sum + s.length, 0)
         if (totalSectionShelves === 0) {
-            GameBoxSpawner.logger.debug(
-                'placeSections: no section shelves available for this run'
-            )
-            return false
+            GameBoxSpawner.logger.debug('placeSections: no section shelves available for this run')
+            return
         }
 
-        this.renderer.clearPlacements()
+        EventManager.getInstance().emit<PlacementRunResetRequestedEvent>(
+            GameRenderEventTypes.PlacementRunResetRequested,
+            {}
+        )
 
         let shelvesUsed = 0
-        for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
-            const section = sections[sectionIndex]
-            const sectionShelves = sectionShelvesByIndex[sectionIndex]
-
-            const gameQueue = [...section.games] as SteamGameData[]
-            for (const [shelfIndex, shelfPos] of sectionShelves) {
-                if (gameQueue.length === 0) break
-                const stockSurfaces = GameBoxUtils.buildStockSurfaces(
-                    shelfPos.position, shelfPos.rotationY, shelfSurfaces, { strategy: this.stockStrategy }
-                )
-                const shelfCapacity = stockSurfaces.reduce((sum, s) => sum + s.capacity, 0)
-                const batch = gameQueue.splice(0, shelfCapacity)
-                this.assignIntentsFromStock(stockSurfaces, batch)
-                EventManager.getInstance().emit<GamesPlacedEvent>(
-                    StorePropsEventTypes.GamesPlaced,
-                    { batchIndex: shelfIndex, status: BatchProcessingStatus.GamesPlaced }
-                )
-                shelvesUsed++
-            }
-
-            if (gameQueue.length > 0) {
-                GameBoxSpawner.logger.warn(
-                    `Section "${section.name}": ${gameQueue.length} games had no shelf space`
-                )
-            }
+        for (let i = 0; i < sections.length; i++) {
+            shelvesUsed += this.placeSection(sections[i], sectionShelvesByIndex[i], shelfSurfaces, stockStrategy)
         }
 
-        GameBoxSpawner.logger.debug(
-            `Placement intents emitted across ${shelvesUsed} shelves`
-        )
-        return true
+        GameBoxSpawner.logger.debug(`Placement intents emitted across ${shelvesUsed} shelves`)
     }
 
-    // -------------------------------------------------------------------------
-    // Intent assignment helpers
+    private placeSection(
+        section: SectionsReadyEvent['sections'][number],
+        sectionShelves: [number, ShelfPosition][],
+        shelfSurfaces: ShelfSurface[],
+        stockStrategy: IStockStrategy
+    ): number {
+        const gameQueue = [...section.games] as SteamGameData[]
+        let shelvesUsed = 0
 
-    private assignIntentsFromStock(
-        stockSurfaces: StockSurface[],
-        games: SteamGameData[]
-    ): void {
+        for (const [shelfIndex, shelfPos] of sectionShelves) {
+            if (gameQueue.length === 0) break
+            const stockSurfaces = GameBoxUtils.buildStockSurfaces(
+                shelfPos.position, shelfPos.rotationY, shelfSurfaces, { strategy: stockStrategy }
+            )
+            const batch = gameQueue.splice(0, stockSurfaces.reduce((sum, s) => sum + s.capacity, 0))
+            this.assignIntentsFromStock(stockSurfaces, batch)
+            EventManager.getInstance().emit<GamesPlacedEvent>(
+                StorePropsEventTypes.GamesPlaced,
+                { batchIndex: shelfIndex, status: BatchProcessingStatus.GamesPlaced }
+            )
+            shelvesUsed++
+        }
+
+        if (gameQueue.length > 0) {
+            GameBoxSpawner.logger.warn(`Section "${section.name}": ${gameQueue.length} games had no shelf space`)
+        }
+        return shelvesUsed
+    }
+
+    private assignIntentsFromStock(stockSurfaces: StockSurface[], games: SteamGameData[]): void {
         const intents = GameBoxUtils.stockSurfaces(stockSurfaces, games)
         for (const { game, position, rotation } of intents) {
             const appid = typeof game.appid === 'number' ? game.appid : 0
@@ -341,6 +236,3 @@ export class GameBoxSpawner {
     }
 
 }
-
-// Construct at import: registers event handlers for app lifetime.
-

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -91,6 +91,10 @@ export class GameBoxSpawner {
             () => this.geometryReset()
         )
         EventManager.getInstance().registerEventHandler(
+            UIEventTypes.LayoutRequested,
+            () => this.geometryReset()
+        )
+        EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.LibraryReloadRequest,
             (e: CustomEvent<StorePropsLibraryReloadRequestEvent>) => this.handleLibraryReloadRequest(e)
         )

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -119,9 +119,12 @@ export class GameBoxSpawner {
     /**
      * Geometry reset — on layout/group/sort switches.
      * Keeps the renderer and prefetch cache; only clears placement state.
+     * Note: renderer.clearPlacements() is NOT called here — placeSections() handles
+     * it atomically just before placing new games. Calling it here would wipe games
+     * placed by StorePropsCoordinator's LayoutRequested handler, which fires before
+     * this geometryReset (handler registration order).
      */
     private geometryReset(): void {
-        this.renderer?.clearPlacements()
         this.stockStrategy = null
         this.layoutReadyForPlacement = false
         this.clearPlacementState()

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -62,8 +62,7 @@ export class GameBoxSpawner {
     private pendingSections: SectionsReadyEvent | null = null
 
     private stockStrategy: IStockStrategy | null = null
-    private sectionsReadyCount = 0
-    private layoutDeterminedCount = 0
+    private layoutReadyForPlacement = false
     private retryPendingOnShelfReady = false
 
     static {
@@ -111,9 +110,8 @@ export class GameBoxSpawner {
         this.renderer?.dispose()
         this.renderer = null
         this.stockStrategy = null
+        this.layoutReadyForPlacement = false
         this.clearPlacementState()
-        this.sectionsReadyCount = 0
-        this.layoutDeterminedCount = 0
         this.retryPendingOnShelfReady = false
         GameBoxSpawner.logger.debug('Full reset (library reload)')
     }
@@ -125,9 +123,8 @@ export class GameBoxSpawner {
     private geometryReset(): void {
         this.renderer?.clearPlacements()
         this.stockStrategy = null
+        this.layoutReadyForPlacement = false
         this.clearPlacementState()
-        this.sectionsReadyCount = 0
-        this.layoutDeterminedCount = 0
         this.retryPendingOnShelfReady = false
         GameBoxSpawner.logger.debug('Geometry reset (layout switch)')
     }
@@ -172,7 +169,7 @@ export class GameBoxSpawner {
 
     private handleLayoutDetermined(event: CustomEvent<ShelfLayoutDeterminedEvent>): void {
         this.stockStrategy = event.detail.stockStrategy
-        this.layoutDeterminedCount++
+        this.layoutReadyForPlacement = true
         GameBoxSpawner.logger.debug('Stock strategy received from ShelfLayoutDetermined')
 
         this.tryPlacePendingSections()
@@ -220,20 +217,14 @@ export class GameBoxSpawner {
     // Phase 2: cache sections, place when strategy is available
 
     private handleSectionsReady(event: CustomEvent<SectionsReadyEvent>): void {
-        this.sectionsReadyCount++
-
         // Cache sections for placement. Placement can be triggered by either
         // ShelfLayoutDetermined (normal order) or SectionsReady (if layout already arrived).
         this.pendingSections = event.detail
         GameBoxSpawner.logger.debug('SectionsReady: cached sections for placement attempt')
 
-        if (this.isLayoutReadyForPendingSections()) {
+        if (this.layoutReadyForPlacement) {
             this.tryPlacePendingSections()
         }
-    }
-
-    private isLayoutReadyForPendingSections(): boolean {
-        return this.layoutDeterminedCount >= this.sectionsReadyCount
     }
 
     private canPlacePendingSections(): boolean {

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -9,7 +9,6 @@ import {
     StorePropsEventTypes, 
     GameEventTypes,
     SteamEventTypes,
-    UIEventTypes,
     type PlacementIntentReadyEvent,
     type ShelfReadyEvent,
     type ShelfLayoutDeterminedEvent,
@@ -63,7 +62,7 @@ export class GameBoxSpawner {
 
     private stockStrategy: IStockStrategy | null = null
     private layoutReadyForPlacement = false
-    private retryPendingOnShelfReady = false
+    private layoutDeterminedSinceLastSections = false
 
     static {
         new GameBoxSpawner()
@@ -87,14 +86,6 @@ export class GameBoxSpawner {
             (e: CustomEvent<SteamLibraryManifestReadyEvent>) => this.handleLibraryManifestReady(e)
         )
         EventManager.getInstance().registerEventHandler(
-            UIEventTypes.ArrangementRequested,
-            () => this.geometryReset()
-        )
-        EventManager.getInstance().registerEventHandler(
-            UIEventTypes.LayoutRequested,
-            () => this.geometryReset()
-        )
-        EventManager.getInstance().registerEventHandler(
             StorePropsEventTypes.LibraryReloadRequest,
             (e: CustomEvent<StorePropsLibraryReloadRequestEvent>) => this.handleLibraryReloadRequest(e)
         )
@@ -111,30 +102,14 @@ export class GameBoxSpawner {
         this.renderer = null
         this.stockStrategy = null
         this.layoutReadyForPlacement = false
+        this.layoutDeterminedSinceLastSections = false
         this.clearPlacementState()
-        this.retryPendingOnShelfReady = false
         GameBoxSpawner.logger.debug('Full reset (library reload)')
     }
 
     /**
-     * Geometry reset — on layout/group/sort switches.
-     * Keeps the renderer and prefetch cache; only clears placement state.
-     * Note: renderer.clearPlacements() is NOT called here — placeSections() handles
-     * it atomically just before placing new games. Calling it here would wipe games
-     * placed by StorePropsCoordinator's LayoutRequested handler, which fires before
-     * this geometryReset (handler registration order).
-     */
-    private geometryReset(): void {
-        this.stockStrategy = null
-        this.layoutReadyForPlacement = false
-        this.clearPlacementState()
-        this.retryPendingOnShelfReady = false
-        GameBoxSpawner.logger.debug('Geometry reset (layout switch)')
-    }
-
-    /**
      * Clear all placement-related state.
-     * Invoked on geometry resets and run boundaries.
+     * Invoked on run boundaries.
      * Stock strategy persists across run boundaries until layout changes.
      */
     private clearPlacementState(): void {
@@ -173,6 +148,7 @@ export class GameBoxSpawner {
     private handleLayoutDetermined(event: CustomEvent<ShelfLayoutDeterminedEvent>): void {
         this.stockStrategy = event.detail.stockStrategy
         this.layoutReadyForPlacement = true
+        this.layoutDeterminedSinceLastSections = true
         GameBoxSpawner.logger.debug('Stock strategy received from ShelfLayoutDetermined')
 
         this.tryPlacePendingSections()
@@ -184,9 +160,6 @@ export class GameBoxSpawner {
     private handleShelfReady(event: CustomEvent<ShelfReadyEvent>): void {
         const { shelfIndex, sectionIndex, position, rotationY } = event.detail
         this.cacheShelfPosition(shelfIndex, sectionIndex, position, rotationY)
-        if (this.retryPendingOnShelfReady) {
-            this.tryPlacePendingSections()
-        }
     }
 
     /**
@@ -220,9 +193,17 @@ export class GameBoxSpawner {
     // Phase 2: cache sections, place when strategy is available
 
     private handleSectionsReady(event: CustomEvent<SectionsReadyEvent>): void {
+        // If SectionsReady arrives before layout computation, clear stale shelf state.
+        // If layout already arrived for this run (alternate ordering), keep the freshly
+        // computed shelf map and place immediately.
+        if (!this.layoutDeterminedSinceLastSections) {
+            this.clearPlacementState()
+        }
+
         // Cache sections for placement. Placement can be triggered by either
         // ShelfLayoutDetermined (normal order) or SectionsReady (if layout already arrived).
         this.pendingSections = event.detail
+        this.layoutDeterminedSinceLastSections = false
         GameBoxSpawner.logger.debug('SectionsReady: cached sections for placement attempt')
 
         if (this.layoutReadyForPlacement) {
@@ -260,7 +241,7 @@ export class GameBoxSpawner {
 
         if (this.placeSections(this.pendingSections)) {
             this.pendingSections = null
-            this.retryPendingOnShelfReady = false
+            this.layoutDeterminedSinceLastSections = false
         }
     }
 
@@ -300,9 +281,8 @@ export class GameBoxSpawner {
         )
 
         if (totalSectionShelves === 0) {
-            this.retryPendingOnShelfReady = true
             GameBoxSpawner.logger.debug(
-                'placeSections: no section shelves available yet; deferring placement until ShelfReady arrives'
+                'placeSections: no section shelves available for this run'
             )
             return false
         }

--- a/client/src/scene/spawning/GameBoxSpawner.ts
+++ b/client/src/scene/spawning/GameBoxSpawner.ts
@@ -64,6 +64,7 @@ export class GameBoxSpawner {
     private stockStrategy: IStockStrategy | null = null
     private sectionsReadyCount = 0
     private layoutDeterminedCount = 0
+    private retryPendingOnShelfReady = false
 
     static {
         new GameBoxSpawner()
@@ -113,6 +114,7 @@ export class GameBoxSpawner {
         this.clearPlacementState()
         this.sectionsReadyCount = 0
         this.layoutDeterminedCount = 0
+        this.retryPendingOnShelfReady = false
         GameBoxSpawner.logger.debug('Full reset (library reload)')
     }
 
@@ -126,6 +128,7 @@ export class GameBoxSpawner {
         this.clearPlacementState()
         this.sectionsReadyCount = 0
         this.layoutDeterminedCount = 0
+        this.retryPendingOnShelfReady = false
         GameBoxSpawner.logger.debug('Geometry reset (layout switch)')
     }
 
@@ -181,6 +184,9 @@ export class GameBoxSpawner {
     private handleShelfReady(event: CustomEvent<ShelfReadyEvent>): void {
         const { shelfIndex, sectionIndex, position, rotationY } = event.detail
         this.cacheShelfPosition(shelfIndex, sectionIndex, position, rotationY)
+        if (this.retryPendingOnShelfReady) {
+            this.tryPlacePendingSections()
+        }
     }
 
     /**
@@ -258,11 +264,13 @@ export class GameBoxSpawner {
             return
         }
 
-        this.placeSections(this.pendingSections)
-        this.pendingSections = null
+        if (this.placeSections(this.pendingSections)) {
+            this.pendingSections = null
+            this.retryPendingOnShelfReady = false
+        }
     }
 
-    private placeSections(detail: SectionsReadyEvent): void {
+    private placeSections(detail: SectionsReadyEvent): boolean {
         const { sections } = detail
         const totalGames = sections.reduce((sum, s) => sum + s.games.length, 0)
 
@@ -272,28 +280,45 @@ export class GameBoxSpawner {
 
         if (!this.renderer) {
             GameBoxSpawner.logger.warn('placeSections: renderer not yet constructed')
-            return
+            return false
         }
 
         if (!this.stockStrategy) {
             GameBoxSpawner.logger.warn('placeSections: no stock strategy')
-            return
+            return false
         }
-
-        this.renderer.clearPlacements()
 
         const shelfSurfaces = ShelfSurfaceUtils.findShelfSurfaces(null, true)
         if (shelfSurfaces.length === 0) {
             GameBoxSpawner.logger.warn('placeSections: no shelf surfaces found')
-            return
+            return false
         }
+
+        const sectionShelvesByIndex = sections.map((_, sectionIndex) =>
+            [...this.shelfPositions.entries()]
+                .filter(([, shelf]) => shelf.sectionIndex === sectionIndex)
+                .sort(([a], [b]) => a - b)
+        )
+
+        const totalSectionShelves = sectionShelvesByIndex.reduce(
+            (sum, sectionShelves) => sum + sectionShelves.length,
+            0
+        )
+
+        if (totalSectionShelves === 0) {
+            this.retryPendingOnShelfReady = true
+            GameBoxSpawner.logger.debug(
+                'placeSections: no section shelves available yet; deferring placement until ShelfReady arrives'
+            )
+            return false
+        }
+
+        this.renderer.clearPlacements()
 
         let shelvesUsed = 0
         for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
             const section = sections[sectionIndex]
-            const sectionShelves = [...this.shelfPositions.entries()]
-                .filter(([, shelf]) => shelf.sectionIndex === sectionIndex)
-                .sort(([a], [b]) => a - b)
+            const sectionShelves = sectionShelvesByIndex[sectionIndex]
 
             const gameQueue = [...section.games] as SteamGameData[]
             for (const [shelfIndex, shelfPos] of sectionShelves) {
@@ -321,6 +346,7 @@ export class GameBoxSpawner {
         GameBoxSpawner.logger.debug(
             `Placement intents emitted across ${shelvesUsed} shelves`
         )
+        return true
     }
 
     // -------------------------------------------------------------------------

--- a/client/src/types/InteractionEvents.ts
+++ b/client/src/types/InteractionEvents.ts
@@ -228,6 +228,8 @@ export interface PlacementResolvedEvent extends BaseInteractionEvent {
     rotation: THREE.Quaternion
 }
 
+export interface PlacementRunResetRequestedEvent extends BaseInteractionEvent {}
+
 // =============================================================================
 // STORE PROPS EVENTS
 // =============================================================================
@@ -325,6 +327,7 @@ export const GameEventTypes = {
 } as const
 
 export const GameRenderEventTypes = {
+    PlacementRunResetRequested: 'game-render:placement-run-reset-requested',
     ArtworkIntentSettled: 'game-render:artwork-intent-settled',
     PlacementIntentReady: 'game-render:placement-intent-ready',
     PlacementResolved: 'game-render:placement-resolved',

--- a/client/test/integration/group-then-layout-placement.int.test.ts
+++ b/client/test/integration/group-then-layout-placement.int.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as THREE from 'three'
+
+import { EventManager } from '../../src/core/EventManager'
+import { DataDomain, DataKey, DataManager } from '../../src/core/data'
+import { GameSorter } from '../../src/scene/categorization/GameSorter'
+import { createStorePropsTestHarness, type StorePropsTestHarness } from '../helpers/StorePropsTestHarness'
+import {
+    GameEventTypes,
+    SteamEventTypes,
+    StorePropsEventTypes,
+    UIEventTypes,
+    type GamesPlacedEvent,
+    type SteamLibraryManifestReadyEvent,
+} from '../../src/types/InteractionEvents'
+import type { ArrangementRequestedEvent, GameDataReadyEvent, LayoutRequestedEvent } from '../../src/types/EnvironmentEvents'
+import { GroupModes, SortModes } from '../../src/types/LayoutTypes'
+import type { SteamGame } from '../../src/steam'
+
+vi.mock('../../src/utils/TextureManager', async () => {
+    const { MockTextureManager } = await import('../mocks/utils/TextureManager.mock')
+    return {
+        TextureManager: {
+            getInstance: () => MockTextureManager.getInstance(),
+        },
+    }
+})
+
+vi.mock('../../src/steam-integration/SteamIntegration', () => ({
+    SteamIntegration: {
+        getInstance: () => ({
+            isAnonymous: () => true,
+        }),
+    },
+}))
+
+function makeGenreGames(count: number): SteamGame[] {
+    const genres = ['Action', 'Adventure', 'RPG']
+    return Array.from({ length: count }, (_, i) => ({
+        appid: i + 1,
+        name: `Genre Test ${i + 1}`,
+        playtime_forever: i * 10,
+        img_icon_url: '',
+        img_logo_url: '',
+        artwork: {
+            library: `https://cdn.akamai.steamstatic.com/steam/apps/${i + 1}/library_600x900_stub.jpg`,
+            header: `https://cdn.akamai.steamstatic.com/steam/apps/${i + 1}/header_stub.jpg`,
+            icon: '',
+            logo: '',
+        },
+        genres: [{ id: `${(i % genres.length) + 1}`, description: genres[i % genres.length] }],
+    }))
+}
+
+describe('group then layout placement regression', () => {
+    let scene: THREE.Scene
+    let eventManager: EventManager
+    let dataManager: DataManager
+    let harness: StorePropsTestHarness
+
+    beforeEach(() => {
+        scene = new THREE.Scene()
+        eventManager = EventManager.getInstance()
+        eventManager.removeAllListeners()
+
+        dataManager = DataManager.getInstance()
+        dataManager.clear()
+        dataManager.set(DataKey.MainScene, scene, {
+            domain: DataDomain.Scene,
+            description: 'group-then-layout regression scene',
+        })
+
+        harness = createStorePropsTestHarness(scene)
+        new GameSorter()
+    })
+
+    afterEach(() => {
+        harness?.dispose()
+        eventManager.removeAllListeners()
+        dataManager.clear()
+        scene.clear()
+        vi.restoreAllMocks()
+    })
+
+    it('keeps placing games after switching group then layout', async () => {
+        const games = makeGenreGames(24)
+
+        dataManager.set('steam.games', games as any, {
+            domain: DataDomain.SteamIntegration,
+            description: 'group-then-layout test games',
+        })
+
+        const warnSpy = vi.spyOn(console, 'warn')
+        let gamesPlacedCount = 0
+        eventManager.registerEventHandler(
+            StorePropsEventTypes.GamesPlaced,
+            (_event: CustomEvent<GamesPlacedEvent>) => {
+                gamesPlacedCount++
+            }
+        )
+
+        eventManager.emit<SteamLibraryManifestReadyEvent>(SteamEventTypes.LibraryManifestReady, {
+            totalGames: games.length,
+        })
+
+        eventManager.emit<ArrangementRequestedEvent>(UIEventTypes.ArrangementRequested, {
+            groupMode: GroupModes.ByGenre,
+            sortMode: SortModes.ByPlaytime,
+        })
+
+        await vi.waitFor(() => {
+            expect(gamesPlacedCount).toBeGreaterThan(0)
+        }, { timeout: 8000, interval: 50 })
+
+        const beforeLayoutPlacedCount = gamesPlacedCount
+
+        eventManager.emit<LayoutRequestedEvent>(UIEventTypes.LayoutRequested, {
+            layoutMode: 'row',
+        })
+
+        // StorePropsCoordinator emits GameDataReady after layout changes in runtime.
+        eventManager.emit<GameDataReadyEvent>(GameEventTypes.GameDataReady, {
+            totalGames: games.length,
+            totalBatches: Math.ceil(games.length / 18),
+        })
+
+        await vi.waitFor(() => {
+            expect(gamesPlacedCount).toBeGreaterThan(beforeLayoutPlacedCount)
+        }, { timeout: 8000, interval: 50 })
+
+        const noShelfSpaceWarnings = warnSpy.mock.calls.filter(call =>
+            call.some(arg => typeof arg === 'string' && arg.includes('had no shelf space'))
+        )
+
+        expect(noShelfSpaceWarnings).toHaveLength(0)
+    })
+})

--- a/client/test/unit/scene/game-box/GpuGameBoxRenderer.test.ts
+++ b/client/test/unit/scene/game-box/GpuGameBoxRenderer.test.ts
@@ -3,7 +3,7 @@
  *
  * GpuGameBoxRenderer is now a thin coordinator: it constructs
  * LodArtworkOrchestratorDebug (via fromAppSettings) and InstancedLabelRenderer,
- * and provides placeGame() / clearPlacements() / dispose().
+ * and wires placement-resolved handling plus dispose().
  *
  * The LodDistanceManager lifecycle tests that previously lived here have moved:
  * LodDistanceManager is now owned by LodArtworkOrchestratorDebug and
@@ -121,10 +121,14 @@ describe('GpuGameBoxRenderer', () => {
         expect(mockAddLabelInstance).toHaveBeenCalledTimes(1)
     })
 
-    it('clearPlacements: clears both artwork and label renderers', () => {
-        renderer.clearPlacements()
-        expect(mockClearPlacements).toHaveBeenCalledTimes(1)
-        expect(mockLabelClear).toHaveBeenCalledTimes(1)
+    it('does not subscribe directly to PlacementRunResetRequested', () => {
+        const resetRegistrations = mockRegisterEventHandler.mock.calls.filter(
+            (call: unknown[]) => call[0] === GameRenderEventTypes.PlacementRunResetRequested
+        )
+        const rendererOwnedRegistration = resetRegistrations.find(
+            (call: unknown[]) => String((call[1] as Function)?.name ?? '').includes('handlePlacementRunResetRequested')
+        )
+        expect(rendererOwnedRegistration).toBeFalsy()
     })
 
     it('dispose: disposes both renderers', () => {

--- a/client/test/unit/scene/game-box/RenderIntentCoordinator.test.ts
+++ b/client/test/unit/scene/game-box/RenderIntentCoordinator.test.ts
@@ -5,13 +5,11 @@ import { EventManager } from '../../../../src/core/EventManager'
 import { RenderIntentCoordinator } from '../../../../src/scene/game-box/RenderIntentCoordinator'
 import {
     GameRenderEventTypes,
-    UIEventTypes,
+    GameEventTypes,
     StorePropsEventTypes,
     type ArtworkIntentSettledEvent,
     type PlacementResolvedEvent,
     type PlacementIntentReadyEvent,
-    type ArrangementRequestedEvent,
-    type LayoutRequestedEvent,
     type StorePropsLibraryReloadRequestEvent,
 } from '../../../../src/types/InteractionEvents'
 
@@ -101,7 +99,7 @@ describe('RenderIntentCoordinator', () => {
         coordinator.dispose()
     })
 
-    it('clears stale pending placement intents on ArrangementRequested', () => {
+    it('clears stale pending placement intents on SectionsReady run boundary', () => {
         const coordinator = new RenderIntentCoordinator()
         const resolved: PlacementResolvedEvent[] = []
 
@@ -120,10 +118,11 @@ describe('RenderIntentCoordinator', () => {
             } as any
         )
 
-        EventManager.getInstance().emit<ArrangementRequestedEvent>(
-            UIEventTypes.ArrangementRequested,
-            { groupMode: 'genre', sortMode: 'name-asc' } as any
-        )
+        EventManager.getInstance().emit(GameEventTypes.SectionsReady, {
+            sections: [{ name: 'Run2', games: [], groupMode: 'genre', sortMode: 'name-asc' }],
+            groupMode: 'genre',
+            sortMode: 'name-asc',
+        } as any)
 
         EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
             GameRenderEventTypes.ArtworkIntentSettled,
@@ -135,7 +134,7 @@ describe('RenderIntentCoordinator', () => {
         coordinator.dispose()
     })
 
-    it('preserves settled artwork across ArrangementRequested so replay can resolve', () => {
+    it('preserves settled artwork across SectionsReady so replay can resolve', () => {
         const coordinator = new RenderIntentCoordinator()
         const resolved: PlacementResolvedEvent[] = []
 
@@ -149,10 +148,11 @@ describe('RenderIntentCoordinator', () => {
             { appid: 77, gameName: 'Game 77' }
         )
 
-        EventManager.getInstance().emit<ArrangementRequestedEvent>(
-            UIEventTypes.ArrangementRequested,
-            { groupMode: 'genre', sortMode: 'name-asc' } as any
-        )
+        EventManager.getInstance().emit(GameEventTypes.SectionsReady, {
+            sections: [{ name: 'Run2', games: [], groupMode: 'genre', sortMode: 'name-asc' }],
+            groupMode: 'genre',
+            sortMode: 'name-asc',
+        } as any)
 
         EventManager.getInstance().emit<PlacementIntentReadyEvent>(
             GameRenderEventTypes.PlacementIntentReady,
@@ -190,11 +190,12 @@ describe('RenderIntentCoordinator', () => {
             } as any
         )
 
-        // Re-sort clear: stale pending intents must be dropped before settlement.
-        EventManager.getInstance().emit<ArrangementRequestedEvent>(
-            UIEventTypes.ArrangementRequested,
-            { groupMode: 'genre', sortMode: 'name-asc' } as any
-        )
+        // New run boundary: stale pending intents must be dropped before settlement.
+        EventManager.getInstance().emit(GameEventTypes.SectionsReady, {
+            sections: [{ name: 'Run2', games: [], groupMode: 'genre', sortMode: 'name-asc' }],
+            groupMode: 'genre',
+            sortMode: 'name-asc',
+        } as any)
 
         EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
             GameRenderEventTypes.ArtworkIntentSettled,
@@ -216,75 +217,6 @@ describe('RenderIntentCoordinator', () => {
         expect(resolved).toHaveLength(1)
         expect(resolved[0]?.appid).toBe(11)
         expect(resolved[0]?.position).toEqual(new THREE.Vector3(2, 0, 0))
-
-        coordinator.dispose()
-    })
-
-    it('clears stale pending placement intents on LayoutRequested', () => {
-        const coordinator = new RenderIntentCoordinator()
-        const resolved: PlacementResolvedEvent[] = []
-
-        EventManager.getInstance().registerEventHandler(
-            GameRenderEventTypes.PlacementResolved,
-            (event: CustomEvent<PlacementResolvedEvent>) => resolved.push(event.detail)
-        )
-
-        EventManager.getInstance().emit<PlacementIntentReadyEvent>(
-            GameRenderEventTypes.PlacementIntentReady,
-            {
-                appid: 19,
-                game: makeGame(19),
-                position: new THREE.Vector3(9, 0, 0),
-                rotation: new THREE.Quaternion(),
-            } as any
-        )
-
-        EventManager.getInstance().emit<LayoutRequestedEvent>(
-            UIEventTypes.LayoutRequested,
-            { layoutMode: 'arc' } as any
-        )
-
-        EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
-            GameRenderEventTypes.ArtworkIntentSettled,
-            { appid: 19, gameName: 'Game 19' }
-        )
-
-        expect(resolved).toHaveLength(0)
-
-        coordinator.dispose()
-    })
-
-    it('preserves settled artwork across LayoutRequested so replay can resolve', () => {
-        const coordinator = new RenderIntentCoordinator()
-        const resolved: PlacementResolvedEvent[] = []
-
-        EventManager.getInstance().registerEventHandler(
-            GameRenderEventTypes.PlacementResolved,
-            (event: CustomEvent<PlacementResolvedEvent>) => resolved.push(event.detail)
-        )
-
-        EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
-            GameRenderEventTypes.ArtworkIntentSettled,
-            { appid: 88, gameName: 'Game 88' }
-        )
-
-        EventManager.getInstance().emit<LayoutRequestedEvent>(
-            UIEventTypes.LayoutRequested,
-            { layoutMode: 'arc' } as any
-        )
-
-        EventManager.getInstance().emit<PlacementIntentReadyEvent>(
-            GameRenderEventTypes.PlacementIntentReady,
-            {
-                appid: 88,
-                game: makeGame(88),
-                position: new THREE.Vector3(8, 0, 0),
-                rotation: new THREE.Quaternion(),
-            } as any
-        )
-
-        expect(resolved).toHaveLength(1)
-        expect(resolved[0]?.appid).toBe(88)
 
         coordinator.dispose()
     })

--- a/client/test/unit/scene/game-box/RenderIntentCoordinator.test.ts
+++ b/client/test/unit/scene/game-box/RenderIntentCoordinator.test.ts
@@ -5,7 +5,6 @@ import { EventManager } from '../../../../src/core/EventManager'
 import { RenderIntentCoordinator } from '../../../../src/scene/game-box/RenderIntentCoordinator'
 import {
     GameRenderEventTypes,
-    GameEventTypes,
     StorePropsEventTypes,
     type ArtworkIntentSettledEvent,
     type PlacementResolvedEvent,
@@ -99,7 +98,7 @@ describe('RenderIntentCoordinator', () => {
         coordinator.dispose()
     })
 
-    it('clears stale pending placement intents on SectionsReady run boundary', () => {
+    it('clears stale pending placement intents when run reset is requested explicitly', () => {
         const coordinator = new RenderIntentCoordinator()
         const resolved: PlacementResolvedEvent[] = []
 
@@ -118,11 +117,10 @@ describe('RenderIntentCoordinator', () => {
             } as any
         )
 
-        EventManager.getInstance().emit(GameEventTypes.SectionsReady, {
-            sections: [{ name: 'Run2', games: [], groupMode: 'genre', sortMode: 'name-asc' }],
-            groupMode: 'genre',
-            sortMode: 'name-asc',
-        } as any)
+        EventManager.getInstance().emit(
+            GameRenderEventTypes.PlacementRunResetRequested,
+            {}
+        )
 
         EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
             GameRenderEventTypes.ArtworkIntentSettled,
@@ -134,7 +132,7 @@ describe('RenderIntentCoordinator', () => {
         coordinator.dispose()
     })
 
-    it('preserves settled artwork across SectionsReady so replay can resolve', () => {
+    it('preserves settled artwork when run-reset clears pending placements', () => {
         const coordinator = new RenderIntentCoordinator()
         const resolved: PlacementResolvedEvent[] = []
 
@@ -148,11 +146,10 @@ describe('RenderIntentCoordinator', () => {
             { appid: 77, gameName: 'Game 77' }
         )
 
-        EventManager.getInstance().emit(GameEventTypes.SectionsReady, {
-            sections: [{ name: 'Run2', games: [], groupMode: 'genre', sortMode: 'name-asc' }],
-            groupMode: 'genre',
-            sortMode: 'name-asc',
-        } as any)
+        EventManager.getInstance().emit(
+            GameRenderEventTypes.PlacementRunResetRequested,
+            {}
+        )
 
         EventManager.getInstance().emit<PlacementIntentReadyEvent>(
             GameRenderEventTypes.PlacementIntentReady,
@@ -191,11 +188,10 @@ describe('RenderIntentCoordinator', () => {
         )
 
         // New run boundary: stale pending intents must be dropped before settlement.
-        EventManager.getInstance().emit(GameEventTypes.SectionsReady, {
-            sections: [{ name: 'Run2', games: [], groupMode: 'genre', sortMode: 'name-asc' }],
-            groupMode: 'genre',
-            sortMode: 'name-asc',
-        } as any)
+        EventManager.getInstance().emit(
+            GameRenderEventTypes.PlacementRunResetRequested,
+            {}
+        )
 
         EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
             GameRenderEventTypes.ArtworkIntentSettled,

--- a/client/test/unit/scene/game-box/RenderIntentCoordinator.test.ts
+++ b/client/test/unit/scene/game-box/RenderIntentCoordinator.test.ts
@@ -135,6 +135,41 @@ describe('RenderIntentCoordinator', () => {
         coordinator.dispose()
     })
 
+    it('preserves settled artwork across ArrangementRequested so replay can resolve', () => {
+        const coordinator = new RenderIntentCoordinator()
+        const resolved: PlacementResolvedEvent[] = []
+
+        EventManager.getInstance().registerEventHandler(
+            GameRenderEventTypes.PlacementResolved,
+            (event: CustomEvent<PlacementResolvedEvent>) => resolved.push(event.detail)
+        )
+
+        EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
+            GameRenderEventTypes.ArtworkIntentSettled,
+            { appid: 77, gameName: 'Game 77' }
+        )
+
+        EventManager.getInstance().emit<ArrangementRequestedEvent>(
+            UIEventTypes.ArrangementRequested,
+            { groupMode: 'genre', sortMode: 'name-asc' } as any
+        )
+
+        EventManager.getInstance().emit<PlacementIntentReadyEvent>(
+            GameRenderEventTypes.PlacementIntentReady,
+            {
+                appid: 77,
+                game: makeGame(77),
+                position: new THREE.Vector3(7, 0, 0),
+                rotation: new THREE.Quaternion(),
+            } as any
+        )
+
+        expect(resolved).toHaveLength(1)
+        expect(resolved[0]?.appid).toBe(77)
+
+        coordinator.dispose()
+    })
+
     it('does not replay stale intents after reset on re-sort, but resolves new intents', () => {
         const coordinator = new RenderIntentCoordinator()
         const resolved: PlacementResolvedEvent[] = []
@@ -215,6 +250,41 @@ describe('RenderIntentCoordinator', () => {
         )
 
         expect(resolved).toHaveLength(0)
+
+        coordinator.dispose()
+    })
+
+    it('preserves settled artwork across LayoutRequested so replay can resolve', () => {
+        const coordinator = new RenderIntentCoordinator()
+        const resolved: PlacementResolvedEvent[] = []
+
+        EventManager.getInstance().registerEventHandler(
+            GameRenderEventTypes.PlacementResolved,
+            (event: CustomEvent<PlacementResolvedEvent>) => resolved.push(event.detail)
+        )
+
+        EventManager.getInstance().emit<ArtworkIntentSettledEvent>(
+            GameRenderEventTypes.ArtworkIntentSettled,
+            { appid: 88, gameName: 'Game 88' }
+        )
+
+        EventManager.getInstance().emit<LayoutRequestedEvent>(
+            UIEventTypes.LayoutRequested,
+            { layoutMode: 'arc' } as any
+        )
+
+        EventManager.getInstance().emit<PlacementIntentReadyEvent>(
+            GameRenderEventTypes.PlacementIntentReady,
+            {
+                appid: 88,
+                game: makeGame(88),
+                position: new THREE.Vector3(8, 0, 0),
+                rotation: new THREE.Quaternion(),
+            } as any
+        )
+
+        expect(resolved).toHaveLength(1)
+        expect(resolved[0]?.appid).toBe(88)
 
         coordinator.dispose()
     })

--- a/client/test/unit/scene/gpu-game-box-renderer.fallback.test.ts
+++ b/client/test/unit/scene/gpu-game-box-renderer.fallback.test.ts
@@ -88,11 +88,10 @@ describe('GpuGameBoxRenderer — pure execution surface', () => {
         expect(labelAddInstanceSpy.mock.calls[1][1]).toBe('Game B')
     })
 
-    it('clearPlacements resets instanced label renderer', () => {
+    it('constructs and places label boxes without requiring a renderer clear API', () => {
         const renderer = new GpuGameBoxRenderer(10)
-        renderer.placeLabelBox({ appid: 1, name: 'Game A' } as any, new THREE.Vector3(0, 0, 0), new THREE.Quaternion())
-
-        // clearPlacements should not throw even after label boxes placed
-        expect(() => renderer.clearPlacements()).not.toThrow()
+        expect(() => {
+            renderer.placeLabelBox({ appid: 1, name: 'Game A' } as any, new THREE.Vector3(0, 0, 0), new THREE.Quaternion())
+        }).not.toThrow()
     })
 })

--- a/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
@@ -704,7 +704,7 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
     })
 
     describe('LayoutRequested — placement replay', () => {
-        it('does not clear placements until the next SectionsReady run starts', async () => {
+        it('clears placements immediately and replays on the next sections run', async () => {
             const games = createMockGamesWithArtwork(4, 0) as any[]
 
             eventManager.emit<BatchReadyForPlacementEvent>(
@@ -728,7 +728,9 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
 
             eventManager.emit(UIEventTypes.LayoutRequested, { layoutMode: 'grid' } as any)
 
-            expect(mockClearPlacements).not.toHaveBeenCalled()
+            expect(mockClearPlacements).toHaveBeenCalledTimes(1)
+
+            mockClearPlacements.mockClear()
 
             eventManager.emit<SectionsReadyEvent>(GameEventTypes.SectionsReady, {
                 sections: [{ name: 'Test', games: [...games].reverse() as any, groupMode: 'by-recency', sortMode: 'by-last-played' }],
@@ -747,6 +749,66 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
 
             expect(mockClearPlacements).toHaveBeenCalledTimes(1)
             expect(mockPlaceGame).toHaveBeenCalledTimes(4)
+        })
+
+        it('does not place against stale shelf positions after a layout switch', async () => {
+            const run1Game = createMockGamesWithArtwork(1, 0)[0] as any
+            const run2Game = createMockGamesWithArtwork(1, 1)[0] as any
+
+            eventManager.emit<BatchReadyForPlacementEvent>(
+                StorePropsEventTypes.BatchReadyForPlacement,
+                { games: [run1Game], batchIndex: 0, totalBatches: 1 }
+            )
+            await Promise.resolve()
+
+            eventManager.emit<SectionsReadyEvent>(GameEventTypes.SectionsReady, {
+                sections: [{ name: 'Run1', games: [run1Game], groupMode: 'by-recency', sortMode: 'by-last-played' }],
+                groupMode: 'by-recency',
+                sortMode: 'by-last-played',
+            })
+            eventManager.emit<ShelfReadyEvent>(StorePropsEventTypes.ShelfReady, makeShelfReady(0, new THREE.Vector3(0, 0, 0), 0, 0))
+            emitShelfLayoutDetermined(eventManager)
+            eventManager.emit<ArtworkIntentSettledEvent>(
+                GameRenderEventTypes.ArtworkIntentSettled,
+                { appid: run1Game.appid, gameName: run1Game.name }
+            )
+
+            expect(mockPlaceGame).toHaveBeenCalledTimes(1)
+
+            mockPlaceGame.mockClear()
+            mockClearPlacements.mockClear()
+
+            eventManager.emit(UIEventTypes.LayoutRequested, { layoutMode: 'grid' } as any)
+
+            eventManager.emit<BatchReadyForPlacementEvent>(
+                StorePropsEventTypes.BatchReadyForPlacement,
+                { games: [run2Game], batchIndex: 0, totalBatches: 1 }
+            )
+            await Promise.resolve()
+
+            eventManager.emit<SectionsReadyEvent>(GameEventTypes.SectionsReady, {
+                sections: [{ name: 'Run2', games: [run2Game], groupMode: 'by-recency', sortMode: 'by-last-played' }],
+                groupMode: 'by-recency',
+                sortMode: 'by-last-played',
+            })
+
+            eventManager.emit<ArtworkIntentSettledEvent>(
+                GameRenderEventTypes.ArtworkIntentSettled,
+                { appid: run2Game.appid, gameName: run2Game.name }
+            )
+
+            expect(mockClearPlacements).toHaveBeenCalledTimes(1)
+            expect(mockPlaceGame).toHaveBeenCalledTimes(0)
+
+            eventManager.emit<ShelfReadyEvent>(StorePropsEventTypes.ShelfReady, makeShelfReady(0, new THREE.Vector3(4, 0, 0), 0, 0))
+            emitShelfLayoutDetermined(eventManager)
+            eventManager.emit<ArtworkIntentSettledEvent>(
+                GameRenderEventTypes.ArtworkIntentSettled,
+                { appid: run2Game.appid, gameName: run2Game.name }
+            )
+
+            expect(mockPlaceGame).toHaveBeenCalledTimes(1)
+            expect(mockPlaceGame.mock.calls[0][0].appid).toBe(run2Game.appid)
         })
     })
 

--- a/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
@@ -47,7 +47,6 @@ vi.mock('../../../../src/scene/game-box/GpuGameBoxRenderer', async () => {
         GpuGameBoxRenderer: vi.fn().mockImplementation(function() {
             this.prefetchArtwork = mockPrefetchArtwork
             this.placeGame = mockPlaceGame
-            this.clearPlacements = vi.fn(() => mockClearPlacements())
             this.addToScene = vi.fn()
             this.updateLODForCamera = vi.fn()
             const coordinator = new ArtworkPrefetchCoordinator({ renderer: this })
@@ -177,6 +176,14 @@ function wireRenderIntentRendezvous(em: EventManager): () => void {
             pending.push(event.detail)
             pendingIntents.set(event.detail.appid, pending)
             flush(event.detail.appid)
+        }
+    )
+
+    em.registerEventHandler(
+        GameRenderEventTypes.PlacementRunResetRequested,
+        () => {
+            pendingIntents.clear()
+            mockClearPlacements()
         }
     )
 

--- a/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
+++ b/client/test/unit/scene/spawning/GameBoxSpawner.test.ts
@@ -699,7 +699,9 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
 
             eventManager.emit(UIEventTypes.ArrangementRequested, { groupMode: 'by-recency', sortMode: 'by-last-played' } as any)
             expect(mockRendererDispose).not.toHaveBeenCalled()
-            expect(mockClearPlacements).toHaveBeenCalled()
+            // clearPlacements is called inside placeSections() before new placement,
+            // not immediately on ArrangementRequested.
+            expect(mockClearPlacements).not.toHaveBeenCalled()
         })
     })
 
@@ -728,7 +730,9 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
 
             eventManager.emit(UIEventTypes.LayoutRequested, { layoutMode: 'grid' } as any)
 
-            expect(mockClearPlacements).toHaveBeenCalledTimes(1)
+            // clearPlacements is NOT called immediately on LayoutRequested — it fires
+            // atomically inside placeSections() just before new games are placed.
+            expect(mockClearPlacements).toHaveBeenCalledTimes(0)
 
             mockClearPlacements.mockClear()
 
@@ -797,7 +801,8 @@ describe('GameBoxSpawner — Two-Phase Load/Place', () => {
                 { appid: run2Game.appid, gameName: run2Game.name }
             )
 
-            expect(mockClearPlacements).toHaveBeenCalledTimes(1)
+            // clearPlacements not called yet — placement deferred until shelves arrive
+            expect(mockClearPlacements).toHaveBeenCalledTimes(0)
             expect(mockPlaceGame).toHaveBeenCalledTimes(0)
 
             eventManager.emit<ShelfReadyEvent>(StorePropsEventTypes.ShelfReady, makeShelfReady(0, new THREE.Vector3(4, 0, 0), 0, 0))


### PR DESCRIPTION
## Summary
- prevent layout-switch replay from running inside the same `LayoutRequested` dispatch
- preserve settled artwork state across arrangement/layout resets (clear pending intents only)
- avoid wiping freshly placed instances during geometry reset; placement clears atomically in `placeSections`
- update unit tests for spawner reset semantics and add coordinator coverage for arrangement/layout replay preservation

## Why
Switching group then layout could race reset and replay handlers in one synchronous event wave, causing stale clears and dropped placement outcomes.

## Validation
- `yarn vitest run --reporter=verbose test/unit/scene/spawning/GameBoxSpawner.test.ts test/unit/scene/game-box/RenderIntentCoordinator.test.ts`
- `yarn vitest run --config vitest.integration.config.ts test/integration/group-then-layout-placement.int.test.ts`

## Notes
This PR intentionally excludes temporary diagnostic logging and broader logging-policy changes.