### PR TITLE
Intermission: aisle interruption, runner alignment, and layout follow-ups

### DIFF
--- a/client/src/scene/PropRenderer.ts
+++ b/client/src/scene/PropRenderer.ts
@@ -33,6 +33,11 @@ export interface WireRackOptions {
   spacing?: number
 }
 
+export interface EntranceMatOptions {
+  width?: number
+  depth?: number
+}
+
 export class PropRenderer {
   public static logger = Logger.createLogFunctions(PropRenderer.name)
   private scene: THREE.Scene
@@ -280,13 +285,13 @@ export class PropRenderer {
   /**
    * Create entrance floor mat for visual entrance indication
    */
-  public createEntranceFloorMat(roomWidth: number, _roomDepth: number): THREE.Group {
+  public createEntranceFloorMat(roomWidth: number, roomDepth: number, options: EntranceMatOptions = {}): THREE.Group {
     const entranceGroup = new THREE.Group()
     entranceGroup.name = 'entrance-floor-mat'
     
-    // Create entrance mat geometry (will be positioned by caller)
-    const matWidth = Math.min(6, roomWidth * 0.4) // 40% of room width, max 6m
-    const matDepth = 1.5 // 1.5m deep entrance mat
+    // Aisle runner: narrow along X, long along Z (PlaneGeometry(w,h) + rotation.x=-PI/2 maps w→X, h→Z)
+    const matWidth = options.width ?? Math.min(3.2, roomWidth * 0.15)
+    const matDepth = options.depth ?? Math.min(10, roomDepth * 0.7)
     const matGeometry = new THREE.PlaneGeometry(matWidth, matDepth)
     
     // Create mat material with different color/texture

--- a/client/src/scene/ShelfSignPlanner.ts
+++ b/client/src/scene/ShelfSignPlanner.ts
@@ -22,6 +22,7 @@ import type { SectionsReadyEvent } from '../types/EnvironmentEvents'
 import { SceneSignManager, SignStyles } from './SceneSignManager'
 import type { SignMount } from './SignTypes'
 import { Logger } from '../utils/Logger'
+import type { LayoutMode } from '../types/LayoutTypes'
 
 export interface ShelfSignPlannerConfig {
     signYOffset?: number
@@ -31,6 +32,7 @@ export interface ShelfSignPlannerConfig {
 const SHELF_SIGN_Y_OFFSET = 2.02
 const SHELF_SIGN_MOUNT_STYLE: SignMount['style'] = 'above-shelf'
 const SHELF_SIGN_FRONT_OFFSET = 0.28
+const ROW_AISLE_MIN_GAP_METRES = 2.4
 export class ShelfSignPlanner {
     private static readonly logger = Logger.createLogFunctions(ShelfSignPlanner.name)
 
@@ -41,6 +43,7 @@ export class ShelfSignPlanner {
     private shelfRotations: number[] = []
     private shelfSectionIndices: number[] = []
     private pendingSections: SectionsReadyEvent | null = null
+    private activeLayoutMode: LayoutMode | null = null
     private readonly placedSignIdentifiers = new Set<string>()
 
     private buildSignIdentifier(sectionName: string, edge: 'start' | 'end'): string {
@@ -87,6 +90,7 @@ export class ShelfSignPlanner {
         this.shelfRotations = []
         this.shelfSectionIndices = []
         this.pendingSections = null
+        this.activeLayoutMode = null
         this.clearSigns()
         ShelfSignPlanner.logger.debug('Cleared shelf positions and signs (setup request)')
     }
@@ -96,6 +100,7 @@ export class ShelfSignPlanner {
         this.shelfRotations = []
         this.shelfSectionIndices = []
         this.pendingSections = null
+        this.activeLayoutMode = null
         this.clearSigns()
         ShelfSignPlanner.logger.debug('Cleared shelf positions and signs (library reload)')
     }
@@ -113,6 +118,8 @@ export class ShelfSignPlanner {
         if (!this.pendingSections) {
             return
         }
+
+        this.activeLayoutMode = _detail.layoutMode ?? null
 
         this.placeSignsForSections(this.pendingSections)
         this.pendingSections = null
@@ -183,9 +190,82 @@ export class ShelfSignPlanner {
             }
         }
 
+        if (this.activeLayoutMode === 'row') {
+            this.placeRowAisleEdgeSigns(sections)
+        }
+
         ShelfSignPlanner.logger.debug(
             `Placed ${this.placedSignIdentifiers.size} signs across ${sections.length} sections`
         )
+    }
+
+    private placeRowAisleEdgeSigns(sections: ReadonlyArray<{ name: string }>): void {
+        type RowAnchor = { shelfIndex: number; position: THREE.Vector3; rotationY: number }
+        const rowAnchorsByZ = new Map<number, RowAnchor[]>()
+
+        for (let shelfIndex = 0; shelfIndex < this.shelfPositions.length; shelfIndex++) {
+            const position = this.shelfPositions[shelfIndex]
+            if (!position) {
+                continue
+            }
+            const rowZKey = Math.round(position.z * 100)
+            const anchors = rowAnchorsByZ.get(rowZKey) ?? []
+            anchors.push({
+                shelfIndex,
+                position,
+                rotationY: this.shelfRotations[shelfIndex] ?? 0,
+            })
+            rowAnchorsByZ.set(rowZKey, anchors)
+        }
+
+        for (const [rowZKey, rowAnchors] of rowAnchorsByZ) {
+            const leftInnerAnchor = rowAnchors
+                .filter(anchor => anchor.position.x < 0)
+                .sort((a, b) => b.position.x - a.position.x)[0]
+            const rightInnerAnchor = rowAnchors
+                .filter(anchor => anchor.position.x > 0)
+                .sort((a, b) => a.position.x - b.position.x)[0]
+
+            if (!leftInnerAnchor || !rightInnerAnchor) {
+                continue
+            }
+
+            const aisleGapWidth = rightInnerAnchor.position.x - leftInnerAnchor.position.x
+            if (aisleGapWidth < ROW_AISLE_MIN_GAP_METRES) {
+                continue
+            }
+
+            this.placeRowAisleSignForAnchor(rowZKey, leftInnerAnchor, 'left', sections)
+            this.placeRowAisleSignForAnchor(rowZKey, rightInnerAnchor, 'right', sections)
+        }
+    }
+
+    private placeRowAisleSignForAnchor(
+        rowZKey: number,
+        anchor: { position: THREE.Vector3; rotationY: number },
+        side: 'left' | 'right',
+        sections: ReadonlyArray<{ name: string }>
+    ): void {
+        const sectionIndex = this.shelfSectionIndices[anchor.shelfIndex]
+        const sectionName = sections[sectionIndex]?.name
+        if (!sectionName || sectionName === 'Other') {
+            return
+        }
+
+        const uniqueIdentifier = `row-aisle-${rowZKey}-${side}`
+        this.signSystem.placeSign('canvas', {
+            uniqueIdentifier,
+            text: sectionName,
+            anchorPosition: anchor.position,
+            mount: {
+                style: this.config.signMountStyle,
+                yOffset: this.config.signYOffset,
+                frontOffset: SHELF_SIGN_FRONT_OFFSET,
+                signFacingY: anchor.rotationY,
+            },
+            style: { ...SignStyles.Category, fontSize: 0.12, padding: '0.05 0.08' },
+        })
+        this.placedSignIdentifiers.add(uniqueIdentifier)
     }
 
     private clearSigns(): void {
@@ -199,6 +279,7 @@ export class ShelfSignPlanner {
         this.shelfPositions = []
         this.shelfRotations = []
         this.shelfSectionIndices = []
+        this.activeLayoutMode = null
         this.clearSigns()
         this.signSystem.clearAll()
     }

--- a/client/src/scene/props/StorePropsCoordinator.ts
+++ b/client/src/scene/props/StorePropsCoordinator.ts
@@ -42,7 +42,11 @@ import { type LayoutMode } from '../../types/LayoutTypes'
 import { DataManager } from '../../core/data'
 import { ShelfLayoutCoordinator } from '../shelves/ShelfLayoutCoordinator'
 import { InstancedShelfRenderer } from '../instancing/InstancedShelfRenderer'
-import { PropRenderer } from '../PropRenderer'
+import { PropRenderer, type EntranceMatOptions } from '../PropRenderer'
+import { STORE_CENTER_AISLE_HALF_WIDTH_X } from './shared/ArcLayoutUtils'
+
+const ROW_CENTER_AISLE_WIDTH_X = 3.0
+const SPOKE_CENTER_RUNNER_WIDTH_X = 3.2
 
 class StorePropsCoordinator {
     private static readonly logger = Logger.createLogFunctions(StorePropsCoordinator.name)
@@ -185,11 +189,31 @@ class StorePropsCoordinator {
         }
 
         const propRenderer = new PropRenderer(this.scene)
-        this.entranceMat = propRenderer.createEntranceFloorMat(dimensions.width, dimensions.depth)
+        this.entranceMat = propRenderer.createEntranceFloorMat(
+            dimensions.width,
+            dimensions.depth,
+            this.buildEntranceMatOptions(dimensions)
+        )
         this.entranceMat.position.set(0, 0, 0)
         this.scene.add(this.entranceMat)
 
         StorePropsCoordinator.logger.debug('Entrance mat placed at origin')
+    }
+
+    private buildEntranceMatOptions(dimensions: { width: number; depth: number }): EntranceMatOptions {
+        const runnerWidthByLayout: Record<LayoutMode, number> = {
+            arc: STORE_CENTER_AISLE_HALF_WIDTH_X * 2,
+            row: ROW_CENTER_AISLE_WIDTH_X,
+            spoke: SPOKE_CENTER_RUNNER_WIDTH_X,
+        }
+
+        const runnerWidth = runnerWidthByLayout[this.activeLayoutMode] ?? ROW_CENTER_AISLE_WIDTH_X
+        const runnerDepth = Math.max(4.5, dimensions.depth * 0.92)
+
+        return {
+            width: runnerWidth,
+            depth: runnerDepth,
+        }
     }
 
     private handleLayoutRequested(detail: LayoutRequestedEvent): void {

--- a/client/src/scene/props/StorePropsCoordinator.ts
+++ b/client/src/scene/props/StorePropsCoordinator.ts
@@ -43,11 +43,8 @@ import { DataManager } from '../../core/data'
 import { ShelfLayoutCoordinator } from '../shelves/ShelfLayoutCoordinator'
 import { InstancedShelfRenderer } from '../instancing/InstancedShelfRenderer'
 import { PropRenderer, type EntranceMatOptions } from '../PropRenderer'
-import { STORE_CENTER_AISLE_HALF_WIDTH_X } from './shared/ArcLayoutUtils'
+import { AISLE_WIDTH_X } from './shared/LayoutAisleWidths'
 import { RoomConstants } from '../RoomManager'
-
-const ROW_CENTER_AISLE_WIDTH_X = 3.0
-const SPOKE_CENTER_RUNNER_WIDTH_X = 3.2
 
 class StorePropsCoordinator {
     private static readonly logger = Logger.createLogFunctions(StorePropsCoordinator.name)
@@ -210,13 +207,7 @@ class StorePropsCoordinator {
     }
 
     private buildEntranceMatOptions(dimensions: { width: number; depth: number }): EntranceMatOptions {
-        const runnerWidthByLayout: Record<LayoutMode, number> = {
-            arc: STORE_CENTER_AISLE_HALF_WIDTH_X * 2,
-            row: ROW_CENTER_AISLE_WIDTH_X,
-            spoke: SPOKE_CENTER_RUNNER_WIDTH_X,
-        }
-
-        const runnerWidth = runnerWidthByLayout[this.activeLayoutMode] ?? ROW_CENTER_AISLE_WIDTH_X
+        const runnerWidth = AISLE_WIDTH_X
         const runnerDepth = Math.max(4.5, dimensions.depth * 0.92)
 
         return {

--- a/client/src/scene/props/StorePropsCoordinator.ts
+++ b/client/src/scene/props/StorePropsCoordinator.ts
@@ -46,6 +46,10 @@ import { PropRenderer, type EntranceMatOptions } from '../PropRenderer'
 import { AISLE_WIDTH_X } from './shared/LayoutAisleWidths'
 import { RoomConstants } from '../RoomManager'
 
+const RUNNER_MIN_DEPTH_METRES = 4.5
+const RUNNER_MARGIN_RATIO_PER_SIDE = 0.01
+const PERCENT_BASE = 100
+
 class StorePropsCoordinator {
     private static readonly logger = Logger.createLogFunctions(StorePropsCoordinator.name)
 
@@ -208,12 +212,17 @@ class StorePropsCoordinator {
 
     private buildEntranceMatOptions(dimensions: { width: number; depth: number }): EntranceMatOptions {
         const runnerWidth = AISLE_WIDTH_X
-        const runnerDepth = Math.max(4.5, dimensions.depth * 0.92)
+        const runnerDepth = this.getRunnerDepthMetres(dimensions.depth)
 
         return {
             width: runnerWidth,
             depth: runnerDepth,
         }
+    }
+
+    private getRunnerDepthMetres(roomDepthMetres: number): number {
+        const runnerDepthRatio = (PERCENT_BASE - (2 * RUNNER_MARGIN_RATIO_PER_SIDE * PERCENT_BASE)) / PERCENT_BASE
+        return Math.max(RUNNER_MIN_DEPTH_METRES, roomDepthMetres * runnerDepthRatio)
     }
 
     private handleLayoutRequested(detail: LayoutRequestedEvent): void {

--- a/client/src/scene/props/StorePropsCoordinator.ts
+++ b/client/src/scene/props/StorePropsCoordinator.ts
@@ -44,6 +44,7 @@ import { ShelfLayoutCoordinator } from '../shelves/ShelfLayoutCoordinator'
 import { InstancedShelfRenderer } from '../instancing/InstancedShelfRenderer'
 import { PropRenderer, type EntranceMatOptions } from '../PropRenderer'
 import { STORE_CENTER_AISLE_HALF_WIDTH_X } from './shared/ArcLayoutUtils'
+import { RoomConstants } from '../RoomManager'
 
 const ROW_CENTER_AISLE_WIDTH_X = 3.0
 const SPOKE_CENTER_RUNNER_WIDTH_X = 3.2
@@ -165,6 +166,11 @@ class StorePropsCoordinator {
 
     private async handleRoomResized(event: CustomEvent<RoomResizedEvent>): Promise<void> {
         const { dimensions } = event.detail
+        const roomWorldOffsetX = event.detail.centerOffset?.x ?? 0
+        const roomWorldOffsetY = event.detail.centerOffset?.y ?? 0
+        const roomWorldOffsetZ = event.detail.centerOffset
+            ? event.detail.centerOffset.z + RoomConstants.STORE_FRONT_OFFSET
+            : 0
 
         if (!this.scene) {
             this.scene = DataManager.getInstance().get<THREE.Scene>('core.mainScene')
@@ -178,7 +184,10 @@ class StorePropsCoordinator {
         // Guard: skip if dimensions haven't changed — avoids creating duplicate
         // PropRenderer instances and leaking materials on repeated room:resized events.
         if (this.entranceMat?.scale.x === dimensions.width &&
-            this.entranceMat.scale.z === dimensions.depth) {
+            this.entranceMat.scale.z === dimensions.depth &&
+            this.entranceMat.position.x === roomWorldOffsetX &&
+            this.entranceMat.position.y === roomWorldOffsetY &&
+            this.entranceMat.position.z === roomWorldOffsetZ) {
             StorePropsCoordinator.logger.debug('Room dimensions unchanged — skipping entrance mat recreation')
             return
         }
@@ -194,7 +203,7 @@ class StorePropsCoordinator {
             dimensions.depth,
             this.buildEntranceMatOptions(dimensions)
         )
-        this.entranceMat.position.set(0, 0, 0)
+        this.entranceMat.position.set(roomWorldOffsetX, roomWorldOffsetY, roomWorldOffsetZ)
         this.scene.add(this.entranceMat)
 
         StorePropsCoordinator.logger.debug('Entrance mat placed at origin')

--- a/client/src/scene/props/shared/ArcLayoutUtils.ts
+++ b/client/src/scene/props/shared/ArcLayoutUtils.ts
@@ -20,6 +20,7 @@ import type { BoardSurfacePair, IStockStrategy } from './StockStrategy'
 import type { StockSurface } from '../../../types/LayoutTypes'
 import type { ISectionAwareLayoutDefinition } from './ILayoutDefinition'
 import type { ShelfInfo, Section, SectionShelfInfo } from '../../../types/LayoutTypes'
+import { AISLE_HALF_WIDTH_X } from './LayoutAisleWidths'
 
 /**
  * ArcStockStrategy
@@ -90,13 +91,7 @@ const DEFAULTS: Required<Pick<ArcLayoutConfig, 'rows' | 'shelvesPerRow' | 'rowRa
 
 const DEFAULT_CENTER_AISLE_HALF_ANGLE = 0
 const STORE_ROW_RADIUS_STEP_METRES = 4.0
-const STORE_CENTER_AISLE_WIDTH_MULTIPLIER = 1.25
-export const STORE_CENTER_AISLE_HALF_WIDTH_X = (STORE_ROW_RADIUS_STEP_METRES * STORE_CENTER_AISLE_WIDTH_MULTIPLIER) / 2
 const ARC_ROW_SPREAD_SCALE = 0.8
-
-function lerp(start: number, end: number, t: number): number {
-    return start + (end - start) * t
-}
 
 function buildArcRowAngles(count: number, halfAngle: number, centerAisleHalfAngle: number): number[] {
     if (count <= 0) {
@@ -112,8 +107,8 @@ function buildArcRowAngles(count: number, halfAngle: number, centerAisleHalfAngl
     if (usableHalfAngle <= 0) {
         return Array.from({ length: count }, (_, index) => {
             if (count === 1) return 0
-            const t = index / (count - 1)
-            return lerp(-halfAngle, halfAngle, t)
+            const interpolationFactor = index / (count - 1)
+            return THREE.MathUtils.lerp(-halfAngle, halfAngle, interpolationFactor)
         })
     }
 
@@ -122,13 +117,13 @@ function buildArcRowAngles(count: number, halfAngle: number, centerAisleHalfAngl
     const angles: number[] = []
 
     for (let index = 0; index < leftCount; index++) {
-        const t = leftCount === 1 ? 0.5 : index / (leftCount - 1)
-        angles.push(lerp(-halfAngle, -usableHalfAngle, t))
+        const interpolationFactor = leftCount === 1 ? 0.5 : index / (leftCount - 1)
+        angles.push(THREE.MathUtils.lerp(-halfAngle, -usableHalfAngle, interpolationFactor))
     }
 
     for (let index = 0; index < rightCount; index++) {
-        const t = rightCount === 1 ? 0.5 : index / (rightCount - 1)
-        angles.push(lerp(usableHalfAngle, halfAngle, t))
+        const interpolationFactor = rightCount === 1 ? 0.5 : index / (rightCount - 1)
+        angles.push(THREE.MathUtils.lerp(usableHalfAngle, halfAngle, interpolationFactor))
     }
 
     return angles
@@ -316,7 +311,7 @@ export function computeStoreArcShelfLayout(totalShelves: number): ArcShelfInfo[]
         minShelfGap: 1.0,
         rowRadiusStep: STORE_ROW_RADIUS_STEP_METRES,
         firstRowRadius: 5.5,
-        centerAisleHalfWidthX: STORE_CENTER_AISLE_HALF_WIDTH_X,
+        centerAisleHalfWidthX: AISLE_HALF_WIDTH_X,
     }
     return computeArcShelfLayout(totalShelves, config)
 }
@@ -348,7 +343,7 @@ function computeArcShelvesForSections(sections: ReadonlyArray<Section>): Section
         rowRadiusStep: ringBands.rowRadiusStep,
         minShelfGap: 1.0,
         shelfWidthMetres: 2.0,
-        centerAisleHalfWidthX: STORE_CENTER_AISLE_HALF_WIDTH_X,
+        centerAisleHalfWidthX: AISLE_HALF_WIDTH_X,
     })
 
     // Map each physical shelf back to its original (unsorted) section index

--- a/client/src/scene/props/shared/ArcLayoutUtils.ts
+++ b/client/src/scene/props/shared/ArcLayoutUtils.ts
@@ -92,13 +92,15 @@ const DEFAULTS: Required<Pick<ArcLayoutConfig, 'rows' | 'shelvesPerRow' | 'rowRa
 const DEFAULT_CENTER_AISLE_HALF_ANGLE = 0
 const STORE_ROW_RADIUS_STEP_METRES = 4.0
 const ARC_ROW_SPREAD_SCALE = 0.8
+const MIN_HALF_ANGLE_CLEARANCE = 0.01
+const ASIN_RATIO_MAX = 0.99
 
 function buildArcRowAngles(count: number, halfAngle: number, centerAisleHalfAngle: number): number[] {
     if (count <= 0) {
         return []
     }
 
-    const usableHalfAngle = Math.max(0, Math.min(centerAisleHalfAngle, halfAngle - 0.01))
+    const usableHalfAngle = Math.max(0, Math.min(centerAisleHalfAngle, halfAngle - MIN_HALF_ANGLE_CLEARANCE))
 
     if (count === 1) {
         return [usableHalfAngle > 0 ? usableHalfAngle : 0]
@@ -138,7 +140,7 @@ function deriveCenterAisleHalfAngleForRow(
         return Math.max(0, fallbackHalfAngle)
     }
 
-    const ratio = Math.min(0.99, centerAisleHalfWidthX / radius)
+    const ratio = Math.min(ASIN_RATIO_MAX, centerAisleHalfWidthX / radius)
     const widthDerivedHalfAngle = Math.asin(ratio)
     return Math.max(widthDerivedHalfAngle, fallbackHalfAngle)
 }

--- a/client/src/scene/props/shared/ArcLayoutUtils.ts
+++ b/client/src/scene/props/shared/ArcLayoutUtils.ts
@@ -94,6 +94,7 @@ const STORE_ROW_RADIUS_STEP_METRES = 4.0
 const ARC_ROW_SPREAD_SCALE = 0.8
 const MIN_HALF_ANGLE_CLEARANCE = 0.01
 const ASIN_RATIO_MAX = 0.99
+const DEFAULT_SHELF_HALF_WIDTH_X = 1.0  // 2.0m shelf / 2
 
 function buildArcRowAngles(count: number, halfAngle: number, centerAisleHalfAngle: number): number[] {
     if (count <= 0) {
@@ -313,7 +314,7 @@ export function computeStoreArcShelfLayout(totalShelves: number): ArcShelfInfo[]
         minShelfGap: 1.0,
         rowRadiusStep: STORE_ROW_RADIUS_STEP_METRES,
         firstRowRadius: 5.5,
-        centerAisleHalfWidthX: AISLE_HALF_WIDTH_X,
+        centerAisleHalfWidthX: AISLE_HALF_WIDTH_X + DEFAULT_SHELF_HALF_WIDTH_X,
     }
     return computeArcShelfLayout(totalShelves, config)
 }
@@ -345,7 +346,7 @@ function computeArcShelvesForSections(sections: ReadonlyArray<Section>): Section
         rowRadiusStep: ringBands.rowRadiusStep,
         minShelfGap: 1.0,
         shelfWidthMetres: 2.0,
-        centerAisleHalfWidthX: AISLE_HALF_WIDTH_X,
+        centerAisleHalfWidthX: AISLE_HALF_WIDTH_X + DEFAULT_SHELF_HALF_WIDTH_X,
     })
 
     // Map each physical shelf back to its original (unsorted) section index

--- a/client/src/scene/props/shared/ArcLayoutUtils.ts
+++ b/client/src/scene/props/shared/ArcLayoutUtils.ts
@@ -51,6 +51,15 @@ export interface ArcLayoutConfig {
     halfAngle?: number
     /** Optional per-row half-angle overrides (radians). */
     halfAngleByRow?: number[]
+    /** Half-angle of a central aisle interruption in radians. Default PI/18 (~10 deg). */
+    centerAisleHalfAngle?: number
+    /** Optional per-row central aisle half-angle overrides (radians). */
+    centerAisleHalfAngleByRow?: number[]
+    /**
+     * Half-width of the center bisection corridor on X (metres).
+     * If provided, rows reserve |x| < centerAisleHalfWidthX.
+     */
+    centerAisleHalfWidthX?: number
     /** Physical width of one shelf unit in metres (used with minShelfGap). Default 2.0. */
     shelfWidthMetres?: number
     /**
@@ -79,6 +88,66 @@ const DEFAULTS: Required<Pick<ArcLayoutConfig, 'rows' | 'shelvesPerRow' | 'rowRa
     halfAngle: Math.PI / 3, // 60 deg each side
 }
 
+const DEFAULT_CENTER_AISLE_HALF_ANGLE = 0
+const STORE_ROW_RADIUS_STEP_METRES = 4.0
+const STORE_CENTER_AISLE_WIDTH_MULTIPLIER = 1.25
+export const STORE_CENTER_AISLE_HALF_WIDTH_X = (STORE_ROW_RADIUS_STEP_METRES * STORE_CENTER_AISLE_WIDTH_MULTIPLIER) / 2
+const ARC_ROW_SPREAD_SCALE = 0.8
+
+function lerp(start: number, end: number, t: number): number {
+    return start + (end - start) * t
+}
+
+function buildArcRowAngles(count: number, halfAngle: number, centerAisleHalfAngle: number): number[] {
+    if (count <= 0) {
+        return []
+    }
+
+    const usableHalfAngle = Math.max(0, Math.min(centerAisleHalfAngle, halfAngle - 0.01))
+
+    if (count === 1) {
+        return [usableHalfAngle > 0 ? usableHalfAngle : 0]
+    }
+
+    if (usableHalfAngle <= 0) {
+        return Array.from({ length: count }, (_, index) => {
+            if (count === 1) return 0
+            const t = index / (count - 1)
+            return lerp(-halfAngle, halfAngle, t)
+        })
+    }
+
+    const leftCount = Math.ceil(count / 2)
+    const rightCount = count - leftCount
+    const angles: number[] = []
+
+    for (let index = 0; index < leftCount; index++) {
+        const t = leftCount === 1 ? 0.5 : index / (leftCount - 1)
+        angles.push(lerp(-halfAngle, -usableHalfAngle, t))
+    }
+
+    for (let index = 0; index < rightCount; index++) {
+        const t = rightCount === 1 ? 0.5 : index / (rightCount - 1)
+        angles.push(lerp(usableHalfAngle, halfAngle, t))
+    }
+
+    return angles
+}
+
+function deriveCenterAisleHalfAngleForRow(
+    radius: number,
+    centerAisleHalfWidthX: number | undefined,
+    fallbackHalfAngle: number
+): number {
+    if (!centerAisleHalfWidthX || centerAisleHalfWidthX <= 0 || radius <= 0) {
+        return Math.max(0, fallbackHalfAngle)
+    }
+
+    const ratio = Math.min(0.99, centerAisleHalfWidthX / radius)
+    const widthDerivedHalfAngle = Math.asin(ratio)
+    return Math.max(widthDerivedHalfAngle, fallbackHalfAngle)
+}
+
 /**
  * Build a per-row shelf config so each section maps to a contiguous band of complete rings.
  *
@@ -99,8 +168,8 @@ function buildRingBandsForSections(
     rowRadiusStep: number
 } {
     const FIRST_ROW_RADIUS = 5.5
-    const ROW_RADIUS_STEP = 4.0
-    const HALF_ANGLE = Math.PI / 3      // 60° each side = 120° arc span
+    const ROW_RADIUS_STEP = STORE_ROW_RADIUS_STEP_METRES
+    const HALF_ANGLE = (Math.PI / 3) * ARC_ROW_SPREAD_SCALE
     const MIN_GAP = 1.0
     const SHELF_WIDTH = 2.0
 
@@ -184,12 +253,18 @@ export function computeArcShelfLayout(
         // Clamp to how many shelves we'll actually place in this row so the
         // placed shelves are centred at angle=0 rather than bunched to one side.
         const actualCount = Math.min(count, totalShelves - shelfIndex)
+        const rowCenterAisleHalfAngle = cfg.centerAisleHalfAngleByRow?.[row]
+            ?? cfg.centerAisleHalfAngle
+            ?? DEFAULT_CENTER_AISLE_HALF_ANGLE
+        const effectiveCenterAisleHalfAngle = deriveCenterAisleHalfAngleForRow(
+            radius,
+            cfg.centerAisleHalfWidthX,
+            rowCenterAisleHalfAngle
+        )
+        const rowAngles = buildArcRowAngles(actualCount, rowHalfAngle, effectiveCenterAisleHalfAngle)
 
-        for (let i = 0; i < count && shelfIndex < totalShelves; i++) {
-            // Spread shelves evenly across the arc span, using actualCount for
-            // spacing so a partial row stays centred (not left-justified).
-            const t = actualCount === 1 ? 0 : (i / (actualCount - 1)) - 0.5   // -0.5 .. +0.5
-            const angle = t * 2 * rowHalfAngle                     // -halfAngle .. +halfAngle
+        for (let i = 0; i < rowAngles.length && shelfIndex < totalShelves; i++) {
+            const angle = rowAngles[i]
 
             // Arc is in the -Z half-space (in front of player)
             // angle = 0 means straight ahead (-Z axis), positive angle = left, negative = right
@@ -232,15 +307,16 @@ export function computeStoreArcShelfLayout(totalShelves: number): ArcShelfInfo[]
             Math.max(1, totalShelves - STORE_ARC_FIXED_ROWS_COUNT),
         ],
         halfAngleByRow: [
-            Math.PI / 3.5,
-            Math.PI / 3.5,
-            Math.PI / 3,
-            Math.PI / 3,
-            Math.PI / 2.6,
+            (Math.PI / 3.5) * ARC_ROW_SPREAD_SCALE,
+            (Math.PI / 3.5) * ARC_ROW_SPREAD_SCALE,
+            (Math.PI / 3) * ARC_ROW_SPREAD_SCALE,
+            (Math.PI / 3) * ARC_ROW_SPREAD_SCALE,
+            (Math.PI / 2.6) * ARC_ROW_SPREAD_SCALE,
         ],
         minShelfGap: 1.0,
-        rowRadiusStep: 4.0,
+        rowRadiusStep: STORE_ROW_RADIUS_STEP_METRES,
         firstRowRadius: 5.5,
+        centerAisleHalfWidthX: STORE_CENTER_AISLE_HALF_WIDTH_X,
     }
     return computeArcShelfLayout(totalShelves, config)
 }
@@ -272,6 +348,7 @@ function computeArcShelvesForSections(sections: ReadonlyArray<Section>): Section
         rowRadiusStep: ringBands.rowRadiusStep,
         minShelfGap: 1.0,
         shelfWidthMetres: 2.0,
+        centerAisleHalfWidthX: STORE_CENTER_AISLE_HALF_WIDTH_X,
     })
 
     // Map each physical shelf back to its original (unsorted) section index

--- a/client/src/scene/props/shared/LayoutAisleWidths.ts
+++ b/client/src/scene/props/shared/LayoutAisleWidths.ts
@@ -1,0 +1,2 @@
+export const AISLE_WIDTH_X = 3.2
+export const AISLE_HALF_WIDTH_X = AISLE_WIDTH_X / 2

--- a/client/src/scene/props/shared/RowLayoutUtils.ts
+++ b/client/src/scene/props/shared/RowLayoutUtils.ts
@@ -19,6 +19,7 @@ import type { BoardSurfacePair, IStockStrategy } from './StockStrategy'
 import type { StockSurface } from '../../../types/LayoutTypes'
 import type { ISectionAwareLayoutDefinition } from './ILayoutDefinition'
 import type { ShelfInfo, Section, SectionShelfInfo } from '../../../types/LayoutTypes'
+import { AISLE_WIDTH_X } from './LayoutAisleWidths'
 
 /**
  * RowStockStrategy
@@ -74,7 +75,7 @@ const ROW_DEFAULTS: Required<RowLayoutConfig> = {
     rowSpacingZ: 4.0,
     firstRowZ: 4.0,
     maxRows: 8,
-    centralAisleWidthX: 3.0,
+    centralAisleWidthX: AISLE_WIDTH_X,
 }
 
 function ensureEven(count: number): number {

--- a/client/src/scene/props/shared/RowLayoutUtils.ts
+++ b/client/src/scene/props/shared/RowLayoutUtils.ts
@@ -60,6 +60,12 @@ export interface RowLayoutConfig {
      * Default: 8.
      */
     maxRows?: number
+    /**
+     * Width of the central walkable aisle (metres, along X).
+     * Shelf centres are shifted away from X=0 to preserve this gap.
+     * Default: 3.0.
+     */
+    centralAisleWidthX?: number
 }
 
 const ROW_DEFAULTS: Required<RowLayoutConfig> = {
@@ -68,18 +74,44 @@ const ROW_DEFAULTS: Required<RowLayoutConfig> = {
     rowSpacingZ: 4.0,
     firstRowZ: 4.0,
     maxRows: 8,
+    centralAisleWidthX: 3.0,
+}
+
+function ensureEven(count: number): number {
+    return count % 2 === 0 ? count : count + 1
+}
+
+function computeAisleShiftedX(
+    colIndex: number,
+    shelvesPerRow: number,
+    shelfSpacingX: number,
+    centralAisleWidthX: number
+): number {
+    const totalWidth = (shelvesPerRow - 1) * shelfSpacingX
+    const baseX = -totalWidth / 2 + colIndex * shelfSpacingX
+    const aisleHalfWidth = centralAisleWidthX / 2
+
+    if (baseX < 0) {
+        return baseX - aisleHalfWidth
+    }
+    if (baseX > 0) {
+        return baseX + aisleHalfWidth
+    }
+    return baseX - aisleHalfWidth
 }
 
 function deriveRowLayoutConfigFromSectionCounts(sections: ReadonlyArray<Section>): RowLayoutConfig {
     const sectionShelfCounts = sections.map(section => Math.max(1, Math.ceil(section.games.length / 18)))
     const maxShelvesInAnySection = Math.max(1, ...sectionShelfCounts)
+    const dynamicShelvesPerRow = Math.max(8, Math.ceil(Math.sqrt(maxShelvesInAnySection) * 2.6))
 
     return {
-        shelvesPerRow: Math.max(8, Math.ceil(Math.sqrt(maxShelvesInAnySection) * 2.6)),
+        shelvesPerRow: ensureEven(dynamicShelvesPerRow),
         shelfSpacingX: Math.max(2.5, 2.2 + maxShelvesInAnySection * 0.015),
         rowSpacingZ: Math.max(4.0, 3.5 + maxShelvesInAnySection * 0.02),
         firstRowZ: ROW_DEFAULTS.firstRowZ,
         maxRows: Math.max(ROW_DEFAULTS.maxRows, Math.ceil(maxShelvesInAnySection / 2) + 2),
+        centralAisleWidthX: ROW_DEFAULTS.centralAisleWidthX,
     }
 }
 
@@ -103,17 +135,21 @@ export function computeRowShelfLayout(
     config: RowLayoutConfig = {}
 ): RowShelfInfo[] {
     const cfg = { ...ROW_DEFAULTS, ...config }
+    const shelvesPerRow = ensureEven(Math.max(2, cfg.shelvesPerRow))
     const result: RowShelfInfo[] = []
     let placed = 0
 
     for (let row = 0; row < cfg.maxRows && placed < totalShelves; row++) {
         const z = -(cfg.firstRowZ + row * cfg.rowSpacingZ)
-        const actualCount = Math.min(cfg.shelvesPerRow, totalShelves - placed)
-        const totalWidth = (cfg.shelvesPerRow - 1) * cfg.shelfSpacingX
-        const startX = -totalWidth / 2
+        const actualCount = Math.min(shelvesPerRow, totalShelves - placed)
 
         for (let col = 0; col < actualCount; col++) {
-            const x = startX + col * cfg.shelfSpacingX
+            const x = computeAisleShiftedX(
+                col,
+                shelvesPerRow,
+                cfg.shelfSpacingX,
+                cfg.centralAisleWidthX
+            )
             result.push({
                 position: new THREE.Vector3(x, 0, z),
                 rotationY: 0, // faces -Z, toward player

--- a/client/src/scene/props/shared/SpokeLayoutUtils.ts
+++ b/client/src/scene/props/shared/SpokeLayoutUtils.ts
@@ -54,6 +54,12 @@ export interface SpokeLayoutConfig {
      */
     firstSpokeAngleOffset?: number
     /**
+     * When true, default spoke angles avoid the central aisle axis (X=0 corridor)
+     * by centering spoke gaps on the +Z/-Z axis. Explicit firstSpokeAngleOffset wins.
+     * Default: true.
+     */
+    avoidCentralAisleAxis?: boolean
+    /**
      * Distance from origin to the first shelf pair on each spoke (metres).
      * Should be large enough to leave a walkable open hub area. Default: 4.
      */
@@ -70,18 +76,65 @@ export interface SpokeLayoutConfig {
     shelfSpacingMetres?: number
     /**
      * Lateral offset from the spoke centreline to each shelf row (metres).
-     * Shelf fronts (Near surfaces) face the aisle at this distance. Default: 1.5.
+     * Shelf fronts (Near surfaces) face the aisle at this distance. Default: 1.8.
      */
     aisleHalfWidthMetres?: number
+    /**
+     * Half-width of the global entrance runner aisle on X (metres).
+     * Shelves are shifted so |x| stays outside this corridor.
+     * Default: 1.6.
+     */
+    centerRunnerHalfWidthX?: number
 }
 
 const SPOKE_DEFAULTS: Required<SpokeLayoutConfig> = {
     spokeCount: 4,
     firstSpokeAngleOffset: -Math.PI / 2 + Math.PI / 8, // 22.5° bias off cardinal axes
+    avoidCentralAisleAxis: true,
     hubClearanceMetres: 4,
     shelvesPerSpoke: 6,
     shelfSpacingMetres: 2.5,
-    aisleHalfWidthMetres: 1.5,
+    aisleHalfWidthMetres: 1.8,
+    centerRunnerHalfWidthX: 1.6,
+}
+
+const DEFAULT_SHELF_HALF_WIDTH_X = 1.0
+
+function enforceCenterRunnerAisleX(
+    position: THREE.Vector3,
+    halfWidth: number,
+    shelfHalfWidthX: number,
+    spokeDirX: number,
+): THREE.Vector3 {
+    if (halfWidth <= 0) {
+        return position
+    }
+
+    const absX = Math.abs(position.x)
+    const minimumShelfCenterAbsX = halfWidth + Math.max(0, shelfHalfWidthX)
+    if (absX >= minimumShelfCenterAbsX) {
+        return position
+    }
+
+    const dominantSide = Math.abs(position.x) > 0.0001
+        ? Math.sign(position.x)
+        : (Math.sign(spokeDirX) || 1)
+
+    return new THREE.Vector3(dominantSide * minimumShelfCenterAbsX, position.y, position.z)
+}
+
+function deriveFirstSpokeAngleOffset(config: SpokeLayoutConfig, spokeCount: number): number {
+    if (config.firstSpokeAngleOffset !== undefined) {
+        return config.firstSpokeAngleOffset
+    }
+
+    if (!config.avoidCentralAisleAxis && config.avoidCentralAisleAxis !== undefined) {
+        return SPOKE_DEFAULTS.firstSpokeAngleOffset
+    }
+
+    const angleStep = (2 * Math.PI) / Math.max(1, spokeCount)
+    // Spokes are centered between +Z and -Z so the central aisle axis remains clear.
+    return angleStep / 2
 }
 
 function deriveSpokeSpacingFromSectionCounts(
@@ -134,9 +187,10 @@ export function computeSpokeShelfLayout(
     const result: SpokeShelfInfo[] = []
 
     const angleStep = (2 * Math.PI) / cfg.spokeCount
+    const firstSpokeAngleOffset = deriveFirstSpokeAngleOffset(cfg, cfg.spokeCount)
 
     for (let spokeIndex = 0; spokeIndex < cfg.spokeCount; spokeIndex++) {
-        const spokeAngle = cfg.firstSpokeAngleOffset + spokeIndex * angleStep
+        const spokeAngle = firstSpokeAngleOffset + spokeIndex * angleStep
 
         // Unit vector along the spoke (outward from hub)
         const spokeDir = new THREE.Vector3(Math.cos(spokeAngle), 0, Math.sin(spokeAngle))
@@ -152,6 +206,12 @@ export function computeSpokeShelfLayout(
                 const lateralSign = side === 'left' ? 1 : -1
                 const shelfCentre = centrePoint.clone()
                     .addScaledVector(perpDir, lateralSign * cfg.aisleHalfWidthMetres)
+                const adjustedShelfCentre = enforceCenterRunnerAisleX(
+                    shelfCentre,
+                    cfg.centerRunnerHalfWidthX,
+                    DEFAULT_SHELF_HALF_WIDTH_X,
+                    spokeDir.x,
+                )
 
                 // Shelf Near face must face the aisle (toward centreline).
                 // Left row faces right (-perpDir), right row faces left (+perpDir).
@@ -161,7 +221,7 @@ export function computeSpokeShelfLayout(
                 const rotationY = Math.atan2(facingDir.x, facingDir.z)
 
                 result.push({
-                    position: shelfCentre.clone(),
+                    position: adjustedShelfCentre,
                     rotationY,
                     spokeIndex,
                     positionIndex,

--- a/client/src/scene/props/shared/SpokeLayoutUtils.ts
+++ b/client/src/scene/props/shared/SpokeLayoutUtils.ts
@@ -27,6 +27,7 @@ import type { BoardSurfacePair, IStockStrategy } from './StockStrategy'
 import type { StockSurface } from '../../../types/LayoutTypes'
 import type { ISectionAwareLayoutDefinition } from './ILayoutDefinition'
 import type { ShelfInfo, SectionShelfInfo, Section } from '../../../types/LayoutTypes'
+import { AISLE_HALF_WIDTH_X } from './LayoutAisleWidths'
 
 /**
  * SpokeStockStrategy
@@ -55,8 +56,8 @@ export interface SpokeLayoutConfig {
     firstSpokeAngleOffset?: number
     /**
      * When true, default spoke angles avoid the central aisle axis (X=0 corridor)
-     * by centering spoke gaps on the +Z/-Z axis. Explicit firstSpokeAngleOffset wins.
-     * Default: true.
+        * by centering spoke gaps on the +Z/-Z axis. Explicit firstSpokeAngleOffset wins.
+        * Default: derived from centerRunnerHalfWidthX > 0.
      */
     avoidCentralAisleAxis?: boolean
     /**
@@ -87,15 +88,22 @@ export interface SpokeLayoutConfig {
     centerRunnerHalfWidthX?: number
 }
 
+const DEFAULT_SPOKE_COUNT = 4
+const DEFAULT_FIRST_SPOKE_ANGLE_OFFSET = -Math.PI / 2 + Math.PI / 8
+const DEFAULT_HUB_CLEARANCE_METRES = 4
+const DEFAULT_SHELVES_PER_SPOKE = 6
+const DEFAULT_SHELF_SPACING_METRES = 2.5
+const DEFAULT_AISLE_HALF_WIDTH_METRES = 1.8
+
 const SPOKE_DEFAULTS: Required<SpokeLayoutConfig> = {
-    spokeCount: 4,
-    firstSpokeAngleOffset: -Math.PI / 2 + Math.PI / 8, // 22.5° bias off cardinal axes
+    spokeCount: DEFAULT_SPOKE_COUNT,
+    firstSpokeAngleOffset: DEFAULT_FIRST_SPOKE_ANGLE_OFFSET,
     avoidCentralAisleAxis: true,
-    hubClearanceMetres: 4,
-    shelvesPerSpoke: 6,
-    shelfSpacingMetres: 2.5,
-    aisleHalfWidthMetres: 1.8,
-    centerRunnerHalfWidthX: 1.6,
+    hubClearanceMetres: DEFAULT_HUB_CLEARANCE_METRES,
+    shelvesPerSpoke: DEFAULT_SHELVES_PER_SPOKE,
+    shelfSpacingMetres: DEFAULT_SHELF_SPACING_METRES,
+    aisleHalfWidthMetres: DEFAULT_AISLE_HALF_WIDTH_METRES,
+    centerRunnerHalfWidthX: AISLE_HALF_WIDTH_X,
 }
 
 const DEFAULT_SHELF_HALF_WIDTH_X = 1.0
@@ -128,7 +136,10 @@ function deriveFirstSpokeAngleOffset(config: SpokeLayoutConfig, spokeCount: numb
         return config.firstSpokeAngleOffset
     }
 
-    if (!config.avoidCentralAisleAxis && config.avoidCentralAisleAxis !== undefined) {
+    const shouldAvoidCentralAisleAxis = config.avoidCentralAisleAxis
+        ?? (config.centerRunnerHalfWidthX ?? 0) > 0
+
+    if (!shouldAvoidCentralAisleAxis) {
         return SPOKE_DEFAULTS.firstSpokeAngleOffset
     }
 
@@ -259,6 +270,7 @@ function computeSpokeShelvesByTotal(totalShelves: number): ShelfInfo[] {
         computeSpokeShelfLayout({
             spokeCount: defaultSpokeCount,
             shelvesPerSpoke: shelvesPerSpokeNeeded,
+            centerRunnerHalfWidthX: AISLE_HALF_WIDTH_X,
         }),
         totalShelves
     )
@@ -306,6 +318,7 @@ function computeSpokeShelvesForSections(sections: ReadonlyArray<Section>): Secti
         hubClearanceMetres: spacing.hubClearanceMetres,
         shelfSpacingMetres: spacing.shelfSpacingMetres,
         aisleHalfWidthMetres: clampedAisleHalfWidth,
+        centerRunnerHalfWidthX: AISLE_HALF_WIDTH_X,
     })
 
     const sectionAwareShelves: SectionShelfInfo[] = []

--- a/client/src/scene/shelves/ShelfLayoutCoordinator.ts
+++ b/client/src/scene/shelves/ShelfLayoutCoordinator.ts
@@ -156,6 +156,7 @@ export class ShelfLayoutCoordinator {
         EventManager.getInstance().emit<ShelfLayoutDeterminedEvent>(
             GameEventTypes.ShelfLayoutDetermined,
             {
+                layoutMode: this.layoutMode,
                 shelfBounds: bounds,
                 shelfLayout: {
                     rows: rowCount,

--- a/client/src/types/InteractionEvents.ts
+++ b/client/src/types/InteractionEvents.ts
@@ -20,6 +20,7 @@ import type { WebXRCapabilities } from '../webxr/WebXRManager'
 import type { SteamGame } from '../steam'
 import type { SteamGameData } from '../scene/game-box/types/GameData'
 import type { IStockStrategy } from '../scene/props/shared/StockStrategy'
+import type { LayoutMode } from './LayoutTypes'
 
 // =============================================================================
 // STEAM EVENTS
@@ -189,6 +190,7 @@ export interface ShelfBounds {
 }
 
 export interface ShelfLayoutDeterminedEvent extends BaseInteractionEvent {
+    layoutMode?: LayoutMode
     shelfBounds: ShelfBounds
     shelfLayout: { rows: number; shelvesPerRow?: number }
     stockStrategy: IStockStrategy

--- a/client/test/unit/scene/ShelfSignPlanner.test.ts
+++ b/client/test/unit/scene/ShelfSignPlanner.test.ts
@@ -8,7 +8,7 @@ import {
     type ShelfLayoutDeterminedEvent,
 } from '../../../src/types/InteractionEvents'
 import type { SectionsReadyEvent } from '../../../src/types/EnvironmentEvents'
-import type { Section } from '../../../src/types/LayoutTypes'
+import type { LayoutMode, Section } from '../../../src/types/LayoutTypes'
 import type { SteamGameData } from '../../../src/scene/game-box/types/GameData'
 
 const placeSignSpy = vi.fn().mockReturnValue(new THREE.Group())
@@ -73,8 +73,9 @@ function emitShelfReady(shelfIndex: number, position = FAR_POSITION, rotationY =
     })
 }
 
-function emitShelfLayoutDetermined(): void {
+function emitShelfLayoutDetermined(layoutMode?: LayoutMode): void {
     EventManager.getInstance().emit<ShelfLayoutDeterminedEvent>(GameEventTypes.ShelfLayoutDetermined, {
+        layoutMode,
         shelfBounds: { minX: -10, maxX: 10, minZ: -20, maxZ: -2 },
         shelfLayout: { rows: 1 },
         stockStrategy: { order: (boards: any[]) => boards } as any,
@@ -263,5 +264,27 @@ describe('ShelfSignPlanner — sign placement from SectionsReady', () => {
             emitSectionsReady([makeSection('Action')])
         }).not.toThrow()
         expect(placeSignSpy).not.toHaveBeenCalled()
+    })
+
+    it('adds aisle-edge signs for row layouts where a central aisle exists', () => {
+        new ShelfSignPlanner()
+        emitShelfReady(0, new THREE.Vector3(-4, 0, -8), 0, 0)
+        emitShelfReady(1, new THREE.Vector3(-1.5, 0, -8), 0, 0)
+        emitShelfReady(2, new THREE.Vector3(1.5, 0, -8), 0, 0)
+        emitShelfReady(3, new THREE.Vector3(4, 0, -8), 0, 0)
+
+        emitSectionsReady([makeSection('Action')])
+        emitShelfLayoutDetermined('row')
+
+        const placedIds = placeSignSpy.mock.calls.map(([, detail]) => detail.uniqueIdentifier)
+        expect(placedIds).toContain('Action::start')
+        expect(placedIds).toContain('Action::end')
+        expect(placedIds).toContain('row-aisle--800-left')
+        expect(placedIds).toContain('row-aisle--800-right')
+
+        const leftAisleSign = placeSignSpy.mock.calls.find(([, detail]) => detail.uniqueIdentifier === 'row-aisle--800-left')
+        const rightAisleSign = placeSignSpy.mock.calls.find(([, detail]) => detail.uniqueIdentifier === 'row-aisle--800-right')
+        expect(leftAisleSign?.[1].text).toBe('Action')
+        expect(rightAisleSign?.[1].text).toBe('Action')
     })
 })

--- a/client/test/unit/scene/props/shared/ArcLayoutUtils.test.ts
+++ b/client/test/unit/scene/props/shared/ArcLayoutUtils.test.ts
@@ -214,4 +214,30 @@ describe('partial-row centering', () => {
         const xSum = shelves[0].position.x + shelves[1].position.x
         expect(Math.abs(xSum)).toBeLessThan(0.01) // symmetric around x=0
     })
+
+    it('interrupts arc rows around the center aisle opening', () => {
+        const shelves = computeArcShelfLayout(8, {
+            rows: 1,
+            shelvesPerRow: 8,
+            firstRowRadius: 7,
+            halfAngle: Math.PI / 3,
+            centerAisleHalfAngle: Math.PI / 12,
+        })
+
+        const closestToCenterX = Math.min(...shelves.map(shelf => Math.abs(shelf.position.x)))
+        expect(closestToCenterX).toBeGreaterThan(1.7)
+    })
+
+    it('does not place a single-shelf row at x=0 when center aisle width interruption is enabled', () => {
+        const shelves = computeArcShelfLayout(1, {
+            rows: 1,
+            shelvesPerRow: 1,
+            firstRowRadius: 5.5,
+            halfAngle: Math.PI / 3,
+            centerAisleHalfWidthX: 2.5,
+        })
+
+        expect(shelves).toHaveLength(1)
+        expect(Math.abs(shelves[0].position.x)).toBeGreaterThanOrEqual(2.45)
+    })
 })

--- a/client/test/unit/scene/props/shared/RowLayoutUtils.test.ts
+++ b/client/test/unit/scene/props/shared/RowLayoutUtils.test.ts
@@ -18,6 +18,21 @@ describe('computeRowShelfLayout', () => {
         const secondRowZ = shelves[8].position.z
         expect(secondRowZ).toBeLessThan(firstRowZ)
     })
+
+    it('leaves a central aisle gap between left and right shelf blocks', () => {
+        const shelves = computeRowShelfLayout(8, {
+            shelvesPerRow: 8,
+            shelfSpacingX: 2.5,
+            centralAisleWidthX: 3.0,
+        })
+        const row0 = shelves.filter(shelf => shelf.row === 0).sort((a, b) => a.position.x - b.position.x)
+        const leftInner = row0.filter(shelf => shelf.position.x < 0).at(-1)
+        const rightInner = row0.find(shelf => shelf.position.x > 0)
+
+        expect(leftInner).toBeDefined()
+        expect(rightInner).toBeDefined()
+        expect((rightInner?.position.x ?? 0) - (leftInner?.position.x ?? 0)).toBeGreaterThan(5.0)
+    })
 })
 
 describe('RowLayout section-aware shelf ownership', () => {

--- a/client/test/unit/scene/props/shared/SpokeLayoutUtils.test.ts
+++ b/client/test/unit/scene/props/shared/SpokeLayoutUtils.test.ts
@@ -172,7 +172,7 @@ describe('computeSpokeShelfLayout', () => {
     })
 
     it('spokes are evenly angularly spaced', () => {
-        const config: SpokeLayoutConfig = { spokeCount: 4, shelvesPerSpoke: 1 }
+        const config: SpokeLayoutConfig = { spokeCount: 4, shelvesPerSpoke: 1, centerRunnerHalfWidthX: 0 }
         const shelves = computeSpokeShelfLayout(config)
         // For each spoke, get the midpoint of its two shelves to approximate centreline angle
         const angles: number[] = []
@@ -193,5 +193,24 @@ describe('computeSpokeShelfLayout', () => {
         for (const diff of diffs) {
             expect(diff).toBeCloseTo(Math.PI / 2, 1)
         }
+    })
+
+    it('default spoke centrelines avoid the central aisle axis', () => {
+        const config: SpokeLayoutConfig = { spokeCount: 4, shelvesPerSpoke: 1, centerRunnerHalfWidthX: 0 }
+        const shelves = computeSpokeShelfLayout(config)
+
+        for (let spoke = 0; spoke < 4; spoke++) {
+            const inSpoke = shelves.filter(shelf => shelf.spokeIndex === spoke)
+            const midX = inSpoke.reduce((sum, shelf) => sum + shelf.position.x, 0) / inSpoke.length
+            expect(Math.abs(midX)).toBeGreaterThan(0.5)
+        }
+    })
+
+    it('keeps the global entrance runner aisle clear on the X axis', () => {
+        const config: SpokeLayoutConfig = { spokeCount: 4, shelvesPerSpoke: 3, centerRunnerHalfWidthX: 1.6 }
+        const shelves = computeSpokeShelfLayout(config)
+
+        const closestToRunnerCenter = Math.min(...shelves.map(shelf => Math.abs(shelf.position.x)))
+        expect(closestToRunnerCenter).toBeGreaterThanOrEqual(2.59)
     })
 })

--- a/docs/acts/act2-ready-for-friends.md
+++ b/docs/acts/act2-ready-for-friends.md
@@ -35,7 +35,7 @@
 
 - [Steam Tag Pipeline](../features/steam-tag-pipeline.md) — SteamSpy tags via background Lambda + S3 snapshot; active in separate branch; invest to try, not required
 - [Local File Investigation](../features/local-file-investigation.md) — research completed enough to make an Act 2 decision: local collections are useful, but filesystem API integration is deferred; revisit in AC4.4
-- [Layout Variations](../features/layout-variations.md) — arc exists; square rows + dynamic switching are the open work; grouping is Encore; include layout-owned entrance mat placement for spoke and stage mat/carpet convergence as a later Act 2 layout follow-up
+- [Layout Variations](../features/layout-variations.md) — arc exists; square rows + dynamic switching are the open work; grouping is Encore; include layout-owned entrance mat placement for spoke and stage mat/carpet convergence as a mid-Act 2 follow-up, and treat angled-layout center-aisle overlap cleanup (`arc`/`spoke`) as medium priority without a fixed timebox
 - [Game Detail Screen](../features/game-detail-screen.md) — design pass tied to VR; do once with VR in mind rather than twice
 - [Room Variants](../features/room-variants.md) — room structure cleanup first, then variant system; Cozy Basement is the target variant
 - [Lighting and Atmosphere](../features/lighting-and-atmosphere.md) — tone presets (corporate → dank), dongle switch panel; core lighting is done, this is the experiential layer

--- a/docs/acts/act3-ready-for-everyone.md
+++ b/docs/acts/act3-ready-for-everyone.md
@@ -15,6 +15,10 @@
 - [Legal / Privacy Compliance](../features/legal-privacy-compliance.md) — privacy policy, user consent, GDPR/CCPA
 - [Production Infrastructure](../features/production-infrastructure.md) — auto-scaling, security hardening, DDoS protection, ops readiness
 
+## Also In Act 3 (Best Effort)
+
+- **Front glass wall door interaction** — add a visible front-door handle on the glass wall; selecting the handle prompts a confirm dialog ("Are you sure?") and closes the store tab/window on confirmation.
+
 ## Completion Criteria
 
 - Complete privacy policy and user consent management

--- a/docs/acts/act4-encore-someday-maybe.md
+++ b/docs/acts/act4-encore-someday-maybe.md
@@ -37,6 +37,19 @@ The main thing we'll want to check in this "encore" act is: Can we embed an audi
 - **Community management** — Discord/forums, code of conduct, moderation, beta programs
 - **A/B testing framework** — for feature improvements and UX experiments
 
+## Misc
+
+- Portal-style portals linking different rooms
+would love to build to support inside the same room, but not at first
+Would love to build as much as possible, a "filter" drawing effect that causes the different appearance of the different "rooms"
+like a cartoonish effect for a more Nikelodeon feel,
+art deco effect that adds a little emphasis on top of our 'blockbuster' scene
+
 ## Deferred Re-entry Candidates
 
 - **AC4.4: Local collections import (filesystem API)** — revisit `cloud-storage-namespace-1.json` import only if we are ready to accept filesystem API UX/security complexity. Prior findings show categories are the main unique value; other local metadata did not justify shipping this in Act 2.
+
+## I don't know where to put this note
+but want it displayed in the games menus somewhere
+"Nostalgia is evoking a memory of how something made you feel
+retro (?) is harmonizing with _why_ that thing made you feel what you did"

--- a/docs/acts/act4-encore-someday-maybe.md
+++ b/docs/acts/act4-encore-someday-maybe.md
@@ -25,6 +25,7 @@ The main thing we'll want to check in this "encore" act is: Can we embed an audi
 - **Encircling Games layout mode** — the "Cyberspace room"; games orbit the player in concentric rings
 - **Dynamic spoke/aisle shelf arrangement** — shelves as spokes per category, or giant aisles running past; 4-6 day estimate post-Act 2 core; see [Layout Variations](../features/layout-variations.md)
 - **Layout grouping** — apply a shape to N shelves then repeat; stretch goal within [Layout Variations](../features/layout-variations.md)
+- **Entrance aisle runner carpet with marquee lights** — add a long runner along the primary entrance aisle (from door through center) with movie-theater style border lighting.
 
 ## Extensibility
 

--- a/docs/features/layout-variations.md
+++ b/docs/features/layout-variations.md
@@ -107,3 +107,22 @@ Landed in PR #81 (`openclaw/feat-stock-strategy`). `IStockStrategy` in `StockStr
 - Dynamic switching requires shelves to be repositionable - check whether current `ShelfRenderer`/`InstancedShelfRenderer` supports in-place position updates or needs rebuild
 - The spoke/aisle arrangement (4-6 day estimate) from the Encore list is a natural candidate for pull-forward once two shapes are working
 - Layout grouping is related to `ShelfSectionPlanner` - section boundaries may need to be aware of group limits
+
+## Aisles + Clustering Sequence (Intermission Plan)
+
+To support both central aisles and upcoming row clustering without rework, treat this as a two-branch sequence:
+
+### Branch A (current): Aisle-capable geometry
+
+- Add a central aisle seam to each layout family:
+- Rows: split each row into left/right shelf blocks with a clean center corridor.
+- Arcs: interrupt each ring at the center corridor and cluster shelves before/after the aisle opening.
+- Spokes: rotate spokes so lanes avoid the aisle axis by default.
+- Add aisle-edge sign anchors where row shelf runs terminate at the aisle opening.
+
+### Branch B (next): Cluster-aware section assignment
+
+- Move section-to-shelf assignment from strict linear fill toward layout-directed packing.
+- Support balancing scenarios like `6` shelves on one side and `2+4` on the other.
+- Preserve aisle seams while allowing grouped section blocks per side.
+- Keep this as a section-allocation layer so geometry code remains stable.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -14,6 +14,25 @@
 
 ## Fix Now (Intermission)
 
+## id: angled-layout-center-aisle-overlap
+**Priority**: High  
+**Effort**: ~0.5-1 day (geometry pass + visual validation)  
+**Context**: In angled layouts (`arc`, `spoke`), shelf bodies can still visually crowd/overlap around center-aisle boundaries under some section distributions. Row layout spacing is currently acceptable; this debt is specifically for angled layout geometry seams.
+
+**Done when**:
+- Shelf body extents (not only shelf centers) are guaranteed to remain outside the reserved center aisle corridor in `arc` and `spoke`
+- No shelf-to-shelf overlap appears in angled layouts at default and high-count section distributions
+- Regression tests cover center-aisle clearance and nearest-neighbor spacing for both angled layouts
+
+**When to pick up**:
+- Early Act 2 (after current intermission layout tuning is merged)
+
+**Related files**:
+- `client/src/scene/props/shared/ArcLayoutUtils.ts`
+- `client/src/scene/props/shared/SpokeLayoutUtils.ts`
+
+---
+
 ## id: debug-window-consolidation
 **Priority**: Low  
 **Effort**: ~1-2 hours  

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -173,6 +173,26 @@
 
 ## Later (only true debt, not feature wish-list)
 
+## id: layout-math-renderer-decoupling
+**Priority**: Low  
+**Effort**: Deferred (no active timebox)  
+**Context**: Layout math in shelf layout utilities currently depends on `THREE` types/constructors (`Vector3`) and overlaps with renderer-adjacent concerns. Long term, layout generation should be pure geometry data so it can be tested and reused without Three.js coupling.
+
+**Done when**:
+- Layout utility outputs are plain serializable geometry data (no `THREE.Vector3` construction in layout files)
+- A mapping layer translates layout DTOs into renderer-specific types near rendering boundaries
+- Layout files no longer import `three`
+
+**When to pick up**:
+- Indefinite backlog (revisit only when layout architecture work naturally touches these modules)
+
+**Related files**:
+- `client/src/scene/props/shared/ArcLayoutUtils.ts`
+- `client/src/scene/props/shared/RowLayoutUtils.ts`
+- `client/src/scene/props/shared/SpokeLayoutUtils.ts`
+
+---
+
 ### Test suite runtime-cost reduction
 Keep reducing expensive overlap in tests (prefer cheaper deterministic coverage where equivalent).
 


### PR DESCRIPTION
## Summary
This PR completes intermission aisle/layout follow-up work across row, arc, and spoke layouts, plus entrance runner behavior and documentation alignment.

## What Changed
- Updated layout geometry/sign behavior:
  - Row aisle-edge signs now use section names
  - Arc center aisle interruption/spacing tuned for clearer bisection behavior
  - Spoke center-runner interruption and spacing tuned to keep aisle separation clearer
- Converted the entrance mat to an aisle runner treatment
  - Applied runner sizing behavior across layouts
  - Anchored runner placement to room world center offset (instead of origin anchoring)
- Updated docs
  - Trimmed temporary intermission planning notes
  - Added Act notes for door interaction and lit aisle runner concept
  - Scheduled angled-layout overlap cleanup as a medium-priority, mid-Act-2 follow-up

## Validation
- Targeted unit tests were run during implementation for:
  - `ArcLayoutUtils`
  - `SpokeLayoutUtils`
  - `PropRenderer-floor`
  - `StorePropsCoordinator` layout/shelf reset behavior
- Latest targeted runs passed after the final fixes.

## Commits
- `f3d227b4` docs(layout): trim intermission aisle planning notes
- `0b492513` docs(acts): capture door interaction and lit aisle runner ideas
- `053b30cc` feat(layout): tune aisle interruption and angled layout spacing
- `68482d81` feat(props): convert entrance mat to full aisle runner
- `eaec62f2` fix(props): anchor aisle runner to room world center
- `bb85f362` docs(layout): schedule overlap cleanup for mid Act 2