### PR TITLE
refactor(sorter): simplify placement planning and trim warnings

### DIFF
--- a/client/src/scene/categorization/GameSorter.ts
+++ b/client/src/scene/categorization/GameSorter.ts
@@ -47,6 +47,8 @@ const MAX_SHELVES_PER_ARRANGEMENT = Math.min(
     180,
     Math.max(1, Math.floor(MAX_GAME_BOX_INSTANCES_PER_ARRANGEMENT / SHELF_BATCH_SIZE))
 )
+const SECTION_TRIM_PERCENT_PER_PASS = 10
+const MIN_SHELVES_PER_RETAINED_SECTION = 1
 
 type SectionPlacementPlanRow = {
     sectionId: string
@@ -161,40 +163,110 @@ export class GameSorter {
     private buildSectionPlacementPlan(
         sections: ReadonlyArray<{ sectionId: string; section: Section }>
     ) {
-        let usedShelves = 0
-        let totalAllocatedSections = 0
-
-        const sectionPlans: SectionPlacementPlanRow[] = []
+        const sectionPlans: SectionPlacementPlanRow[] = sections.map(({ sectionId, section }) => ({
+            sectionId,
+            requestedShelves: Math.max(0, Math.ceil(section.games.length / SHELF_BATCH_SIZE)),
+            allocatedShelves: 0,
+            shelfCapacity: SHELF_BATCH_SIZE,
+            requestedGames: section.games.length,
+            allocatedGames: 0,
+            deferredGames: 0,
+        }))
         let totalRequestedShelves = 0
         let totalRequestedGames = 0
+        for (const sectionPlan of sectionPlans) {
+            totalRequestedShelves += sectionPlan.requestedShelves
+            totalRequestedGames += sectionPlan.requestedGames
+        }
+
+        const allocatedShelvesBySection = sectionPlans.map(sectionPlan => sectionPlan.requestedShelves)
+        let shelvesToTrim = Math.max(0, totalRequestedShelves - MAX_SHELVES_PER_ARRANGEMENT)
+
+        if (sectionPlans.length > MAX_SHELVES_PER_ARRANGEMENT) {
+            for (let sectionIndex = MAX_SHELVES_PER_ARRANGEMENT; sectionIndex < allocatedShelvesBySection.length; sectionIndex++) {
+                shelvesToTrim -= allocatedShelvesBySection[sectionIndex]
+                allocatedShelvesBySection[sectionIndex] = 0
+            }
+            shelvesToTrim = Math.max(0, shelvesToTrim)
+
+            GameSorter.logger.warn(
+                `Edge case: ${sectionPlans.length} sections exceed shelf cap ${MAX_SHELVES_PER_ARRANGEMENT}; trimming tail sections by current sort order before proportional passes`
+            )
+        }
+
+        while (shelvesToTrim > 0) {
+            const trimmableSections = allocatedShelvesBySection
+                .map((allocatedShelves, sectionIndex) => ({ allocatedShelves, sectionIndex }))
+                .filter(({ allocatedShelves }) => allocatedShelves > MIN_SHELVES_PER_RETAINED_SECTION)
+                .sort((left, right) => {
+                    if (right.allocatedShelves !== left.allocatedShelves) {
+                        return right.allocatedShelves - left.allocatedShelves
+                    }
+                    return left.sectionIndex - right.sectionIndex
+                })
+
+            if (trimmableSections.length === 0) {
+                break
+            }
+
+            let trimmedThisPass = 0
+
+            for (const { sectionIndex, allocatedShelves } of trimmableSections) {
+                if (shelvesToTrim <= 0) {
+                    break
+                }
+
+                const proportionalTrim = Math.floor(allocatedShelves * SECTION_TRIM_PERCENT_PER_PASS / 100)
+                const passTrim = Math.max(1, proportionalTrim)
+                const maxTrimForSection = Math.max(0, allocatedShelves - MIN_SHELVES_PER_RETAINED_SECTION)
+                const appliedTrim = Math.min(passTrim, maxTrimForSection, shelvesToTrim)
+
+                if (appliedTrim <= 0) {
+                    continue
+                }
+
+                allocatedShelvesBySection[sectionIndex] -= appliedTrim
+                shelvesToTrim -= appliedTrim
+                trimmedThisPass += appliedTrim
+            }
+
+            if (trimmedThisPass === 0) {
+                break
+            }
+        }
+
+        if (shelvesToTrim > 0) {
+            for (let sectionIndex = allocatedShelvesBySection.length - 1; sectionIndex >= 0 && shelvesToTrim > 0; sectionIndex--) {
+                const trim = Math.min(allocatedShelvesBySection[sectionIndex], shelvesToTrim)
+                allocatedShelvesBySection[sectionIndex] -= trim
+                shelvesToTrim -= trim
+            }
+
+            if (shelvesToTrim > 0) {
+                GameSorter.logger.warn(`Safety trim exhausted while ${shelvesToTrim} shelves still over cap`)
+            }
+        }
+
+        let totalAllocatedSections = 0
+        let usedShelves = 0
         let totalAllocatedGames = 0
 
-        for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
-            const { sectionId, section } = sections[sectionIndex]
-            const sectionShelves = Math.max(0, Math.ceil(section.games.length / SHELF_BATCH_SIZE))
-            const remainingShelves = Math.max(0, MAX_SHELVES_PER_ARRANGEMENT - usedShelves)
-            const allocatedShelves = Math.min(sectionShelves, remainingShelves)
-            const allocatedGames = Math.min(section.games.length, allocatedShelves * SHELF_BATCH_SIZE)
-            const deferredGames = section.games.length - allocatedGames
+        for (let sectionIndex = 0; sectionIndex < sectionPlans.length; sectionIndex++) {
+            const plan = sectionPlans[sectionIndex]
+            const allocatedShelves = allocatedShelvesBySection[sectionIndex]
+            const allocatedGames = Math.min(plan.requestedGames, allocatedShelves * SHELF_BATCH_SIZE)
+            const deferredGames = plan.requestedGames - allocatedGames
 
-            totalRequestedShelves += sectionShelves
-            totalRequestedGames += section.games.length
+            plan.allocatedShelves = allocatedShelves
+            plan.allocatedGames = allocatedGames
+            plan.deferredGames = deferredGames
+
             totalAllocatedGames += allocatedGames
 
             if (allocatedShelves > 0) {
                 usedShelves += allocatedShelves
                 totalAllocatedSections++
             }
-
-            sectionPlans.push({
-                sectionId,
-                requestedShelves: sectionShelves,
-                allocatedShelves,
-                shelfCapacity: SHELF_BATCH_SIZE,
-                requestedGames: section.games.length,
-                allocatedGames,
-                deferredGames,
-            })
         }
 
         const deferredSections = sectionPlans.filter(section => section.allocatedShelves === 0).length

--- a/client/src/scene/categorization/GameSorter.ts
+++ b/client/src/scene/categorization/GameSorter.ts
@@ -47,6 +47,8 @@ const MAX_SHELVES_PER_ARRANGEMENT = Math.min(
     180,
     Math.max(1, Math.floor(MAX_GAME_BOX_INSTANCES_PER_ARRANGEMENT / SHELF_BATCH_SIZE))
 )
+// export is only for test
+export const ARRANGEMENT_SHELF_CAP = MAX_SHELVES_PER_ARRANGEMENT
 const SECTION_TRIM_PERCENT_PER_PASS = 10
 const MIN_SHELVES_PER_RETAINED_SECTION = 1
 
@@ -58,6 +60,11 @@ type SectionPlacementPlanRow = {
     requestedGames: number
     allocatedGames: number
     deferredGames: number
+}
+
+type PlacementPlanTotals = {
+    totalAllocatedSections: number
+    totalAllocatedShelves: number
 }
 
 // Re-export bucket helpers so existing callers don't break
@@ -125,8 +132,8 @@ export class GameSorter {
             sectionIndex,
             section,
         }))
-        const plan = this.buildSectionPlacementPlan(computedSections)
-        const allocatedSections = this.buildAllocatedSections(computedSections, plan.sections)
+        const sectionPlans = this.buildSectionPlacementPlan(computedSections)
+        const allocatedSections = this.buildAllocatedSections(computedSections, sectionPlans)
         const sections = allocatedSections.map(({ section }) => section)
 
         EventManager.getInstance().emit<SectionsComputedEvent>(GameEventTypes.SectionsComputed, {
@@ -141,14 +148,6 @@ export class GameSorter {
             sections: allocatedSections,
         })
 
-        if (plan.totalAllocatedSections < sortedSections.length) {
-            GameSorter.logger.warn(
-                `Arrangement capped in ${groupMode}: using ${plan.totalAllocatedSections}/${sortedSections.length} sections ` +
-                `(${plan.totalAllocatedShelves}/${MAX_SHELVES_PER_ARRANGEMENT} shelves), deferred ${plan.deferredSections} sections ` +
-                `(${plan.deferredGames} game placements)`
-            )
-        }
-
         EventManager.getInstance().emit<SectionsReadyEvent>(GameEventTypes.SectionsReady, {
             sections,
             groupMode,
@@ -162,7 +161,7 @@ export class GameSorter {
 
     private buildSectionPlacementPlan(
         sections: ReadonlyArray<{ sectionId: string; section: Section }>
-    ) {
+    ): SectionPlacementPlanRow[] {
         const sectionPlans: SectionPlacementPlanRow[] = sections.map(({ sectionId, section }) => ({
             sectionId,
             requestedShelves: Math.max(0, Math.ceil(section.games.length / SHELF_BATCH_SIZE)),
@@ -172,28 +171,99 @@ export class GameSorter {
             allocatedGames: 0,
             deferredGames: 0,
         }))
-        let totalRequestedShelves = 0
-        let totalRequestedGames = 0
-        for (const sectionPlan of sectionPlans) {
-            totalRequestedShelves += sectionPlan.requestedShelves
-            totalRequestedGames += sectionPlan.requestedGames
-        }
+        const totalRequestedShelves = this.sumRequestedShelves(sectionPlans)
 
         const allocatedShelvesBySection = sectionPlans.map(sectionPlan => sectionPlan.requestedShelves)
-        let shelvesToTrim = Math.max(0, totalRequestedShelves - MAX_SHELVES_PER_ARRANGEMENT)
+        this.trimShelvesToCap(allocatedShelvesBySection, totalRequestedShelves)
 
-        if (sectionPlans.length > MAX_SHELVES_PER_ARRANGEMENT) {
-            for (let sectionIndex = MAX_SHELVES_PER_ARRANGEMENT; sectionIndex < allocatedShelvesBySection.length; sectionIndex++) {
-                shelvesToTrim -= allocatedShelvesBySection[sectionIndex]
-                allocatedShelvesBySection[sectionIndex] = 0
-            }
-            shelvesToTrim = Math.max(0, shelvesToTrim)
+        const {
+            totalAllocatedSections,
+            totalAllocatedShelves,
+        } = this.applyAllocatedShelvesToPlan(sectionPlans, allocatedShelvesBySection)
 
+        if (totalAllocatedSections < sections.length) {
             GameSorter.logger.warn(
-                `Edge case: ${sectionPlans.length} sections exceed shelf cap ${MAX_SHELVES_PER_ARRANGEMENT}; trimming tail sections by current sort order before proportional passes`
+                `Arrangement capped: using ${totalAllocatedSections}/${sections.length} sections ` +
+                `(${totalAllocatedShelves}/${MAX_SHELVES_PER_ARRANGEMENT} shelves)`
             )
         }
 
+        return sectionPlans
+    }
+
+    private sumRequestedShelves(sectionPlans: ReadonlyArray<SectionPlacementPlanRow>): number {
+        let totalRequestedShelves = 0
+        for (const sectionPlan of sectionPlans) {
+            totalRequestedShelves += sectionPlan.requestedShelves
+        }
+        return totalRequestedShelves
+    }
+
+    private applyAllocatedShelvesToPlan(
+        sectionPlans: SectionPlacementPlanRow[],
+        allocatedShelvesBySection: ReadonlyArray<number>
+    ): PlacementPlanTotals {
+        let totalAllocatedSections = 0
+        let totalAllocatedShelves = 0
+
+        for (let sectionIndex = 0; sectionIndex < sectionPlans.length; sectionIndex++) {
+            const plan = sectionPlans[sectionIndex]
+            const allocatedShelves = allocatedShelvesBySection[sectionIndex]
+            const allocatedGames = Math.min(plan.requestedGames, allocatedShelves * SHELF_BATCH_SIZE)
+            const deferredGames = plan.requestedGames - allocatedGames
+
+            plan.allocatedShelves = allocatedShelves
+            plan.allocatedGames = allocatedGames
+            plan.deferredGames = deferredGames
+
+            if (allocatedShelves > 0) {
+                totalAllocatedShelves += allocatedShelves
+                totalAllocatedSections++
+            }
+        }
+
+        return {
+            totalAllocatedSections,
+            totalAllocatedShelves,
+        }
+    }
+
+    private trimShelvesToCap(allocatedShelvesBySection: number[], totalRequestedShelves: number) {
+        const exceedsShelfCap = totalRequestedShelves > MAX_SHELVES_PER_ARRANGEMENT
+        let shelvesToTrim = Math.max(0, totalRequestedShelves - MAX_SHELVES_PER_ARRANGEMENT)
+        const nonEmptySectionCount = allocatedShelvesBySection.filter(s => s > 0).length
+        const sectionCountExceedsShelfCap = nonEmptySectionCount > MAX_SHELVES_PER_ARRANGEMENT
+
+        if (exceedsShelfCap) {
+            GameSorter.logger.warn(
+                `Shelf cap exceeded: requested ${totalRequestedShelves} shelves, cap ${MAX_SHELVES_PER_ARRANGEMENT}; trimming ${shelvesToTrim} shelves`
+            )
+        }
+
+        if (sectionCountExceedsShelfCap) {
+            shelvesToTrim = this.trimTrailingSectionOverflow(allocatedShelvesBySection, shelvesToTrim)
+            GameSorter.logger.warn(
+                `Edge case: minimum one-shelf-per-section requirement (${nonEmptySectionCount}) exceeds shelf cap ${MAX_SHELVES_PER_ARRANGEMENT}; trimming tail sections by current sort order before proportional passes`
+            )
+        }
+
+        shelvesToTrim = this.trimLargestSectionsByPass(allocatedShelvesBySection, shelvesToTrim)
+        shelvesToTrim = this.applySafetyTrim(allocatedShelvesBySection, shelvesToTrim)
+
+        if (shelvesToTrim > 0) {
+            GameSorter.logger.warn(`Safety trim exhausted while ${shelvesToTrim} shelves still over cap`)
+        }
+    }
+
+    private trimTrailingSectionOverflow(allocatedShelvesBySection: number[], shelvesToTrim: number): number {
+        for (let sectionIndex = MAX_SHELVES_PER_ARRANGEMENT; sectionIndex < allocatedShelvesBySection.length; sectionIndex++) {
+            shelvesToTrim -= allocatedShelvesBySection[sectionIndex]
+            allocatedShelvesBySection[sectionIndex] = 0
+        }
+        return Math.max(0, shelvesToTrim)
+    }
+
+    private trimLargestSectionsByPass(allocatedShelvesBySection: number[], shelvesToTrim: number): number {
         while (shelvesToTrim > 0) {
             const trimmableSections = allocatedShelvesBySection
                 .map((allocatedShelves, sectionIndex) => ({ allocatedShelves, sectionIndex }))
@@ -235,53 +305,16 @@ export class GameSorter {
             }
         }
 
-        if (shelvesToTrim > 0) {
-            for (let sectionIndex = allocatedShelvesBySection.length - 1; sectionIndex >= 0 && shelvesToTrim > 0; sectionIndex--) {
-                const trim = Math.min(allocatedShelvesBySection[sectionIndex], shelvesToTrim)
-                allocatedShelvesBySection[sectionIndex] -= trim
-                shelvesToTrim -= trim
-            }
+        return shelvesToTrim
+    }
 
-            if (shelvesToTrim > 0) {
-                GameSorter.logger.warn(`Safety trim exhausted while ${shelvesToTrim} shelves still over cap`)
-            }
+    private applySafetyTrim(allocatedShelvesBySection: number[], shelvesToTrim: number): number {
+        for (let sectionIndex = allocatedShelvesBySection.length - 1; sectionIndex >= 0 && shelvesToTrim > 0; sectionIndex--) {
+            const trim = Math.min(allocatedShelvesBySection[sectionIndex], shelvesToTrim)
+            allocatedShelvesBySection[sectionIndex] -= trim
+            shelvesToTrim -= trim
         }
-
-        let totalAllocatedSections = 0
-        let usedShelves = 0
-        let totalAllocatedGames = 0
-
-        for (let sectionIndex = 0; sectionIndex < sectionPlans.length; sectionIndex++) {
-            const plan = sectionPlans[sectionIndex]
-            const allocatedShelves = allocatedShelvesBySection[sectionIndex]
-            const allocatedGames = Math.min(plan.requestedGames, allocatedShelves * SHELF_BATCH_SIZE)
-            const deferredGames = plan.requestedGames - allocatedGames
-
-            plan.allocatedShelves = allocatedShelves
-            plan.allocatedGames = allocatedGames
-            plan.deferredGames = deferredGames
-
-            totalAllocatedGames += allocatedGames
-
-            if (allocatedShelves > 0) {
-                usedShelves += allocatedShelves
-                totalAllocatedSections++
-            }
-        }
-
-        const deferredSections = sectionPlans.filter(section => section.allocatedShelves === 0).length
-        const deferredGames = totalRequestedGames - totalAllocatedGames
-
-        return {
-            totalAllocatedSections,
-            totalRequestedShelves,
-            totalAllocatedShelves: usedShelves,
-            totalRequestedGames,
-            totalAllocatedGames,
-            deferredSections,
-            deferredGames,
-            sections: sectionPlans,
-        }
+        return shelvesToTrim
     }
 
     private buildAllocatedSections(

--- a/client/test/unit/scene/categorization/GameSorter.test.ts
+++ b/client/test/unit/scene/categorization/GameSorter.test.ts
@@ -296,6 +296,58 @@ describe('GameSorter', () => {
     })
 })
 
+describe('GameSorter placement trimming', () => {
+    function makeSectionForPlanner(sectionName: string, shelfCount: number) {
+        return {
+            sectionId: `by-genre:${sectionName}:0`,
+            section: {
+                name: sectionName,
+                groupMode: 'by-genre',
+                sortMode: 'by-playtime',
+                games: Array.from({ length: shelfCount * 18 }, (_, index) => makeGame(index + 1)),
+            },
+        } as any
+    }
+
+    it('trims largest sections first using proportional passes', () => {
+        const sorter = new GameSorter() as any
+        const sections = [
+            makeSectionForPlanner('Action', 50),
+            makeSectionForPlanner('RPG', 30),
+            makeSectionForPlanner('Indie', 20),
+            makeSectionForPlanner('Puzzle', 10),
+            makeSectionForPlanner('Strategy', 5),
+        ]
+
+        const plan = sorter.buildSectionPlacementPlan(sections)
+        const planById = new Map(plan.sections.map((section: any) => [section.sectionId, section]))
+
+        expect(plan.totalRequestedShelves).toBe(115)
+        expect(plan.totalAllocatedShelves).toBe(111)
+        expect(planById.get('by-genre:Action:0')?.allocatedShelves).toBe(46)
+        expect(planById.get('by-genre:RPG:0')?.allocatedShelves).toBe(30)
+        expect(planById.get('by-genre:Indie:0')?.allocatedShelves).toBe(20)
+        expect(planById.get('by-genre:Puzzle:0')?.allocatedShelves).toBe(10)
+        expect(planById.get('by-genre:Strategy:0')?.allocatedShelves).toBe(5)
+    })
+
+    it('safeguards section-overflow edge case by dropping trailing sections in sort order', () => {
+        const sorter = new GameSorter() as any
+        const sections = Array.from({ length: 120 }, (_, index) =>
+            makeSectionForPlanner(`Section-${index}`, 1)
+        )
+
+        const plan = sorter.buildSectionPlacementPlan(sections)
+        const retainedCount = plan.sections.filter((section: any) => section.allocatedShelves > 0).length
+
+        expect(plan.totalRequestedShelves).toBe(120)
+        expect(plan.totalAllocatedShelves).toBe(111)
+        expect(retainedCount).toBe(111)
+        expect(plan.sections[110].allocatedShelves).toBe(1)
+        expect(plan.sections[111].allocatedShelves).toBe(0)
+    })
+})
+
 describe('getRecentlyPlayedBucket', () => {
     const DAY = 24 * 60 * 60
     const now = 1000000000

--- a/client/test/unit/scene/categorization/GameSorter.test.ts
+++ b/client/test/unit/scene/categorization/GameSorter.test.ts
@@ -40,7 +40,7 @@ vi.mock('../../../../src/steam-integration/SteamIntegration', () => ({
     },
 }))
 
-import { GameSorter } from '../../../../src/scene/categorization/GameSorter'
+import { ARRANGEMENT_SHELF_CAP, GameSorter } from '../../../../src/scene/categorization/GameSorter'
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -312,23 +312,19 @@ describe('GameSorter placement trimming', () => {
     it('trims largest sections first using proportional passes', () => {
         const sorter = new GameSorter() as any
         const sections = [
-            makeSectionForPlanner('Action', 50),
-            makeSectionForPlanner('RPG', 30),
-            makeSectionForPlanner('Indie', 20),
-            makeSectionForPlanner('Puzzle', 10),
-            makeSectionForPlanner('Strategy', 5),
+            makeSectionForPlanner('Action', ARRANGEMENT_SHELF_CAP),
+            makeSectionForPlanner('RPG', 1),
+            makeSectionForPlanner('Indie', 1),
+            makeSectionForPlanner('Puzzle', 1),
         ]
 
-        const plan = sorter.buildSectionPlacementPlan(sections)
-        const planById = new Map(plan.sections.map((section: any) => [section.sectionId, section]))
+        const sectionPlans = sorter.buildSectionPlacementPlan(sections)
+        const planById = new Map(sectionPlans.map((section: any) => [section.sectionId, section]))
 
-        expect(plan.totalRequestedShelves).toBe(115)
-        expect(plan.totalAllocatedShelves).toBe(111)
-        expect(planById.get('by-genre:Action:0')?.allocatedShelves).toBe(46)
-        expect(planById.get('by-genre:RPG:0')?.allocatedShelves).toBe(30)
-        expect(planById.get('by-genre:Indie:0')?.allocatedShelves).toBe(20)
-        expect(planById.get('by-genre:Puzzle:0')?.allocatedShelves).toBe(10)
-        expect(planById.get('by-genre:Strategy:0')?.allocatedShelves).toBe(5)
+        expect(planById.get('by-genre:Action:0')?.allocatedShelves).toBe(ARRANGEMENT_SHELF_CAP - 3)
+        expect(planById.get('by-genre:RPG:0')?.allocatedShelves).toBe(1)
+        expect(planById.get('by-genre:Indie:0')?.allocatedShelves).toBe(1)
+        expect(planById.get('by-genre:Puzzle:0')?.allocatedShelves).toBe(1)
     })
 
     it('safeguards section-overflow edge case by dropping trailing sections in sort order', () => {
@@ -337,14 +333,26 @@ describe('GameSorter placement trimming', () => {
             makeSectionForPlanner(`Section-${index}`, 1)
         )
 
-        const plan = sorter.buildSectionPlacementPlan(sections)
-        const retainedCount = plan.sections.filter((section: any) => section.allocatedShelves > 0).length
+        const sectionPlans = sorter.buildSectionPlacementPlan(sections)
+        const retainedCount = sectionPlans.filter((section: any) => section.allocatedShelves > 0).length
 
-        expect(plan.totalRequestedShelves).toBe(120)
-        expect(plan.totalAllocatedShelves).toBe(111)
-        expect(retainedCount).toBe(111)
-        expect(plan.sections[110].allocatedShelves).toBe(1)
-        expect(plan.sections[111].allocatedShelves).toBe(0)
+        expect(retainedCount).toBe(ARRANGEMENT_SHELF_CAP)
+        expect(sectionPlans[ARRANGEMENT_SHELF_CAP - 1].allocatedShelves).toBe(1)
+        expect(sectionPlans[ARRANGEMENT_SHELF_CAP].allocatedShelves).toBe(0)
+    })
+
+    it('does not drop tail sections when shelf pressure is high but section count is still under cap', () => {
+        const sorter = new GameSorter() as any
+        const sectionCount = Math.max(1, ARRANGEMENT_SHELF_CAP - 1)
+        const sections = Array.from({ length: sectionCount }, (_, index) =>
+            makeSectionForPlanner(`Section-${index}`, 2)
+        )
+
+        const sectionPlans = sorter.buildSectionPlacementPlan(sections)
+        const retainedCount = sectionPlans.filter((section: any) => section.allocatedShelves > 0).length
+
+        expect(retainedCount).toBe(sectionCount)
+        expect(sectionPlans[sectionCount - 1].allocatedShelves).toBeGreaterThan(0)
     })
 })
 

--- a/docs/acts/act3-ready-for-everyone.md
+++ b/docs/acts/act3-ready-for-everyone.md
@@ -19,6 +19,7 @@
 
 - **Overhead row-hanging signage pass** — replace current in-store signs with hanging overhead signs between rows to improve navigability. Target double-sided sign faces and include a color swatch system (N colors, or at least two alternating colors) that matches shelving unit colors on the ground; likely needs shader updates to support driven sign/swatch color values.
 - **Front glass wall door interaction** — add a visible front-door handle on the glass wall; selecting the handle prompts a confirm dialog ("Are you sure?") and closes the store tab/window on confirmation.
+- **"Liminal" long-row rendering (sliding window / treadmill shelves)** — use a configurable per-row shelf window with bounds `0..(totalShelves - windowSize)`, smooth continuous movement with hysteresis, and no treadmill when `totalShelves <= windowSize`. Initial version should not render/permit interaction outside the active window (nice-to-haves like impostors can come later). Keep window logic separate from rendering, emit typed movement/shift events for animation/effects, persist per-row window state in-session, and keep non-adjacent rows statically parked while only relevant/adjacent rows treadmill as the player moves along the row aisle. Prefer shifting shelves along the row axis (geometry recycling) rather than moving player state.
 
 ## Completion Criteria
 

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -169,9 +169,22 @@
 
 ---
 
----
-
 ## Later (only true debt, not feature wish-list)
+
+## id: aisle-terminology-main-vs-row
+**Priority**: Low  
+**Effort**: ~1-2 hours  
+**Context**: "Aisle" currently ambiguously refers to both the global/main aisle and row-local aisle traversal space. This creates friction in implementation discussions, event naming, and UI labels.
+
+**Done when**:
+- Canonical terms are chosen and documented for global aisle vs row-local aisle zones
+- Existing references in docs/event names/UI labels are normalized where touched
+- New code/docs avoid the ambiguous term without qualifier
+
+**Related docs**:
+- `docs/acts/act3-ready-for-everyone.md`
+
+---
 
 ## id: layout-math-renderer-decoupling
 **Priority**: Low  


### PR DESCRIPTION
## Summary
- move placement-cap warning into `buildSectionPlacementPlan` and return only `SectionPlacementPlanRow[]`
- extract trim flow into focused helpers (`trimShelvesToCap`, `trimTrailingSectionOverflow`, `trimLargestSectionsByPass`, `applySafetyTrim`)
- simplify cap warning payload to keep only section/shelf usage and drop deferred aggregate logging
- update placement-trimming tests to use `ARRANGEMENT_SHELF_CAP` and the new planner return shape

## Validation
- `yarn vitest --run test/unit/scene/categorization/GameSorter.test.ts`
- result: 24 passed, 0 failed