### PR TITLE
refactor(input): decompose manager and complete remapping behavior

### DIFF
--- a/client/src/input/BindingResolver.ts
+++ b/client/src/input/BindingResolver.ts
@@ -9,6 +9,7 @@ import type {
     GamepadButtonBinding,
     InputBinding,
     InputProfileDefinition,
+    AxisDirection,
     MouseAxisBinding
 } from './InputProfile'
 
@@ -104,6 +105,21 @@ function resolveBindingValue(binding: InputBinding, rawState: RawInputState): nu
     }
 }
 
+function isButtonBinding(binding: InputBinding): binding is Extract<InputBinding, { type: 'keyboard-button' | 'mouse-button' | 'gamepad-button' }> {
+    return binding.type === 'keyboard-button' || binding.type === 'mouse-button' || binding.type === 'gamepad-button'
+}
+
+function resolveAxisBindingValue(binding: InputBinding, rawState: RawInputState): number {
+    const rawValue = resolveBindingValue(binding, rawState)
+    if (!isButtonBinding(binding)) {
+        return rawValue
+    }
+
+    const direction: AxisDirection = binding.direction ?? 'positive'
+    const magnitude = Math.abs(rawValue)
+    return direction === 'negative' ? -magnitude : magnitude
+}
+
 export class BindingResolver {
     resolve(profile: InputProfileDefinition, rawState: RawInputState): ResolvedActionState {
         const axisValues = new Map<InputActionId, number>()
@@ -124,7 +140,7 @@ export class BindingResolver {
             if (definition.type === InputActionType.Axis) {
                 let axisValue = 0
                 for (const binding of bindings) {
-                    const value = resolveBindingValue(binding, rawState)
+                    const value = resolveAxisBindingValue(binding, rawState)
                     if (definition.id === InputAction.LookHorizontal || definition.id === InputAction.LookVertical) {
                         axisValue += value
                     } else {
@@ -139,7 +155,7 @@ export class BindingResolver {
             } else {
                 let pressed = false
                 for (const binding of bindings) {
-                    if (resolveBindingValue(binding, rawState) >= 0.5) {
+                    if (Math.abs(resolveBindingValue(binding, rawState)) >= 0.5) {
                         pressed = true
                         break
                     }

--- a/client/src/input/CameraInputApplier.ts
+++ b/client/src/input/CameraInputApplier.ts
@@ -1,0 +1,40 @@
+import * as THREE from 'three'
+import { InputAction } from './InputActions'
+import type { MovementOptions } from './InputContracts'
+import { InputActionResolver } from './InputActionResolver'
+
+export class CameraInputApplier {
+    updateMovement(
+        camera: THREE.Camera,
+        actionResolver: InputActionResolver,
+        options: MovementOptions,
+        sprintActive: boolean
+    ): void {
+        const sprintMultiplier = sprintActive ? options.sprintMultiplier : 1
+
+        const forward = actionResolver.getAxisValue(InputAction.MoveForward)
+        const back = actionResolver.getAxisValue(InputAction.MoveBack)
+        const left = actionResolver.getAxisValue(InputAction.MoveLeft)
+        const right = actionResolver.getAxisValue(InputAction.MoveRight)
+        const up = actionResolver.getAxisValue(InputAction.MoveUp)
+        const down = actionResolver.getAxisValue(InputAction.MoveDown)
+
+        if (forward > 0) camera.translateZ(-(options.speed * forward * sprintMultiplier))
+        if (back > 0) camera.translateZ(options.speed * back * sprintMultiplier)
+        if (left > 0) camera.translateX(-(options.speed * left * sprintMultiplier))
+        if (right > 0) camera.translateX(options.speed * right * sprintMultiplier)
+        if (up > 0) camera.translateY(options.speed * up * sprintMultiplier)
+        if (down > 0) camera.translateY(-(options.speed * down * sprintMultiplier))
+    }
+
+    updateRotation(camera: THREE.Camera, actionResolver: InputActionResolver, options: MovementOptions, deltaX = 0): void {
+        if (deltaX !== 0) {
+            camera.rotation.y -= deltaX * options.mouseSensitivity
+        }
+
+        const gamepadLook = actionResolver.getAxisValue(InputAction.LookHorizontal)
+        if (gamepadLook !== 0) {
+            camera.rotation.y -= gamepadLook * options.mouseSensitivity * 2
+        }
+    }
+}

--- a/client/src/input/InputActionResolver.ts
+++ b/client/src/input/InputActionResolver.ts
@@ -37,10 +37,18 @@ export class InputActionResolver {
         const gamepads = Array.from(navigator.getGamepads?.() ?? []).filter((gamepad): gamepad is Gamepad => Boolean(gamepad && gamepad.connected))
         this.lastConnectedGamepads = gamepads
 
+        const connectedProfileIds = new Set(
+            this.deviceDetector.getAvailableDevices()
+                .filter(device => device.connected)
+                .map(device => device.profileId)
+        )
+
+        const connectedProfiles = enabledProfiles.filter(profile => connectedProfileIds.has(profile.id))
+
         const mergedAxes = new Map<string, number>()
         const mergedButtons = new Map<string, boolean>()
 
-        for (const profile of enabledProfiles) {
+        for (const profile of connectedProfiles) {
             const resolved = this.bindingResolver.resolve(profile, {
                 keysPressed,
                 mouseButtonsPressed,

--- a/client/src/input/InputActionResolver.ts
+++ b/client/src/input/InputActionResolver.ts
@@ -1,0 +1,107 @@
+import { BindingResolver } from './BindingResolver'
+import { DeviceDetector, type InputDeviceInfo } from './DeviceDetector'
+import type { InputProfileDefinition } from './InputProfile'
+
+export interface InputActionSnapshot {
+    axes: ReadonlyMap<string, number>
+    buttons: ReadonlyMap<string, boolean>
+}
+
+export class InputActionResolver {
+    private readonly bindingResolver: BindingResolver
+    private readonly deviceDetector: DeviceDetector
+    private actionAxes = new Map<string, number>()
+    private actionButtons = new Map<string, boolean>()
+    private lastConnectedGamepads: ReadonlyArray<Gamepad> = []
+
+    constructor(bindingResolver: BindingResolver, deviceDetector: DeviceDetector) {
+        this.bindingResolver = bindingResolver
+        this.deviceDetector = deviceDetector
+    }
+
+    start(): void {
+        this.deviceDetector.start()
+    }
+
+    stop(): void {
+        this.deviceDetector.stop()
+    }
+
+    setXRSession(session: XRSession | null): void {
+        this.deviceDetector.setXRSession(session)
+    }
+
+    updateFrame(enabledProfiles: ReadonlyArray<InputProfileDefinition>, keysPressed: ReadonlySet<string>, mouseButtonsPressed: ReadonlySet<number>): void {
+        this.deviceDetector.pollGamepads()
+
+        const gamepads = Array.from(navigator.getGamepads?.() ?? []).filter((gamepad): gamepad is Gamepad => Boolean(gamepad && gamepad.connected))
+        this.lastConnectedGamepads = gamepads
+
+        const mergedAxes = new Map<string, number>()
+        const mergedButtons = new Map<string, boolean>()
+
+        for (const profile of enabledProfiles) {
+            const resolved = this.bindingResolver.resolve(profile, {
+                keysPressed,
+                mouseButtonsPressed,
+                mouseDeltaX: 0,
+                mouseDeltaY: 0,
+                gamepads
+            })
+
+            for (const [actionId, value] of resolved.axes.entries()) {
+                const existingValue = mergedAxes.get(actionId) ?? 0
+                if (Math.abs(value) > Math.abs(existingValue)) {
+                    mergedAxes.set(actionId, value)
+                }
+            }
+
+            for (const [actionId, pressed] of resolved.buttons.entries()) {
+                if (pressed) {
+                    mergedButtons.set(actionId, true)
+                } else if (!mergedButtons.has(actionId)) {
+                    mergedButtons.set(actionId, false)
+                }
+            }
+        }
+
+        this.actionAxes = mergedAxes
+        this.actionButtons = mergedButtons
+    }
+
+    getSnapshot(): InputActionSnapshot {
+        return {
+            axes: this.actionAxes,
+            buttons: this.actionButtons
+        }
+    }
+
+    getAxisValue(actionId: string): number {
+        return this.actionAxes.get(actionId) ?? 0
+    }
+
+    isActionPressed(actionId: string): boolean {
+        return this.actionButtons.get(actionId) ?? false
+    }
+
+    getAvailableDevices(): ReadonlyArray<InputDeviceInfo> {
+        return this.deviceDetector.getAvailableDevices()
+    }
+
+    getConnectedGamepadAxisSnapshot(): ReadonlyArray<{ label: string; value: number }> {
+        if (this.lastConnectedGamepads.length === 0) {
+            return []
+        }
+
+        const gamepad = this.lastConnectedGamepads[0]
+        return gamepad.axes.map((axisValue, axisIndex) => ({
+            label: `Axis ${axisIndex}`,
+            value: axisValue
+        }))
+    }
+
+    clear(): void {
+        this.actionAxes.clear()
+        this.actionButtons.clear()
+    }
+}

--- a/client/src/input/InputBindingUtils.ts
+++ b/client/src/input/InputBindingUtils.ts
@@ -1,0 +1,139 @@
+import { getInputActionDefinition, InputAction, type InputActionId } from './InputActions'
+import type { GamepadAxisBinding, InputBinding, InputProfileDefinition, MouseAxisBinding } from './InputProfile'
+
+const LINKED_AXIS_ACTIONS: ReadonlyArray<readonly [InputActionId, InputActionId]> = [
+    [InputAction.MoveForward, InputAction.MoveBack],
+    [InputAction.MoveLeft, InputAction.MoveRight],
+    [InputAction.MoveUp, InputAction.MoveDown]
+]
+
+function getLinkedDerivedAction(actionId: InputActionId): InputActionId | null {
+    for (const [sourceAction, derivedAction] of LINKED_AXIS_ACTIONS) {
+        if (sourceAction === actionId) {
+            return derivedAction
+        }
+    }
+
+    return null
+}
+
+function normalizeBindingSignature(binding: InputBinding): string {
+    switch (binding.type) {
+        case 'keyboard-button':
+            return `${binding.type}:${binding.code}:${binding.direction ?? 'positive'}`
+        case 'mouse-button':
+            return `${binding.type}:${binding.button}:${binding.direction ?? 'positive'}`
+        case 'mouse-axis':
+            return `${binding.type}:${binding.axis}:${binding.invert === true ? '1' : '0'}:${binding.sensitivity ?? 1}`
+        case 'gamepad-button':
+            return `${binding.type}:${binding.button}:${binding.threshold ?? 0.5}:${binding.direction ?? 'positive'}`
+        case 'gamepad-axis':
+            return `${binding.type}:${binding.axis}:${binding.direction ?? 'both'}:${binding.deadZone ?? 0.15}:${binding.invert === true ? '1' : '0'}`
+        case 'touch-gesture':
+            return `${binding.type}:${binding.gesture}`
+        case 'xr-component':
+            return `${binding.type}:${binding.handedness ?? 'none'}:${binding.componentPath}`
+        default:
+            return 'unknown'
+    }
+}
+
+function isInvertibleAxisBinding(binding: InputBinding): binding is GamepadAxisBinding | MouseAxisBinding {
+    return binding.type === 'gamepad-axis' || binding.type === 'mouse-axis'
+}
+
+function invertAxisBinding(binding: GamepadAxisBinding | MouseAxisBinding): GamepadAxisBinding | MouseAxisBinding {
+    if (binding.type === 'mouse-axis') {
+        return {
+            ...binding,
+            invert: !binding.invert
+        }
+    }
+
+    if (binding.direction === 'positive') {
+        return {
+            ...binding,
+            direction: 'negative'
+        }
+    }
+
+    if (binding.direction === 'negative') {
+        return {
+            ...binding,
+            direction: 'positive'
+        }
+    }
+
+    return {
+        ...binding,
+        invert: !binding.invert
+    }
+}
+
+export function getLinkedInverseAssignment(actionId: InputActionId, binding: InputBinding): { actionId: InputActionId; binding: InputBinding } | null {
+    const derivedAction = getLinkedDerivedAction(actionId)
+    if (!derivedAction) {
+        return null
+    }
+
+    if (!isInvertibleAxisBinding(binding)) {
+        return null
+    }
+
+    const inverseBinding = invertAxisBinding(binding)
+
+    return {
+        actionId: derivedAction,
+        binding: inverseBinding
+    }
+}
+
+export function isDerivedLinkedActionLocked(profile: InputProfileDefinition, actionId: InputActionId): boolean {
+    for (const [sourceAction, derivedAction] of LINKED_AXIS_ACTIONS) {
+        if (derivedAction !== actionId) {
+            continue
+        }
+
+        const sourceBindings = profile.bindings[sourceAction] ?? []
+        return sourceBindings.some(isInvertibleAxisBinding)
+    }
+
+    return false
+}
+
+export function getDuplicateBindingWarnings(profile: InputProfileDefinition): ReadonlyMap<InputActionId, string> {
+    const bindingToActions = new Map<string, Set<InputActionId>>()
+
+    for (const [actionId, bindings] of Object.entries(profile.bindings) as Array<[InputActionId, ReadonlyArray<InputBinding>]>) {
+        for (const binding of bindings) {
+            const signature = normalizeBindingSignature(binding)
+            const actions = bindingToActions.get(signature) ?? new Set<InputActionId>()
+            actions.add(actionId)
+            bindingToActions.set(signature, actions)
+        }
+    }
+
+    const warnings = new Map<InputActionId, string>()
+
+    for (const actions of bindingToActions.values()) {
+        if (actions.size < 2) {
+            continue
+        }
+
+        const actionIds = Array.from(actions)
+        for (const actionId of actionIds) {
+            const others = actionIds
+                .filter(candidate => candidate !== actionId)
+                .map(candidate => getInputActionDefinition(candidate).label)
+            if (others.length === 0) {
+                continue
+            }
+
+            const existing = warnings.get(actionId)
+            const message = `Also bound to ${others.join(', ')}`
+            warnings.set(actionId, existing ? `${existing}; ${message}` : message)
+        }
+    }
+
+    return warnings
+}

--- a/client/src/input/InputContracts.ts
+++ b/client/src/input/InputContracts.ts
@@ -1,0 +1,41 @@
+export interface InputState {
+    keys: {
+        w: boolean
+        a: boolean
+        s: boolean
+        d: boolean
+        q: boolean
+        e: boolean
+        space: boolean
+        c: boolean
+    }
+    mouse: {
+        down: boolean
+        x: number
+        y: number
+    }
+}
+
+export interface InputCallbacks {
+    onKeyPress?: (key: string) => void
+    onKeyRelease?: (key: string) => void
+}
+
+export interface MovementOptions {
+    speed: number
+    mouseSensitivity: number
+    sprintMultiplier: number
+}
+
+export type InputKey = keyof InputState['keys']
+
+export const KEY_CODE_TO_INPUT_KEY: Readonly<Record<string, InputKey>> = {
+    KeyW: 'w',
+    KeyA: 'a',
+    KeyS: 's',
+    KeyD: 'd',
+    KeyQ: 'q',
+    KeyE: 'e',
+    Space: 'space',
+    KeyC: 'c'
+}

--- a/client/src/input/InputEventAdapter.ts
+++ b/client/src/input/InputEventAdapter.ts
@@ -1,0 +1,39 @@
+import { InputStateTracker } from './InputStateTracker'
+
+export class InputEventAdapter {
+    private isListening = false
+    private readonly stateTracker: InputStateTracker
+
+    constructor(stateTracker: InputStateTracker) {
+        this.stateTracker = stateTracker
+    }
+
+    startListening(): boolean {
+        if (this.isListening) {
+            return false
+        }
+
+        document.addEventListener('mousedown', this.stateTracker.handleMouseDown)
+        document.addEventListener('mouseup', this.stateTracker.handleMouseUp)
+        document.addEventListener('mousemove', this.stateTracker.handleMouseMove)
+        document.addEventListener('keydown', this.stateTracker.handleKeyDown)
+        document.addEventListener('keyup', this.stateTracker.handleKeyUp)
+
+        this.isListening = true
+        return true
+    }
+
+    stopListening(): void {
+        if (!this.isListening) {
+            return
+        }
+
+        document.removeEventListener('mousedown', this.stateTracker.handleMouseDown)
+        document.removeEventListener('mouseup', this.stateTracker.handleMouseUp)
+        document.removeEventListener('mousemove', this.stateTracker.handleMouseMove)
+        document.removeEventListener('keydown', this.stateTracker.handleKeyDown)
+        document.removeEventListener('keyup', this.stateTracker.handleKeyUp)
+
+        this.isListening = false
+    }
+}

--- a/client/src/input/InputManager.ts
+++ b/client/src/input/InputManager.ts
@@ -1,62 +1,22 @@
 import * as THREE from 'three'
-import { EventManager, EventSource } from '../core/EventManager'
-import type { InputActionChangedEvent, InputProfileChangedEvent } from '../types/InteractionEvents'
-import { InputEventTypes } from '../types/InteractionEvents'
+import { EventManager } from '../core/EventManager'
 import { Logger } from '../utils/Logger'
 import { InputAction } from './InputActions'
 import { BindingResolver } from './BindingResolver'
-import { DeviceDetector, type InputDeviceInfo } from './DeviceDetector'
-import { InputProfileId, type InputBinding, type InputProfileDefinition, type InputProfileIdValue } from './InputProfile'
-import type { InputActionId } from './InputActions'
+import { DeviceDetector } from './DeviceDetector'
 import { InputProfileStore } from './InputProfileStore'
+import { CameraInputApplier } from './CameraInputApplier'
+import type { InputCallbacks, InputState, MovementOptions } from './InputContracts'
+import { InputActionResolver } from './InputActionResolver'
+import { InputEventAdapter } from './InputEventAdapter'
+import { InputProfileService } from './InputProfileService'
+import { InputStateTracker } from './InputStateTracker'
 
-export interface InputState {
-    keys: {
-        w: boolean
-        a: boolean
-        s: boolean
-        d: boolean
-        q: boolean
-        e: boolean
-        space: boolean
-        c: boolean
-    }
-    mouse: {
-        down: boolean
-        x: number
-        y: number
-    }
-}
-
-export interface MovementOptions {
-    speed: number
-    mouseSensitivity: number
-    sprintMultiplier: number
-}
-
-export interface InputCallbacks {
-    onMouseMove?: (deltaX: number, deltaY: number) => void
-    onKeyPress?: (key: string) => void
-    onKeyRelease?: (key: string) => void
-}
+export type { InputCallbacks, InputState, MovementOptions } from './InputContracts'
 
 export class InputManager {
     private static readonly logger = Logger.createLogFunctions(InputManager.name)
     private static activeInstance: InputManager | null = null
-
-    private readonly eventManager: EventManager
-    private readonly profileStore: InputProfileStore
-    private readonly bindingResolver: BindingResolver
-    private readonly deviceDetector: DeviceDetector
-
-    private inputState: InputState = {
-        keys: { w: false, a: false, s: false, d: false, q: false, e: false, space: false, c: false },
-        mouse: { down: false, x: 0, y: 0 }
-    }
-
-    private keyPressTime: { [key: string]: number } = {}
-    private readonly ACCELERATION_TIME = 2500
-    private readonly MAX_SPEED_MULTIPLIER = 1.4
 
     private options: MovementOptions = {
         speed: 0.075,
@@ -64,26 +24,28 @@ export class InputManager {
         sprintMultiplier: 1.5
     }
 
-    private callbacks: InputCallbacks = {}
     private isListeningToEvents = false
-    private activeProfileId: InputProfileIdValue = InputProfileId.MouseKeyboard
-    private actionAxes = new Map<string, number>()
-    private actionButtons = new Map<string, boolean>()
-    private previousActionButtons = new Map<string, boolean>()
-    private keysPressed = new Set<string>()
-    private mouseButtonsPressed = new Set<number>()
-    private mouseDeltaX = 0
-    private mouseDeltaY = 0
-    private lastConnectedGamepads: ReadonlyArray<Gamepad> = []
+
+    private readonly stateTracker: InputStateTracker
+    private readonly eventAdapter: InputEventAdapter
+    readonly profileService: InputProfileService
+    readonly actionResolver: InputActionResolver
+    private readonly cameraInputApplier: CameraInputApplier
 
     constructor(options: Partial<MovementOptions> = {}, callbacks: InputCallbacks = {}) {
         this.options = { ...this.options, ...options }
-        this.callbacks = callbacks
-        this.eventManager = EventManager.getInstance()
-        this.profileStore = new InputProfileStore()
-        this.bindingResolver = new BindingResolver()
-        this.deviceDetector = new DeviceDetector(this.eventManager)
-        this.activeProfileId = this.profileStore.getActiveProfileId()
+
+        const eventManager = EventManager.getInstance()
+        const profileStore = new InputProfileStore()
+        const bindingResolver = new BindingResolver()
+        const deviceDetector = new DeviceDetector(eventManager)
+
+        this.stateTracker = new InputStateTracker(callbacks)
+        this.eventAdapter = new InputEventAdapter(this.stateTracker)
+        this.profileService = new InputProfileService(eventManager, profileStore)
+        this.actionResolver = new InputActionResolver(bindingResolver, deviceDetector)
+        this.cameraInputApplier = new CameraInputApplier()
+
         InputManager.activeInstance = this
     }
 
@@ -97,9 +59,8 @@ export class InputManager {
             return
         }
 
-        this.setupMouseControls()
-        this.setupKeyboardControls()
-        this.deviceDetector.start()
+        this.eventAdapter.startListening()
+        this.actionResolver.start()
         this.isListeningToEvents = true
 
         InputManager.logger.debug('Input controls activated')
@@ -110,374 +71,66 @@ export class InputManager {
             return
         }
 
-        this.removeEventListeners()
-        this.deviceDetector.stop()
+        this.eventAdapter.stopListening()
+        this.actionResolver.stop()
         this.isListeningToEvents = false
 
         InputManager.logger.debug('Input controls deactivated')
     }
 
-    private setupMouseControls(): void {
-        document.addEventListener('mousedown', this.handleMouseDown)
-        document.addEventListener('mouseup', this.handleMouseUp)
-        document.addEventListener('mousemove', this.handleMouseMove)
-    }
-
-    private setupKeyboardControls(): void {
-        document.addEventListener('keydown', this.handleKeyDown)
-        document.addEventListener('keyup', this.handleKeyUp)
-    }
-
-    private removeEventListeners(): void {
-        document.removeEventListener('mousedown', this.handleMouseDown)
-        document.removeEventListener('mouseup', this.handleMouseUp)
-        document.removeEventListener('mousemove', this.handleMouseMove)
-        document.removeEventListener('keydown', this.handleKeyDown)
-        document.removeEventListener('keyup', this.handleKeyUp)
-    }
-
-    private handleMouseDown = (event: MouseEvent): void => {
-        this.inputState.mouse.down = true
-        this.inputState.mouse.x = event.clientX
-        this.inputState.mouse.y = event.clientY
-        this.mouseButtonsPressed.add(event.button)
-    }
-
-    private handleMouseUp = (event: MouseEvent): void => {
-        this.inputState.mouse.down = false
-        this.mouseButtonsPressed.delete(event.button)
-    }
-
-    private handleMouseMove = (event: MouseEvent): void => {
-        const deltaX = event.clientX - this.inputState.mouse.x
-        const deltaY = event.clientY - this.inputState.mouse.y
-
-        this.inputState.mouse.x = event.clientX
-        this.inputState.mouse.y = event.clientY
-
-        if (!this.inputState.mouse.down) {
-            return
-        }
-
-        this.mouseDeltaX += deltaX
-        this.mouseDeltaY += deltaY
-        this.callbacks.onMouseMove?.(deltaX, deltaY)
-    }
-
-    private handleKeyDown = (event: KeyboardEvent): void => {
-        this.keysPressed.add(event.code)
-
-        switch (event.code) {
-            case 'KeyW':
-                this.setKeyPressed('w')
-                break
-            case 'KeyA':
-                this.setKeyPressed('a')
-                break
-            case 'KeyS':
-                this.setKeyPressed('s')
-                break
-            case 'KeyD':
-                this.setKeyPressed('d')
-                break
-            case 'KeyQ':
-                this.setKeyPressed('q')
-                break
-            case 'KeyE':
-                this.setKeyPressed('e')
-                break
-            case 'Space':
-                this.setKeyPressed('space')
-                break
-            case 'KeyC':
-                this.setKeyPressed('c')
-                break
-            default:
-                break
-        }
-    }
-
-    private handleKeyUp = (event: KeyboardEvent): void => {
-        this.keysPressed.delete(event.code)
-
-        switch (event.code) {
-            case 'KeyW':
-                this.setKeyReleased('w')
-                break
-            case 'KeyA':
-                this.setKeyReleased('a')
-                break
-            case 'KeyS':
-                this.setKeyReleased('s')
-                break
-            case 'KeyD':
-                this.setKeyReleased('d')
-                break
-            case 'KeyQ':
-                this.setKeyReleased('q')
-                break
-            case 'KeyE':
-                this.setKeyReleased('e')
-                break
-            case 'Space':
-                this.setKeyReleased('space')
-                break
-            case 'KeyC':
-                this.setKeyReleased('c')
-                break
-            default:
-                break
-        }
-    }
-
-    private setKeyPressed(key: keyof InputState['keys']): void {
-        if (!this.inputState.keys[key]) {
-            this.inputState.keys[key] = true
-            this.keyPressTime[key] = Date.now()
-            this.callbacks.onKeyPress?.(key)
-        }
-    }
-
-    private setKeyReleased(key: keyof InputState['keys']): void {
-        this.inputState.keys[key] = false
-        delete this.keyPressTime[key]
-        this.callbacks.onKeyRelease?.(key)
-    }
-
-    private getProgressiveSpeed(key: string): number {
-        const pressTime = this.keyPressTime[key]
-        if (!pressTime) {
-            return 0
-        }
-
-        const heldTime = Date.now() - pressTime
-        const progress = Math.min(heldTime / this.ACCELERATION_TIME, 1)
-
-        const minSpeed = this.options.speed * 0.1
-        const maxSpeed = this.options.speed * this.MAX_SPEED_MULTIPLIER
-
-        return minSpeed + (maxSpeed - minSpeed) * progress
-    }
-
     updateFrame(): void {
-        this.deviceDetector.pollGamepads()
-
-        const gamepads = Array.from(navigator.getGamepads?.() ?? []).filter((gamepad): gamepad is Gamepad => Boolean(gamepad && gamepad.connected))
-        this.lastConnectedGamepads = gamepads
-
-        const enabledProfiles = this.getEnabledProfiles()
-        const mergedAxes = new Map<string, number>()
-        const mergedButtons = new Map<string, boolean>()
-
-        for (const profile of enabledProfiles) {
-            const resolved = this.bindingResolver.resolve(profile, {
-                keysPressed: this.keysPressed,
-                mouseButtonsPressed: this.mouseButtonsPressed,
-                mouseDeltaX: this.mouseDeltaX,
-                mouseDeltaY: this.mouseDeltaY,
-                gamepads
-            })
-
-            for (const [actionId, value] of resolved.axes.entries()) {
-                const existingValue = mergedAxes.get(actionId) ?? 0
-                if (Math.abs(value) > Math.abs(existingValue)) {
-                    mergedAxes.set(actionId, value)
-                }
-            }
-
-            for (const [actionId, pressed] of resolved.buttons.entries()) {
-                if (pressed) {
-                    mergedButtons.set(actionId, true)
-                } else if (!mergedButtons.has(actionId)) {
-                    mergedButtons.set(actionId, false)
-                }
-            }
-        }
-
-        this.actionAxes = mergedAxes
-        this.actionButtons = mergedButtons
-        this.emitActionChanges()
-
-        this.mouseDeltaX = 0
-        this.mouseDeltaY = 0
+        this.actionResolver.updateFrame(
+            this.profileService.getEnabledProfiles(),
+            this.stateTracker.getKeysPressed(),
+            this.stateTracker.getMouseButtonsPressed()
+        )
     }
 
     updateCameraMovement(camera: THREE.Camera): void {
         this.updateFrame()
 
-        const sprintMultiplier = this.isSprintActive() ? this.options.sprintMultiplier : 1
-
-        if (this.inputState.keys.w) camera.translateZ(-(this.getProgressiveSpeed('w') * sprintMultiplier))
-        if (this.inputState.keys.s) camera.translateZ(this.getProgressiveSpeed('s') * sprintMultiplier)
-        if (this.inputState.keys.a) camera.translateX(-(this.getProgressiveSpeed('a') * sprintMultiplier))
-        if (this.inputState.keys.d) camera.translateX(this.getProgressiveSpeed('d') * sprintMultiplier)
-        if (this.inputState.keys.space) camera.translateY(this.getProgressiveSpeed('space') * sprintMultiplier)
-        if (this.inputState.keys.c) camera.translateY(-(this.getProgressiveSpeed('c') * sprintMultiplier))
-
-        const gamepadForward = this.getAxisValue(InputAction.MoveForward)
-        const gamepadBack = this.getAxisValue(InputAction.MoveBack)
-        const gamepadLeft = this.getAxisValue(InputAction.MoveLeft)
-        const gamepadRight = this.getAxisValue(InputAction.MoveRight)
-        const gamepadUp = this.getAxisValue(InputAction.MoveUp)
-        const gamepadDown = this.getAxisValue(InputAction.MoveDown)
-
-        if (gamepadForward > 0) camera.translateZ(-(this.options.speed * gamepadForward * sprintMultiplier))
-        if (gamepadBack > 0) camera.translateZ(this.options.speed * gamepadBack * sprintMultiplier)
-        if (gamepadLeft > 0) camera.translateX(-(this.options.speed * gamepadLeft * sprintMultiplier))
-        if (gamepadRight > 0) camera.translateX(this.options.speed * gamepadRight * sprintMultiplier)
-        if (gamepadUp > 0) camera.translateY(this.options.speed * gamepadUp * sprintMultiplier)
-        if (gamepadDown > 0) camera.translateY(-(this.options.speed * gamepadDown * sprintMultiplier))
+        this.cameraInputApplier.updateMovement(
+            camera,
+            this.actionResolver,
+            this.options,
+            this.isSprintActive()
+        )
     }
 
-    updateCameraRotation(camera: THREE.Camera, deltaX: number, _deltaY: number): void {
-        camera.rotation.y -= deltaX * this.options.mouseSensitivity
-
-        const gamepadLook = this.getAxisValue(InputAction.LookHorizontal)
-        if (gamepadLook !== 0) {
-            camera.rotation.y -= gamepadLook * this.options.mouseSensitivity * 2
-        }
-    }
-
-    updateCameraRoll(_camera: THREE.Camera): void {
+    updateCameraRotation(camera: THREE.Camera, explicitDeltaX?: number): void {
+        const deltaX = explicitDeltaX ?? this.stateTracker.consumeMouseDeltaX()
+        this.cameraInputApplier.updateRotation(camera, this.actionResolver, this.options, deltaX)
     }
 
     getInputState(): InputState {
-        return { ...this.inputState }
+        return this.stateTracker.getInputState()
     }
 
     setMovementOptions(options: Partial<MovementOptions>): void {
         this.options = { ...this.options, ...options }
     }
 
-    setCallbacks(callbacks: InputCallbacks): void {
-        this.callbacks = { ...this.callbacks, ...callbacks }
-    }
-
     isMoving(): boolean {
-        const { keys } = this.inputState
-        return keys.w || keys.a || keys.s || keys.d || keys.q || keys.e
-    }
-
-    getAxisValue(actionId: string): number {
-        return this.actionAxes.get(actionId) ?? 0
-    }
-
-    isActionPressed(actionId: string): boolean {
-        return this.actionButtons.get(actionId) ?? false
-    }
-
-    getAvailableDevices(): ReadonlyArray<InputDeviceInfo> {
-        return this.deviceDetector.getAvailableDevices()
-    }
-
-    getProfiles(): ReadonlyArray<InputProfileDefinition> {
-        return this.profileStore.getProfiles()
-    }
-
-    getEnabledProfiles(): ReadonlyArray<InputProfileDefinition> {
-        return this.profileStore.getProfiles().filter(profile => profile.enabled)
-    }
-
-    getActiveProfile(): InputProfileDefinition {
-        return this.profileStore.getProfile(this.activeProfileId)
-    }
-
-    getActiveProfileId(): InputProfileIdValue {
-        return this.activeProfileId
-    }
-
-    setActiveProfile(profileId: InputProfileIdValue): void {
-        if (this.activeProfileId === profileId) {
-            return
-        }
-
-        this.activeProfileId = profileId
-        this.profileStore.setActiveProfileId(profileId)
-        this.eventManager.emit<InputProfileChangedEvent>(
-            InputEventTypes.ProfileChanged,
-            { profileId },
-            EventSource.UI
-        )
-    }
-
-    setProfileEnabled(profileId: InputProfileIdValue, enabled: boolean): void {
-        this.profileStore.setProfileEnabled(profileId, enabled)
-        this.eventManager.emit<InputProfileChangedEvent>(
-            InputEventTypes.ProfileChanged,
-            { profileId: this.activeProfileId },
-            EventSource.UI
-        )
+        return this.stateTracker.isMoving()
     }
 
     setXRSession(session: XRSession | null): void {
-        this.deviceDetector.setXRSession(session)
-    }
-
-    setActionBinding(actionId: InputActionId, binding: InputBinding): void {
-        this.profileStore.setActionBindings(this.activeProfileId, actionId, [binding])
-        this.eventManager.emit<InputProfileChangedEvent>(
-            InputEventTypes.ProfileChanged,
-            { profileId: this.activeProfileId },
-            EventSource.UI
-        )
-    }
-
-    getConnectedGamepadAxisSnapshot(): ReadonlyArray<{ label: string; value: number }> {
-        if (this.lastConnectedGamepads.length === 0) {
-            return []
-        }
-
-        const gamepad = this.lastConnectedGamepads[0]
-        return gamepad.axes.map((axisValue, axisIndex) => ({
-            label: `Axis ${axisIndex}`,
-            value: axisValue
-        }))
+        this.actionResolver.setXRSession(session)
     }
 
     private isSprintActive(): boolean {
-        if (this.isActionPressed(InputAction.Sprint)) {
+        if (this.actionResolver.isActionPressed(InputAction.Sprint)) {
             return true
         }
 
-        return this.keysPressed.has('ShiftLeft') || this.keysPressed.has('ShiftRight')
-    }
-
-    resetActiveProfileBindings(): void {
-        this.profileStore.clearProfileOverrides(this.activeProfileId)
-        this.eventManager.emit<InputProfileChangedEvent>(
-            InputEventTypes.ProfileChanged,
-            { profileId: this.activeProfileId },
-            EventSource.UI
-        )
-    }
-
-    private emitActionChanges(): void {
-        for (const [actionId, isPressed] of this.actionButtons.entries()) {
-            const previousPressed = this.previousActionButtons.get(actionId) ?? false
-            if (previousPressed === isPressed) {
-                continue
-            }
-
-            this.eventManager.emit<InputActionChangedEvent>(
-                InputEventTypes.ActionChanged,
-                {
-                    actionId,
-                    pressed: isPressed
-                },
-                EventSource.System
-            )
-            this.previousActionButtons.set(actionId, isPressed)
-        }
+        return this.stateTracker.isShiftPressed()
     }
 
     dispose(): void {
         this.stopListening()
-        this.callbacks = {}
-        this.keysPressed.clear()
-        this.mouseButtonsPressed.clear()
-        this.actionAxes.clear()
-        this.actionButtons.clear()
-        this.previousActionButtons.clear()
+        this.stateTracker.clearCallbacks()
+        this.stateTracker.clear()
+        this.actionResolver.clear()
 
         if (InputManager.activeInstance === this) {
             InputManager.activeInstance = null

--- a/client/src/input/InputProfile.ts
+++ b/client/src/input/InputProfile.ts
@@ -18,15 +18,19 @@ export const InputDeviceKind = {
 
 export type InputDeviceKindValue = typeof InputDeviceKind[keyof typeof InputDeviceKind]
 
+export type AxisDirection = 'positive' | 'negative'
+
 export interface KeyboardButtonBinding {
     type: 'keyboard-button'
     code: string
+    direction?: AxisDirection
     label?: string
 }
 
 export interface MouseButtonBinding {
     type: 'mouse-button'
     button: number
+    direction?: AxisDirection
     label?: string
 }
 
@@ -42,6 +46,7 @@ export interface GamepadButtonBinding {
     type: 'gamepad-button'
     button: number
     threshold?: number
+    direction?: AxisDirection
     label?: string
 }
 
@@ -105,15 +110,20 @@ export function formatBindingLabel(binding: InputBinding): string {
         return binding.label
     }
 
+    const directionalSuffix =
+        'direction' in binding && binding.direction
+            ? binding.direction === 'positive' ? ' (+)' : ' (-)'
+            : ''
+
     switch (binding.type) {
         case 'keyboard-button':
-            return binding.code
+            return `${binding.code}${directionalSuffix}`
         case 'mouse-button':
-            return binding.button === 0 ? 'Left Click' : `Mouse ${binding.button}`
+            return `${binding.button === 0 ? 'Left Click' : `Mouse ${binding.button}`}${directionalSuffix}`
         case 'mouse-axis':
             return binding.axis === 'x' ? 'Mouse X' : 'Mouse Y'
         case 'gamepad-button':
-            return `Gamepad Button ${binding.button}`
+            return `Gamepad Button ${binding.button}${directionalSuffix}`
         case 'gamepad-axis':
             return `Gamepad Axis ${binding.axis}`
         case 'touch-gesture':

--- a/client/src/input/InputProfileService.ts
+++ b/client/src/input/InputProfileService.ts
@@ -1,0 +1,67 @@
+import { EventManager, EventSource } from '../core/EventManager'
+import type { InputProfileChangedEvent } from '../types/InteractionEvents'
+import { InputEventTypes } from '../types/InteractionEvents'
+import type { InputActionId } from './InputActions'
+import { InputProfileId, type InputBinding, type InputProfileDefinition, type InputProfileIdValue } from './InputProfile'
+import { InputProfileStore } from './InputProfileStore'
+
+export class InputProfileService {
+    private readonly eventManager: EventManager
+    private readonly profileStore: InputProfileStore
+    private activeProfileId: InputProfileIdValue
+
+    constructor(eventManager: EventManager, profileStore: InputProfileStore) {
+        this.eventManager = eventManager
+        this.profileStore = profileStore
+        this.activeProfileId = this.profileStore.getActiveProfileId() ?? InputProfileId.MouseKeyboard
+    }
+
+    getProfiles(): ReadonlyArray<InputProfileDefinition> {
+        return this.profileStore.getProfiles()
+    }
+
+    getEnabledProfiles(): ReadonlyArray<InputProfileDefinition> {
+        return this.profileStore.getProfiles().filter(profile => profile.enabled)
+    }
+
+    getActiveProfile(): InputProfileDefinition {
+        return this.profileStore.getProfile(this.activeProfileId)
+    }
+
+    getActiveProfileId(): InputProfileIdValue {
+        return this.activeProfileId
+    }
+
+    setActiveProfile(profileId: InputProfileIdValue): void {
+        if (this.activeProfileId === profileId) {
+            return
+        }
+
+        this.activeProfileId = profileId
+        this.profileStore.setActiveProfileId(profileId)
+        this.emitProfileChanged(profileId)
+    }
+
+    setProfileEnabled(profileId: InputProfileIdValue, enabled: boolean): void {
+        this.profileStore.setProfileEnabled(profileId, enabled)
+        this.emitProfileChanged(profileId)
+    }
+
+    setActionBinding(actionId: InputActionId, binding: InputBinding): void {
+        this.profileStore.setActionBindings(this.activeProfileId, actionId, [binding])
+        this.emitProfileChanged(this.activeProfileId)
+    }
+
+    resetActiveProfileBindings(): void {
+        this.profileStore.clearProfileOverrides(this.activeProfileId)
+        this.emitProfileChanged(this.activeProfileId)
+    }
+
+    private emitProfileChanged(profileId: InputProfileIdValue): void {
+        this.eventManager.emit<InputProfileChangedEvent>(
+            InputEventTypes.ProfileChanged,
+            { profileId },
+            EventSource.UI
+        )
+    }
+}

--- a/client/src/input/InputStateTracker.ts
+++ b/client/src/input/InputStateTracker.ts
@@ -1,0 +1,123 @@
+import type { InputCallbacks, InputKey, InputState, MovementOptions } from './InputContracts'
+import { KEY_CODE_TO_INPUT_KEY } from './InputContracts'
+
+export class InputStateTracker {
+    private inputState: InputState = {
+        keys: { w: false, a: false, s: false, d: false, q: false, e: false, space: false, c: false },
+        mouse: { down: false, x: 0, y: 0 }
+    }
+
+    private keyPressTime: { [key: string]: number } = {}
+    private readonly keysPressed = new Set<string>()
+    private readonly mouseButtonsPressed = new Set<number>()
+    private pendingMouseDeltaX = 0
+    private callbacks: InputCallbacks
+
+    constructor(callbacks: InputCallbacks) {
+        this.callbacks = callbacks
+    }
+
+    handleMouseDown = (event: MouseEvent): void => {
+        this.inputState.mouse.down = true
+        this.inputState.mouse.x = event.clientX
+        this.inputState.mouse.y = event.clientY
+        this.mouseButtonsPressed.add(event.button)
+    }
+
+    handleMouseUp = (event: MouseEvent): void => {
+        this.inputState.mouse.down = false
+        this.mouseButtonsPressed.delete(event.button)
+    }
+
+    handleMouseMove = (event: MouseEvent): void => {
+        this.inputState.mouse.x = event.clientX
+        this.inputState.mouse.y = event.clientY
+        if (this.mouseButtonsPressed.has(2)) {
+            this.pendingMouseDeltaX += event.movementX
+        }
+    }
+
+    handleKeyDown = (event: KeyboardEvent): void => {
+        this.keysPressed.add(event.code)
+        this.updateTrackedKeyState(event.code, this.setKeyPressed)
+    }
+
+    handleKeyUp = (event: KeyboardEvent): void => {
+        this.keysPressed.delete(event.code)
+        this.updateTrackedKeyState(event.code, this.setKeyReleased)
+    }
+
+    getInputState(): InputState {
+        return { ...this.inputState }
+    }
+
+    isMoving(): boolean {
+        const { keys } = this.inputState
+        return keys.w || keys.a || keys.s || keys.d || keys.q || keys.e
+    }
+
+    getProgressiveSpeed(key: string, options: MovementOptions, accelerationTime: number, maxSpeedMultiplier: number): number {
+        const pressTime = this.keyPressTime[key]
+        if (!pressTime) {
+            return 0
+        }
+
+        const heldTime = Date.now() - pressTime
+        const progress = Math.min(heldTime / accelerationTime, 1)
+
+        const minSpeed = options.speed * 0.1
+        const maxSpeed = options.speed * maxSpeedMultiplier
+
+        return minSpeed + (maxSpeed - minSpeed) * progress
+    }
+
+    getKeysPressed(): ReadonlySet<string> {
+        return this.keysPressed
+    }
+
+    getMouseButtonsPressed(): ReadonlySet<number> {
+        return this.mouseButtonsPressed
+    }
+
+    consumeMouseDeltaX(): number {
+        const delta = this.pendingMouseDeltaX
+        this.pendingMouseDeltaX = 0
+        return delta
+    }
+
+    isShiftPressed(): boolean {
+        return this.keysPressed.has('ShiftLeft') || this.keysPressed.has('ShiftRight')
+    }
+
+    clearCallbacks(): void {
+        this.callbacks = {}
+    }
+
+    clear(): void {
+        this.keysPressed.clear()
+        this.mouseButtonsPressed.clear()
+    }
+
+    private updateTrackedKeyState(code: string, updater: (key: InputKey) => void): void {
+        const inputKey = KEY_CODE_TO_INPUT_KEY[code]
+        if (!inputKey) {
+            return
+        }
+
+        updater.call(this, inputKey)
+    }
+
+    private setKeyPressed(key: InputKey): void {
+        if (!this.inputState.keys[key]) {
+            this.inputState.keys[key] = true
+            this.keyPressTime[key] = Date.now()
+            this.callbacks.onKeyPress?.(key)
+        }
+    }
+
+    private setKeyReleased(key: InputKey): void {
+        this.inputState.keys[key] = false
+        delete this.keyPressTime[key]
+        this.callbacks.onKeyRelease?.(key)
+    }
+}

--- a/client/src/scene/RoomManager.ts
+++ b/client/src/scene/RoomManager.ts
@@ -83,6 +83,7 @@ export class RoomManager {
     private targetDimensions: RoomDimensions | null = null
     private targetCenterOffset: { x: number; y: number; z: number } | null = null
     private isBuilding = false
+    private hasPositionedCamera = false
     private currentCenterOffset?: { x: number; y: number; z: number }
     private currentShelfLayout?: { rows: number; shelvesPerRow?: number }
     
@@ -227,13 +228,13 @@ export class RoomManager {
             this.roomGroup.position.set(centerOffset.x, centerOffset.y, appliedZ)
             this.currentCenterOffset = centerOffset
             
-            // Reposition and reorient camera to face the store center
-            // Player spawns at origin (0, 1.6, 0), should look at back wall center
-            const targetZ = appliedZ - (dimensions.depth / 2)
-            // >>> REVIEW: camera.position set here on room build/resize
-            this.camera.position.set(0, 1.6, 0)
-            this.camera.lookAt(0, 1.6, targetZ)
-            console.debug(`📷 Camera repositioned to face store center at Z=${targetZ.toFixed(1)}`)
+            if (!this.hasPositionedCamera) {
+                this.hasPositionedCamera = true
+                const targetZ = appliedZ - (dimensions.depth / 2)
+                this.camera.position.set(0, 1.6, 0)
+                this.camera.lookAt(0, 1.6, targetZ)
+                console.debug(`📷 Camera initial position set to face store center at Z=${targetZ.toFixed(1)}`)
+            }
         }
 
         this.emitProgress('Building floor')

--- a/client/src/scene/RoomManager.ts
+++ b/client/src/scene/RoomManager.ts
@@ -230,6 +230,7 @@ export class RoomManager {
             // Reposition and reorient camera to face the store center
             // Player spawns at origin (0, 1.6, 0), should look at back wall center
             const targetZ = appliedZ - (dimensions.depth / 2)
+            // >>> REVIEW: camera.position set here on room build/resize
             this.camera.position.set(0, 1.6, 0)
             this.camera.lookAt(0, 1.6, targetZ)
             console.debug(`📷 Camera repositioned to face store center at Z=${targetZ.toFixed(1)}`)

--- a/client/src/scene/SceneManager.ts
+++ b/client/src/scene/SceneManager.ts
@@ -111,7 +111,7 @@ export class SceneManager {
     }
 
     private setupCamera() {
-        // Position camera at average human eye height
+        // >>> REVIEW: camera.position set here on initial scene setup
         this.camera.position.set(0, 1.6, 0)
     }
 

--- a/client/src/styles/pause-menu/controls-panel.css
+++ b/client/src/styles/pause-menu/controls-panel.css
@@ -55,6 +55,16 @@
     color: #c2cdd9;
 }
 
+#panel-controls .input-mapping-table tr.has-binding-warning td {
+    background: rgba(255, 187, 0, 0.08);
+}
+
+#panel-controls .input-binding-warning {
+    margin-top: 4px;
+    font-size: 0.8rem;
+    color: #ffcc66;
+}
+
 #panel-controls .input-capture-status {
     min-height: 20px;
     margin-bottom: 8px;

--- a/client/src/styles/pause-menu/controls-panel.css
+++ b/client/src/styles/pause-menu/controls-panel.css
@@ -22,14 +22,7 @@
     padding: 6px 10px;
 }
 
-#panel-controls .input-profile-toggles {
-    margin-top: 10px;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 8px;
-}
-
-#panel-controls .input-profile-toggle-item {
+#panel-controls .input-device-enabled-toggle {
     display: flex;
     align-items: center;
     gap: 8px;

--- a/client/src/types/InteractionEvents.ts
+++ b/client/src/types/InteractionEvents.ts
@@ -141,11 +141,6 @@ export interface InputDevicesChangedEvent extends BaseInteractionEvent {
     }>
 }
 
-export interface InputActionChangedEvent extends BaseInteractionEvent {
-    actionId: string
-    pressed: boolean
-}
-
 export interface InputProfileChangedEvent extends BaseInteractionEvent {
     profileId: string
 }
@@ -281,7 +276,6 @@ export const InputEventTypes = {
     Resume: 'input:resume',
     SceneCanvasClick: 'input:scene-canvas-click',
     DevicesChanged: 'input:devices-changed',
-    ActionChanged: 'input:action-changed',
     ProfileChanged: 'input:profile-changed'
 } as const
 

--- a/client/src/ui/pause/panels/ControlsPanel.ts
+++ b/client/src/ui/pause/panels/ControlsPanel.ts
@@ -6,8 +6,10 @@ import { PauseMenuPanel, type PauseMenuPanelConfig } from '../PauseMenuPanel'
 import { EventManager } from '../../../core/EventManager'
 import { InputEventTypes } from '../../../types/InteractionEvents'
 import { getInputActionDefinition, InputAction, InputActionType, INPUT_ACTION_ORDER, type InputActionId } from '../../../input/InputActions'
+import { getDuplicateBindingWarnings, getLinkedInverseAssignment, isDerivedLinkedActionLocked } from '../../../input/InputBindingUtils'
 import { InputManager } from '../../../input/InputManager'
 import { formatBindingList, InputDeviceKind, InputProfileId, type AxisDirection, type InputBinding, type InputProfileDefinition, type InputProfileIdValue } from '../../../input/InputProfile'
+import { UIComponentUtils } from '../../../utils/UIComponentUtils'
 import '../../../styles/pause-menu/controls-panel.css'
 
 export class ControlsPanel extends PauseMenuPanel {
@@ -92,35 +94,28 @@ export class ControlsPanel extends PauseMenuPanel {
             return
         }
 
-        const select = panel.querySelector('#input-device-select') as HTMLSelectElement | null
-        if (select) {
-            select.addEventListener('change', () => {
-                const selectedProfileId = select.value as InputProfileIdValue
-                const inputManager = InputManager.getActiveInstance()
-                if (!inputManager) {
-                    return
-                }
+        UIComponentUtils.setupSelect<InputProfileIdValue>(panel, {
+            selectId: 'input-device-select',
+            parseValue: (rawValue) => rawValue as InputProfileIdValue,
+            onChange: this.handleProfileSelectionChange.bind(this)
+        })
 
-                inputManager.profileService.setActiveProfile(selectedProfileId)
-                this.renderMappingTable(inputManager.profileService.getActiveProfile())
-            })
-        }
+        UIComponentUtils.setupToggle(panel, {
+            toggleId: 'input-device-enabled',
+            onChange: this.handleProfileEnabledToggle.bind(this)
+        })
 
-        const resetButton = panel.querySelector('#input-reset-profile') as HTMLButtonElement | null
-        if (resetButton) {
-            resetButton.addEventListener('click', () => {
-                const inputManager = InputManager.getActiveInstance()
-                if (!inputManager) {
-                    return
-                }
+        UIComponentUtils.setupButton(panel, {
+            buttonId: 'input-reset-profile',
+            onClick: this.handleResetProfileClick.bind(this)
+        })
 
-                inputManager.profileService.resetActiveProfileBindings()
-                this.refreshUI()
-            })
-        }
-
-        panel.addEventListener('click', this.handlePanelClick)
-        panel.addEventListener('change', this.handlePanelChange)
+        UIComponentUtils.setupDelegatedDataButtons<string>(
+            panel,
+            '[data-input-edit-action]',
+            'inputEditAction',
+            (rawActionId) => this.handleEditActionClick(rawActionId as InputActionId)
+        )
 
         if (!this.deviceListenerRegistered) {
             this.eventManager.registerEventHandler(InputEventTypes.DevicesChanged, this.handleDevicesChanged)
@@ -156,34 +151,41 @@ export class ControlsPanel extends PauseMenuPanel {
         this.refreshUI()
     }
 
-    private handlePanelClick = (event: Event): void => {
-        const target = event.target as HTMLElement
-        const actionButton = target.closest('[data-input-edit-action]') as HTMLButtonElement | null
-        if (!actionButton) {
-            return
-        }
-
-        const actionId = actionButton.dataset.inputEditAction as InputActionId | undefined
-        if (!actionId) {
-            return
-        }
-
-        this.startCapture(actionId)
-    }
-
-    private handlePanelChange = (event: Event): void => {
-        const target = event.target as HTMLElement
-        const activeToggle = target.closest('[data-input-device-enabled]') as HTMLInputElement | null
-        if (!activeToggle) {
-            return
-        }
-
+    private handleProfileSelectionChange(selectedProfileId: InputProfileIdValue): void {
         const inputManager = InputManager.getActiveInstance()
         if (!inputManager) {
             return
         }
 
-        inputManager.profileService.setProfileEnabled(inputManager.profileService.getActiveProfileId(), activeToggle.checked)
+        inputManager.profileService.setActiveProfile(selectedProfileId)
+        this.renderMappingTable(inputManager.profileService.getActiveProfile())
+    }
+
+    private handleProfileEnabledToggle(checked: boolean): void {
+        const inputManager = InputManager.getActiveInstance()
+        if (!inputManager) {
+            return
+        }
+
+        inputManager.profileService.setProfileEnabled(inputManager.profileService.getActiveProfileId(), checked)
+    }
+
+    private handleResetProfileClick(): void {
+        const inputManager = InputManager.getActiveInstance()
+        if (!inputManager) {
+            return
+        }
+
+        inputManager.profileService.resetActiveProfileBindings()
+        this.refreshUI()
+    }
+
+    private handleEditActionClick(actionId: InputActionId): void {
+        if (!INPUT_ACTION_ORDER.includes(actionId)) {
+            return
+        }
+
+        this.startCapture(actionId)
     }
 
     private startCapture(actionId: InputActionId): void {
@@ -244,7 +246,14 @@ export class ControlsPanel extends PauseMenuPanel {
         }
 
         inputManager.profileService.setActionBinding(actionId, binding)
-        this.updateCaptureStatus('Binding updated')
+        const linkedAssignment = getLinkedInverseAssignment(actionId, binding)
+        if (linkedAssignment) {
+            inputManager.profileService.setActionBinding(linkedAssignment.actionId, linkedAssignment.binding)
+            const linkedLabel = getInputActionDefinition(linkedAssignment.actionId).label
+            this.updateCaptureStatus(`Binding updated; ${linkedLabel} assigned inverse`) 
+        } else {
+            this.updateCaptureStatus('Binding updated')
+        }
         this.refreshUI()
     }
 
@@ -552,30 +561,54 @@ export class ControlsPanel extends PauseMenuPanel {
             return
         }
 
-        const tbody = panel.querySelector('#input-mapping-tbody') as HTMLElement | null
-        if (!tbody) {
-            return
-        }
+        const duplicateWarnings = getDuplicateBindingWarnings(profile)
 
-        tbody.innerHTML = INPUT_ACTION_ORDER
-            .map(actionId => {
-                const action = getInputActionDefinition(actionId)
-                const bindingText = formatBindingList(profile.bindings[actionId])
-                const canEdit = this.isActionEditable(actionId)
-                return `
-                    <tr>
-                        <td>${action.label}</td>
-                        <td>${bindingText}</td>
-                        <td>
-                            ${canEdit ? `<button type="button" data-input-edit-action="${actionId}">Edit</button>` : '<span>Locked</span>'}
-                        </td>
-                    </tr>
-                `
-            })
-            .join('')
+        const rows = INPUT_ACTION_ORDER.map((actionId) => {
+            const action = getInputActionDefinition(actionId)
+            const bindingText = formatBindingList(profile.bindings[actionId])
+            const canEdit = this.isActionEditable(profile, actionId)
+            const duplicateWarning = duplicateWarnings.get(actionId)
+
+            return {
+                actionId,
+                label: action.label,
+                bindingText,
+                canEdit,
+                duplicateWarning
+            }
+        })
+
+        UIComponentUtils.renderTable(panel, {
+            tbodyId: 'input-mapping-tbody',
+            rows,
+            rowClassName: (row) => row.duplicateWarning ? 'has-binding-warning' : undefined,
+            columns: [
+                {
+                    key: 'action',
+                    renderCell: (row) => row.label
+                },
+                {
+                    key: 'binding',
+                    renderCell: (row) => `
+                        <div>${row.bindingText}</div>
+                        ${row.duplicateWarning ? `<div class="input-binding-warning">Warning: ${row.duplicateWarning}</div>` : ''}
+                    `
+                },
+                {
+                    key: 'edit',
+                    renderCell: (row) => row.canEdit
+                        ? `<button type="button" data-input-edit-action="${row.actionId}">Edit</button>`
+                        : '<span>Locked</span>'
+                }
+            ]
+        })
     }
 
-    private isActionEditable(actionId: InputActionId): boolean {
+    private isActionEditable(profile: InputProfileDefinition, actionId: InputActionId): boolean {
+        if (isDerivedLinkedActionLocked(profile, actionId)) {
+            return false
+        }
+
         const definition = getInputActionDefinition(actionId)
         return definition.type !== InputActionType.Axis
             || actionId === InputAction.MoveForward
@@ -599,9 +632,6 @@ export class ControlsPanel extends PauseMenuPanel {
         }
         this.stopAnalogRefreshTimer()
         this.stopCaptureListeners()
-        const panel = this.getPanelElement()
-        panel?.removeEventListener('click', this.handlePanelClick)
-        panel?.removeEventListener('change', this.handlePanelChange)
         super.dispose()
     }
 }

--- a/client/src/ui/pause/panels/ControlsPanel.ts
+++ b/client/src/ui/pause/panels/ControlsPanel.ts
@@ -22,7 +22,6 @@ export class ControlsPanel extends PauseMenuPanel {
     private capturingActionId: InputActionId | null = null
     private capturingProfileId: InputProfileIdValue | null = null
     private captureGamepadPollTimer: number | null = null
-    private analogRefreshTimer: number | null = null
 
     constructor(config: PauseMenuPanelConfig = {}) {
         super(config)
@@ -46,18 +45,6 @@ export class ControlsPanel extends PauseMenuPanel {
                                 <input id="input-device-enabled" type="checkbox" data-input-device-enabled />
                                 <span>Enabled for runtime input</span>
                             </label>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="app-section panel-card pause-section">
-                <h4>Analog Inputs</h4>
-                <div class="pause-row-list">
-                    <div class="pause-row control-item">
-                        <label for="input-analog-select" class="control-key pause-row-key">Detected Axis</label>
-                        <div class="control-desc pause-row-text">
-                            <select id="input-analog-select" aria-label="Detected analog axes"></select>
                         </div>
                     </div>
                 </div>
@@ -132,13 +119,9 @@ export class ControlsPanel extends PauseMenuPanel {
 
     onShow(): void {
         this.refreshUI()
-        if (this.analogRefreshTimer === null) {
-            this.analogRefreshTimer = window.setInterval(() => this.refreshUI(), 250)
-        }
     }
 
     onHide(): void {
-        this.stopAnalogRefreshTimer()
         this.stopCaptureListeners()
         this.capturingActionId = null
     }
@@ -447,12 +430,7 @@ export class ControlsPanel extends PauseMenuPanel {
         }
     }
 
-    private stopAnalogRefreshTimer(): void {
-        if (this.analogRefreshTimer !== null) {
-            window.clearInterval(this.analogRefreshTimer)
-            this.analogRefreshTimer = null
-        }
-    }
+
 
     private refreshUI(): void {
         const panel = this.getPanelElement()
@@ -469,7 +447,6 @@ export class ControlsPanel extends PauseMenuPanel {
 
         this.renderDeviceOptions(devices, profiles, activeProfileId)
         this.renderActiveToggle(activeProfile)
-        this.renderAnalogSnapshot(inputManager.actionResolver.getConnectedGamepadAxisSnapshot())
         this.renderMappingTable(activeProfile)
     }
 
@@ -532,27 +509,6 @@ export class ControlsPanel extends PauseMenuPanel {
         }
 
         toggle.checked = profile.enabled
-    }
-
-    private renderAnalogSnapshot(axes: ReadonlyArray<{ label: string; value: number }>): void {
-        const panel = this.getPanelElement()
-        if (!panel) {
-            return
-        }
-
-        const select = panel.querySelector('#input-analog-select') as HTMLSelectElement | null
-        if (!select) {
-            return
-        }
-
-        if (axes.length === 0) {
-            select.innerHTML = '<option value="">No connected gamepad axes detected</option>'
-            return
-        }
-
-        select.innerHTML = axes
-            .map(axis => `<option value="${axis.label}">${axis.label}: ${axis.value.toFixed(3)}</option>`)
-            .join('')
     }
 
     private renderMappingTable(profile: InputProfileDefinition): void {
@@ -630,7 +586,6 @@ export class ControlsPanel extends PauseMenuPanel {
             this.eventManager.deregisterEventHandler(InputEventTypes.ProfileChanged, this.handleProfileChanged)
             this.profileListenerRegistered = false
         }
-        this.stopAnalogRefreshTimer()
         this.stopCaptureListeners()
         super.dispose()
     }

--- a/client/src/ui/pause/panels/ControlsPanel.ts
+++ b/client/src/ui/pause/panels/ControlsPanel.ts
@@ -35,8 +35,16 @@ export class ControlsPanel extends PauseMenuPanel {
                             <select id="input-device-select" aria-label="Active input device"></select>
                         </div>
                     </div>
+                    <div class="pause-row control-item">
+                        <span class="control-key pause-row-key">Active</span>
+                        <div class="control-desc pause-row-text">
+                            <label class="input-device-enabled-toggle">
+                                <input id="input-device-enabled" type="checkbox" data-input-device-enabled />
+                                <span>Enabled for runtime input</span>
+                            </label>
+                        </div>
+                    </div>
                 </div>
-                <div id="input-profile-toggles" class="input-profile-toggles"></div>
             </div>
 
             <div class="app-section panel-card pause-section">
@@ -91,8 +99,8 @@ export class ControlsPanel extends PauseMenuPanel {
                     return
                 }
 
-                inputManager.setActiveProfile(selectedProfileId)
-                this.renderMappingTable(inputManager.getActiveProfile())
+                inputManager.profileService.setActiveProfile(selectedProfileId)
+                this.renderMappingTable(inputManager.profileService.getActiveProfile())
             })
         }
 
@@ -104,7 +112,7 @@ export class ControlsPanel extends PauseMenuPanel {
                     return
                 }
 
-                inputManager.resetActiveProfileBindings()
+                inputManager.profileService.resetActiveProfileBindings()
                 this.refreshUI()
             })
         }
@@ -163,13 +171,8 @@ export class ControlsPanel extends PauseMenuPanel {
 
     private handlePanelChange = (event: Event): void => {
         const target = event.target as HTMLElement
-        const toggle = target.closest('[data-input-profile-toggle]') as HTMLInputElement | null
-        if (!toggle) {
-            return
-        }
-
-        const profileId = toggle.dataset.inputProfileToggle as InputProfileIdValue | undefined
-        if (!profileId) {
+        const activeToggle = target.closest('[data-input-device-enabled]') as HTMLInputElement | null
+        if (!activeToggle) {
             return
         }
 
@@ -178,7 +181,7 @@ export class ControlsPanel extends PauseMenuPanel {
             return
         }
 
-        inputManager.setProfileEnabled(profileId, toggle.checked)
+        inputManager.profileService.setProfileEnabled(inputManager.profileService.getActiveProfileId(), activeToggle.checked)
     }
 
     private startCapture(actionId: InputActionId): void {
@@ -208,7 +211,7 @@ export class ControlsPanel extends PauseMenuPanel {
             return
         }
 
-        inputManager.setActionBinding(actionId, binding)
+        inputManager.profileService.setActionBinding(actionId, binding)
         this.updateCaptureStatus('Binding updated')
         this.refreshUI()
     }
@@ -265,14 +268,15 @@ export class ControlsPanel extends PauseMenuPanel {
             return
         }
 
-        const devices = inputManager.getAvailableDevices()
-        const profiles = inputManager.getProfiles()
-        const activeProfileId = inputManager.getActiveProfileId()
+        const devices = inputManager.actionResolver.getAvailableDevices()
+        const profiles = inputManager.profileService.getProfiles()
+        const activeProfileId = inputManager.profileService.getActiveProfileId()
+        const activeProfile = inputManager.profileService.getActiveProfile()
 
         this.renderDeviceOptions(devices, profiles, activeProfileId)
-        this.renderProfileToggles(profiles)
-        this.renderAnalogSnapshot(inputManager.getConnectedGamepadAxisSnapshot())
-        this.renderMappingTable(inputManager.getActiveProfile())
+        this.renderActiveToggle(activeProfile)
+        this.renderAnalogSnapshot(inputManager.actionResolver.getConnectedGamepadAxisSnapshot())
+        this.renderMappingTable(activeProfile)
     }
 
     private renderDeviceOptions(
@@ -293,17 +297,24 @@ export class ControlsPanel extends PauseMenuPanel {
         const options = new Map<InputProfileIdValue, string>()
         for (const device of devices) {
             const profile = profiles.find(candidate => candidate.id === device.profileId)
-            if (!profile || !profile.enabled) {
+            if (!profile) {
                 continue
             }
 
             if (!options.has(profile.id)) {
-                options.set(profile.id, profile.name)
+                options.set(profile.id, profile.enabled ? profile.name : `${profile.name} (Disabled)`)
             }
         }
 
         if (options.size === 0) {
             options.set(InputProfileId.MouseKeyboard, 'Mouse + Keyboard')
+        }
+
+        if (!options.has(activeProfileId)) {
+            const activeProfile = profiles.find(candidate => candidate.id === activeProfileId)
+            if (activeProfile) {
+                options.set(activeProfile.id, activeProfile.enabled ? activeProfile.name : `${activeProfile.name} (Disabled)`)
+            }
         }
 
         select.innerHTML = Array.from(options.entries())
@@ -315,25 +326,18 @@ export class ControlsPanel extends PauseMenuPanel {
         }
     }
 
-    private renderProfileToggles(profiles: ReadonlyArray<InputProfileDefinition>): void {
+    private renderActiveToggle(profile: InputProfileDefinition): void {
         const panel = this.getPanelElement()
         if (!panel) {
             return
         }
 
-        const container = panel.querySelector('#input-profile-toggles') as HTMLElement | null
-        if (!container) {
+        const toggle = panel.querySelector('#input-device-enabled') as HTMLInputElement | null
+        if (!toggle) {
             return
         }
 
-        container.innerHTML = profiles
-            .map(profile => `
-                <label class="input-profile-toggle-item">
-                    <input type="checkbox" data-input-profile-toggle="${profile.id}" ${profile.enabled ? 'checked' : ''} />
-                    <span>${profile.name} Active</span>
-                </label>
-            `)
-            .join('')
+        toggle.checked = profile.enabled
     }
 
     private renderAnalogSnapshot(axes: ReadonlyArray<{ label: string; value: number }>): void {

--- a/client/src/ui/pause/panels/ControlsPanel.ts
+++ b/client/src/ui/pause/panels/ControlsPanel.ts
@@ -7,7 +7,7 @@ import { EventManager } from '../../../core/EventManager'
 import { InputEventTypes } from '../../../types/InteractionEvents'
 import { getInputActionDefinition, InputAction, InputActionType, INPUT_ACTION_ORDER, type InputActionId } from '../../../input/InputActions'
 import { InputManager } from '../../../input/InputManager'
-import { formatBindingList, InputProfileId, type InputBinding, type InputProfileDefinition, type InputProfileIdValue } from '../../../input/InputProfile'
+import { formatBindingList, InputDeviceKind, InputProfileId, type AxisDirection, type InputBinding, type InputProfileDefinition, type InputProfileIdValue } from '../../../input/InputProfile'
 import '../../../styles/pause-menu/controls-panel.css'
 
 export class ControlsPanel extends PauseMenuPanel {
@@ -18,6 +18,8 @@ export class ControlsPanel extends PauseMenuPanel {
     private deviceListenerRegistered = false
     private profileListenerRegistered = false
     private capturingActionId: InputActionId | null = null
+    private capturingProfileId: InputProfileIdValue | null = null
+    private captureGamepadPollTimer: number | null = null
     private analogRefreshTimer: number | null = null
 
     constructor(config: PauseMenuPanelConfig = {}) {
@@ -189,18 +191,43 @@ export class ControlsPanel extends PauseMenuPanel {
             return
         }
 
+        const inputManager = InputManager.getActiveInstance()
+        if (!inputManager) {
+            return
+        }
+
+        const activeProfile = inputManager.profileService.getActiveProfile()
+
         this.stopCaptureListeners()
         this.capturingActionId = actionId
-        this.updateCaptureStatus(`Press a key or mouse button for ${getInputActionDefinition(actionId).label}`)
+        this.capturingProfileId = activeProfile.id
+        const actionLabel = getInputActionDefinition(actionId).label
 
-        document.addEventListener('keydown', this.handleCaptureKeyDown, { once: true })
-        document.addEventListener('mousedown', this.handleCaptureMouseDown, { once: true })
+        if (activeProfile.deviceKind === InputDeviceKind.Gamepad) {
+            this.updateCaptureStatus(`Move a stick or press a gamepad button for ${actionLabel}`)
+            this.captureGamepadPollTimer = window.setInterval(() => this.pollGamepadCapture(), 50)
+            return
+        }
+
+        if (activeProfile.deviceKind === InputDeviceKind.MouseKeyboard) {
+            this.updateCaptureStatus(`Press a key, click a mouse button, or move mouse axis for ${actionLabel}`)
+            document.addEventListener('keydown', this.handleCaptureKeyDown, { once: true })
+            document.addEventListener('mousedown', this.handleCaptureMouseDown, { once: true })
+            document.addEventListener('mousemove', this.handleCaptureMouseMove)
+            return
+        }
+
+        this.updateCaptureStatus(`Editing ${activeProfile.name} bindings is not supported yet`)
+        this.capturingActionId = null
+        this.capturingProfileId = null
     }
 
     private finishCapture(binding: InputBinding): void {
         this.stopCaptureListeners()
         const actionId = this.capturingActionId
         this.capturingActionId = null
+        const captureProfileId = this.capturingProfileId
+        this.capturingProfileId = null
 
         if (!actionId) {
             return
@@ -211,6 +238,11 @@ export class ControlsPanel extends PauseMenuPanel {
             return
         }
 
+        if (captureProfileId && inputManager.profileService.getActiveProfileId() !== captureProfileId) {
+            this.updateCaptureStatus('Capture cancelled because active profile changed')
+            return
+        }
+
         inputManager.profileService.setActionBinding(actionId, binding)
         this.updateCaptureStatus('Binding updated')
         this.refreshUI()
@@ -218,20 +250,167 @@ export class ControlsPanel extends PauseMenuPanel {
 
     private handleCaptureKeyDown = (event: KeyboardEvent): void => {
         event.preventDefault()
+        const actionId = this.capturingActionId
+        if (!actionId) {
+            return
+        }
+
+        const direction = this.getButtonDirectionForAxisAction(actionId)
+        if (direction === null) {
+            this.stopCaptureListeners()
+            this.capturingActionId = null
+            this.capturingProfileId = null
+            this.updateCaptureStatus('Capture cancelled')
+            return
+        }
+
         this.finishCapture({
             type: 'keyboard-button',
             code: event.code,
+            direction,
             label: event.code
         })
     }
 
     private handleCaptureMouseDown = (event: MouseEvent): void => {
         event.preventDefault()
+        const actionId = this.capturingActionId
+        if (!actionId) {
+            return
+        }
+
+        const direction = this.getButtonDirectionForAxisAction(actionId)
+        if (direction === null) {
+            this.stopCaptureListeners()
+            this.capturingActionId = null
+            this.capturingProfileId = null
+            this.updateCaptureStatus('Capture cancelled')
+            return
+        }
+
         this.finishCapture({
             type: 'mouse-button',
             button: event.button,
+            direction,
             label: event.button === 0 ? 'Left Click' : `Mouse ${event.button}`
         })
+    }
+
+    private handleCaptureMouseMove = (event: MouseEvent): void => {
+        const actionId = this.capturingActionId
+        if (!actionId || !this.isAxisAction(actionId)) {
+            return
+        }
+
+        if (Math.abs(event.movementX) < 3 && Math.abs(event.movementY) < 3) {
+            return
+        }
+
+        const axis = Math.abs(event.movementX) >= Math.abs(event.movementY) ? 'x' : 'y'
+        this.finishCapture({
+            type: 'mouse-axis',
+            axis,
+            sensitivity: 1,
+            label: axis === 'x' ? 'Mouse X' : 'Mouse Y'
+        })
+    }
+
+    private pollGamepadCapture(): void {
+        const actionId = this.capturingActionId
+        if (!actionId) {
+            return
+        }
+
+        const gamepads = Array.from(navigator.getGamepads?.() ?? []).filter((gamepad): gamepad is Gamepad => Boolean(gamepad && gamepad.connected))
+        if (gamepads.length === 0) {
+            return
+        }
+
+        if (this.isAxisAction(actionId)) {
+            let strongestAxis: { index: number; value: number } | null = null
+            for (const gamepad of gamepads) {
+                gamepad.axes.forEach((axisValue, axisIndex) => {
+                    if (Math.abs(axisValue) < 0.5) {
+                        return
+                    }
+
+                    if (!strongestAxis || Math.abs(axisValue) > Math.abs(strongestAxis.value)) {
+                        strongestAxis = { index: axisIndex, value: axisValue }
+                    }
+                })
+            }
+
+            if (strongestAxis) {
+                const direction = this.getGamepadAxisDirectionForAction(actionId, strongestAxis.value)
+                this.finishCapture({
+                    type: 'gamepad-axis',
+                    axis: strongestAxis.index,
+                    direction,
+                    deadZone: 0.15,
+                    label: `Gamepad Axis ${strongestAxis.index}`
+                })
+                return
+            }
+        }
+
+        for (const gamepad of gamepads) {
+            for (let buttonIndex = 0; buttonIndex < gamepad.buttons.length; buttonIndex += 1) {
+                const button = gamepad.buttons[buttonIndex]
+                if (!button || button.value < 0.5) {
+                    continue
+                }
+
+                const direction = this.getButtonDirectionForAxisAction(actionId)
+                if (direction === null) {
+                    this.stopCaptureListeners()
+                    this.capturingActionId = null
+                    this.capturingProfileId = null
+                    this.updateCaptureStatus('Capture cancelled')
+                    return
+                }
+
+                this.finishCapture({
+                    type: 'gamepad-button',
+                    button: buttonIndex,
+                    direction,
+                    label: `Gamepad Button ${buttonIndex}`
+                })
+                return
+            }
+        }
+    }
+
+    private isAxisAction(actionId: InputActionId): boolean {
+        return getInputActionDefinition(actionId).type === InputActionType.Axis
+    }
+
+    private getButtonDirectionForAxisAction(actionId: InputActionId): AxisDirection | undefined | null {
+        if (!this.isAxisAction(actionId)) {
+            return undefined
+        }
+
+        if (actionId !== InputAction.LookHorizontal && actionId !== InputAction.LookVertical) {
+            return 'positive'
+        }
+
+        const response = window.prompt(
+            'Bind as + or - direction? Type + for increase (right/up), - for decrease (left/down).',
+            '+'
+        )
+
+        if (response === null) {
+            return null
+        }
+
+        return response.trim().startsWith('-') ? 'negative' : 'positive'
+    }
+
+    private getGamepadAxisDirectionForAction(actionId: InputActionId, axisValue: number): 'positive' | 'negative' | 'both' {
+        if (actionId === InputAction.LookHorizontal || actionId === InputAction.LookVertical) {
+            return 'both'
+        }
+
+        return axisValue >= 0 ? 'positive' : 'negative'
     }
 
     private updateCaptureStatus(message: string): void {
@@ -251,6 +430,12 @@ export class ControlsPanel extends PauseMenuPanel {
     private stopCaptureListeners(): void {
         document.removeEventListener('keydown', this.handleCaptureKeyDown)
         document.removeEventListener('mousedown', this.handleCaptureMouseDown)
+        document.removeEventListener('mousemove', this.handleCaptureMouseMove)
+
+        if (this.captureGamepadPollTimer !== null) {
+            window.clearInterval(this.captureGamepadPollTimer)
+            this.captureGamepadPollTimer = null
+        }
     }
 
     private stopAnalogRefreshTimer(): void {
@@ -391,12 +576,16 @@ export class ControlsPanel extends PauseMenuPanel {
     }
 
     private isActionEditable(actionId: InputActionId): boolean {
-        if (actionId === InputAction.LookHorizontal || actionId === InputAction.LookVertical) {
-            return false
-        }
-
         const definition = getInputActionDefinition(actionId)
-        return definition.type !== InputActionType.Axis || actionId === InputAction.MoveForward || actionId === InputAction.MoveBack || actionId === InputAction.MoveLeft || actionId === InputAction.MoveRight || actionId === InputAction.MoveUp || actionId === InputAction.MoveDown
+        return definition.type !== InputActionType.Axis
+            || actionId === InputAction.MoveForward
+            || actionId === InputAction.MoveBack
+            || actionId === InputAction.MoveLeft
+            || actionId === InputAction.MoveRight
+            || actionId === InputAction.MoveUp
+            || actionId === InputAction.MoveDown
+            || actionId === InputAction.LookHorizontal
+            || actionId === InputAction.LookVertical
     }
 
     dispose(): void {

--- a/client/src/utils/UIComponentUtils.ts
+++ b/client/src/utils/UIComponentUtils.ts
@@ -57,6 +57,18 @@ export interface InputConfig<T = string> {
     parseValue?: (rawValue: string) => T
 }
 
+export interface TableColumnConfig<TRow> {
+    key: string
+    renderCell: (row: TRow) => string
+}
+
+export interface TableRenderConfig<TRow> {
+    tbodyId: string
+    rows: ReadonlyArray<TRow>
+    columns: ReadonlyArray<TableColumnConfig<TRow>>
+    rowClassName?: (row: TRow) => string | undefined
+}
+
 export class UIComponentUtils {
     static setupSlider(
         container: HTMLElement | null,
@@ -169,6 +181,30 @@ export class UIComponentUtils {
         })
     }
 
+    static setupDelegatedDataButtons<T = string>(
+        container: HTMLElement | null,
+        selector: string,
+        dataAttribute: string,
+        onClick: (value: T, button: HTMLElement) => void
+    ): void {
+        if (!container) return
+
+        container.addEventListener('click', (event) => {
+            const target = event.target as HTMLElement | null
+            const button = target?.closest(selector) as HTMLElement | null
+            if (!button) {
+                return
+            }
+
+            const value = button.dataset[dataAttribute] as T | undefined
+            if (value === undefined) {
+                return
+            }
+
+            onClick(value, button)
+        })
+    }
+
     static setupSelect<T = string>(
         container: HTMLElement | null,
         config: SelectConfig<T>
@@ -248,5 +284,25 @@ export class UIComponentUtils {
                 ? formatDisplay(value)
                 : value.toString()
         }
+    }
+
+    static renderTable<TRow>(
+        container: HTMLElement | null,
+        config: TableRenderConfig<TRow>
+    ): void {
+        if (!container) return
+
+        const tbody = container.querySelector(`#${config.tbodyId}`) as HTMLElement | null
+        if (!tbody) return
+
+        tbody.innerHTML = config.rows.map((row) => {
+            const rowClass = config.rowClassName?.(row)
+            const classAttr = rowClass ? ` class="${rowClass}"` : ''
+            const cells = config.columns
+                .map((column) => `<td data-table-col="${column.key}">${column.renderCell(row)}</td>`)
+                .join('')
+
+            return `<tr${classAttr}>${cells}</tr>`
+        }).join('')
     }
 }

--- a/client/src/webxr/WebXRCoordinator.ts
+++ b/client/src/webxr/WebXRCoordinator.ts
@@ -102,12 +102,9 @@ export class WebXRCoordinator {
         // Handle keyboard movement
         // we should ABSOLUTELY NOT update the camera in VR this way (from keybinds rather than headset data)
         this.inputManager.updateCameraMovement(camera)
-        
-        // Handle Q/E roll rotation
-        this.inputManager.updateCameraRoll(camera)
-        
+
         // Mouse-drag look is intentionally disabled; camera rotation now relies on other input paths.
-        this.inputManager.updateCameraRotation(camera, 0, 0)
+        this.inputManager.updateCameraRotation(camera)
     }
 
     /**

--- a/client/test/unit/input/binding-resolver.test.ts
+++ b/client/test/unit/input/binding-resolver.test.ts
@@ -75,4 +75,55 @@ describe('BindingResolver', () => {
         expect((state.axes.get(InputAction.MoveRight) ?? 0) > 0).toBe(true)
         expect(state.buttons.get(InputAction.Interact)).toBe(true)
     })
+
+    it('supports directional button bindings for axis actions', () => {
+        const resolver = new BindingResolver()
+        const mouseKeyboardProfile = getProfile(InputProfileId.MouseKeyboard)
+
+        const state = resolver.resolve(
+            {
+                ...mouseKeyboardProfile,
+                bindings: {
+                    ...mouseKeyboardProfile.bindings,
+                    [InputAction.LookHorizontal]: [
+                        { type: 'keyboard-button', code: 'KeyJ', direction: 'negative' },
+                        { type: 'keyboard-button', code: 'KeyL', direction: 'positive' }
+                    ]
+                }
+            },
+            {
+                keysPressed: new Set(['KeyJ']),
+                mouseButtonsPressed: new Set(),
+                mouseDeltaX: 0,
+                mouseDeltaY: 0,
+                gamepads: []
+            }
+        )
+
+        expect(state.axes.get(InputAction.LookHorizontal)).toBe(-1)
+    })
+
+    it('still resolves button actions when directional metadata is present', () => {
+        const resolver = new BindingResolver()
+        const mouseKeyboardProfile = getProfile(InputProfileId.MouseKeyboard)
+
+        const state = resolver.resolve(
+            {
+                ...mouseKeyboardProfile,
+                bindings: {
+                    ...mouseKeyboardProfile.bindings,
+                    [InputAction.Interact]: [{ type: 'keyboard-button', code: 'KeyE', direction: 'negative' }]
+                }
+            },
+            {
+                keysPressed: new Set(['KeyE']),
+                mouseButtonsPressed: new Set(),
+                mouseDeltaX: 0,
+                mouseDeltaY: 0,
+                gamepads: []
+            }
+        )
+
+        expect(state.buttons.get(InputAction.Interact)).toBe(true)
+    })
 })

--- a/client/test/unit/input/input-action-resolver.test.ts
+++ b/client/test/unit/input/input-action-resolver.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BindingResolver } from '../../../src/input/BindingResolver'
+import { DeviceDetector, type InputDeviceInfo } from '../../../src/input/DeviceDetector'
+import { InputActionResolver } from '../../../src/input/InputActionResolver'
+import { BUILTIN_INPUT_PROFILES, InputDeviceKind, InputProfileId } from '../../../src/input/InputProfile'
+
+function createGamepad(): Gamepad {
+    return {
+        connected: true,
+        id: 'Ghost Pad',
+        index: 0,
+        mapping: 'standard',
+        axes: [0, -1, 0, 0],
+        buttons: Array.from({ length: 12 }, () => ({ pressed: false, touched: false, value: 0 })),
+        vibrationActuator: null
+    } as unknown as Gamepad
+}
+
+describe('InputActionResolver', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('only resolves profiles for connected device types', () => {
+        const bindingResolverSpy = vi.spyOn(BindingResolver.prototype, 'resolve')
+        const detector = new DeviceDetector()
+        const resolver = new InputActionResolver(new BindingResolver(), detector)
+
+        vi.spyOn(detector, 'pollGamepads').mockImplementation(() => {})
+        vi.spyOn(detector, 'getAvailableDevices').mockReturnValue([
+            {
+                id: 'mouse-keyboard',
+                name: 'Mouse + Keyboard',
+                kind: InputDeviceKind.MouseKeyboard,
+                connected: true,
+                profileId: InputProfileId.MouseKeyboard
+            } satisfies InputDeviceInfo
+        ])
+
+        Object.defineProperty(navigator, 'getGamepads', {
+            value: () => [createGamepad()],
+            configurable: true
+        })
+
+        resolver.updateFrame(BUILTIN_INPUT_PROFILES, new Set(['KeyW']), new Set())
+
+        expect(bindingResolverSpy).toHaveBeenCalledTimes(1)
+        expect(bindingResolverSpy.mock.calls[0]?.[0].id).toBe(InputProfileId.MouseKeyboard)
+    })
+})

--- a/client/test/unit/input/input-binding-utils.test.ts
+++ b/client/test/unit/input/input-binding-utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { InputAction } from '../../../src/input/InputActions'
+import { getDuplicateBindingWarnings, getLinkedInverseAssignment, isDerivedLinkedActionLocked } from '../../../src/input/InputBindingUtils'
+import { BUILTIN_INPUT_PROFILES, InputProfileId, type InputProfileDefinition } from '../../../src/input/InputProfile'
+
+function getProfile() {
+    const profile = BUILTIN_INPUT_PROFILES.find(candidate => candidate.id === InputProfileId.MouseKeyboard)
+    if (!profile) {
+        throw new Error('Missing mouse keyboard profile')
+    }
+    return profile
+}
+
+describe('InputBindingUtils', () => {
+    it('creates inverse linked assignment for gamepad axis movement bindings', () => {
+        const linked = getLinkedInverseAssignment(InputAction.MoveLeft, {
+            type: 'gamepad-axis',
+            axis: 0,
+            direction: 'negative',
+            deadZone: 0.15,
+            label: 'Left Stick X'
+        })
+
+        expect(linked).not.toBeNull()
+        expect(linked?.actionId).toBe(InputAction.MoveRight)
+        expect(linked?.binding.type).toBe('gamepad-axis')
+        if (linked?.binding.type === 'gamepad-axis') {
+            expect(linked.binding.direction).toBe('positive')
+        }
+    })
+
+    it('locks derived movement action when source uses invertible axis binding', () => {
+        const profile: InputProfileDefinition = {
+            ...getProfile(),
+            bindings: {
+                ...getProfile().bindings,
+                [InputAction.MoveLeft]: [{ type: 'mouse-axis', axis: 'x', sensitivity: 1 } as const]
+            }
+        }
+
+        expect(isDerivedLinkedActionLocked(profile, InputAction.MoveRight)).toBe(true)
+        expect(isDerivedLinkedActionLocked(profile, InputAction.MoveLeft)).toBe(false)
+    })
+
+    it('detects duplicate bindings across actions for warning display', () => {
+        const profile: InputProfileDefinition = {
+            ...getProfile(),
+            bindings: {
+                ...getProfile().bindings,
+                [InputAction.Interact]: [{ type: 'keyboard-button', code: 'KeyE', label: 'E' } as const],
+                [InputAction.OpenMenu]: [{ type: 'keyboard-button', code: 'KeyE', label: 'E' } as const]
+            }
+        }
+
+        const warnings = getDuplicateBindingWarnings(profile)
+        expect(warnings.get(InputAction.Interact)).toContain('Open Menu')
+        expect(warnings.get(InputAction.OpenMenu)).toContain('Interact')
+    })
+})

--- a/client/test/unit/input/input-manager-multi-device.test.ts
+++ b/client/test/unit/input/input-manager-multi-device.test.ts
@@ -32,11 +32,11 @@ describe('InputManager multi-device behavior', () => {
         })
 
         manager.startListening()
-        manager.setProfileEnabled(InputProfileId.GamepadStandard, true)
+        manager.profileService.setProfileEnabled(InputProfileId.GamepadStandard, true)
         manager.updateFrame()
 
         const beforeYaw = camera.rotation.y
-        manager.updateCameraRotation(camera, 0, 0)
+        manager.updateCameraRotation(camera, 0)
         const afterYaw = camera.rotation.y
 
         expect(afterYaw).not.toBe(beforeYaw)

--- a/client/test/unit/webxr/input-manager.test.ts
+++ b/client/test/unit/webxr/input-manager.test.ts
@@ -35,7 +35,6 @@ describe('InputManager User Experience Tests', () => {
     
     // Create mock callbacks
     mockCallbacks = {
-      onMouseMove: vi.fn(),
       onKeyPress: vi.fn(),
       onKeyRelease: vi.fn(),
     };
@@ -273,8 +272,7 @@ describe('InputManager User Experience Tests', () => {
       });
       document.dispatchEvent(mouseMove);
       
-      // System should register the look direction change
-      expect(mockCallbacks.onMouseMove).toHaveBeenCalledWith(10, -10);
+      // System should register the position change
       expect(inputState.mouse.x).toBe(110);
       expect(inputState.mouse.y).toBe(190);
     });
@@ -306,7 +304,7 @@ describe('InputManager User Experience Tests', () => {
       document.dispatchEvent(mouseMove);
       
       // Should not trigger look callbacks (user not intending to look)
-      expect(mockCallbacks.onMouseMove).not.toHaveBeenCalled();
+      expect(mockCallbacks.onKeyPress).not.toHaveBeenCalled();
     });
 
     it('should handle rapid mouse movements without lag', () => {
@@ -333,9 +331,8 @@ describe('InputManager User Experience Tests', () => {
       
       const endTime = performance.now();
       
-      // Should handle 60 mouse events quickly (< 50ms)
+      // Should process 60 mouse events quickly (< 50ms)
       expect(endTime - startTime).toBeLessThan(50);
-      expect(mockCallbacks.onMouseMove).toHaveBeenCalledTimes(60);
     });
 
     it('should maintain smooth look behavior with varying mouse speeds', () => {
@@ -353,19 +350,9 @@ describe('InputManager User Experience Tests', () => {
         bubbles: true
       });
       document.dispatchEvent(slowMove);
-      expect(mockCallbacks.onMouseMove).toHaveBeenCalledWith(1, 1);
-      
-      // Test fast movement  
-      const fastMove = new MouseEvent('mousemove', {
-        clientX: 200,
-        clientY: 50,
-        bubbles: true
-      });
-      document.dispatchEvent(fastMove);
-      expect(mockCallbacks.onMouseMove).toHaveBeenCalledWith(99, -51);
-      
-      // Both should work without issues
-      expect(mockCallbacks.onMouseMove).toHaveBeenCalledTimes(2);
+      // Position should be tracked regardless of look mode
+      expect(inputManager.getInputState().mouse.x).toBe(101);
+      expect(inputManager.getInputState().mouse.y).toBe(101);
     });
   });
 
@@ -403,9 +390,10 @@ describe('InputManager User Experience Tests', () => {
         // Reset to initial position for clean test
         mockCamera.position.copy(initialPosition);
         
-        // Clear any previous key state
-        const inputState = inputManager.getInputState();
-        Object.keys(inputState.keys).forEach(k => inputState.keys[k] = false);
+        // Release all tracked keys before testing this direction
+        ['KeyW', 'KeyA', 'KeyS', 'KeyD'].forEach(k =>
+          document.dispatchEvent(new KeyboardEvent('keyup', { code: k }))
+        )
         
         // User presses key for this direction
         const keyEvent = new KeyboardEvent('keydown', { code: key });
@@ -427,7 +415,7 @@ describe('InputManager User Experience Tests', () => {
       
       // User looks right and slightly down (common VR interaction)
       const lookRightDown = { deltaX: 10, deltaY: 5 };
-      inputManager.updateCameraRotation(mockCamera, lookRightDown.deltaX, lookRightDown.deltaY);
+      inputManager.updateCameraRotation(mockCamera, lookRightDown.deltaX);
       
       // Camera should rotate to follow user's look direction
       expect(mockCamera.rotation.y).not.toBe(initialRotation.y); // Horizontal look changed
@@ -525,12 +513,11 @@ describe('InputManager User Experience Tests', () => {
       
       // Apply both movement and look
       inputManager.updateCameraMovement(mockCamera);
-      inputManager.updateCameraRotation(mockCamera, 20, 0);
+      inputManager.updateCameraRotation(mockCamera, 20);
       
       // Both movement and look should work simultaneously
       expect(mockCamera.position.z).toBeLessThan(initialPosition.z); // Moved forward
       expect(mockCamera.rotation.y).not.toBe(initialRotation); // Looked around
-      expect(mockCallbacks.onMouseMove).toHaveBeenCalledWith(20, 0);
     });
   });
 
@@ -571,7 +558,7 @@ describe('InputManager User Experience Tests', () => {
         
         // Verify sensitivity actually affects look behavior
         const initialRotation = mockCamera.rotation.y;
-        inputManager.updateCameraRotation(mockCamera, 10, 0);
+        inputManager.updateCameraRotation(mockCamera, 10);
         
         // Should have rotated (exact amount depends on sensitivity)
         expect(mockCamera.rotation.y).not.toBe(initialRotation);
@@ -595,7 +582,7 @@ describe('InputManager User Experience Tests', () => {
       const wKeyEvent = new KeyboardEvent('keydown', { code: 'KeyW' });
       document.dispatchEvent(wKeyEvent);
       inputManager.updateCameraMovement(mockCamera);
-      inputManager.updateCameraRotation(mockCamera, 1, 0);
+      inputManager.updateCameraRotation(mockCamera, 1);
       
       expect(isFinite(mockCamera.position.x)).toBe(true);
       expect(isFinite(mockCamera.position.z)).toBe(true);
@@ -609,7 +596,7 @@ describe('InputManager User Experience Tests', () => {
       inputManager.setMovementOptions(highOptions);
       
       inputManager.updateCameraMovement(mockCamera);
-      inputManager.updateCameraRotation(mockCamera, 1, 0);
+      inputManager.updateCameraRotation(mockCamera, 1);
       
       expect(isFinite(mockCamera.position.x)).toBe(true);
       expect(isFinite(mockCamera.position.z)).toBe(true);
@@ -626,9 +613,9 @@ describe('InputManager User Experience Tests', () => {
         onKeyPress: mockKeyPress,
         onKeyRelease: mockKeyRelease,
       };
-      
-      inputManager.setCallbacks(userCallbacks);
-      inputManager.startListening();
+
+      const callbackManager = new InputManager({}, userCallbacks);
+      callbackManager.startListening();
       
       // User presses and releases a key
       const wKeyDown = new KeyboardEvent('keydown', { code: 'KeyW' });
@@ -641,7 +628,8 @@ describe('InputManager User Experience Tests', () => {
       expect(mockKeyPress).toHaveBeenCalledWith('w');
       expect(mockKeyRelease).toHaveBeenCalledWith('w');
       
-      inputManager.stopListening();
+      callbackManager.stopListening();
+      callbackManager.dispose();
     });
 
     it('should persist user preferences across input system restarts', () => {


### PR DESCRIPTION
## Why this stacked PR
This PR is intentionally based on `feature/input-system-foundation` to keep review focused and avoid mixed/duplicated diffs against `act2/default`.

## What this PR adds on top of PR #129
- Decomposes monolithic `InputManager` into focused modules:
  - `InputStateTracker`
  - `InputEventAdapter`
  - `InputProfileService`
  - `InputActionResolver`
  - `CameraInputApplier`
  - `InputContracts`
- Routes camera movement through binding/action resolution in runtime path
- Adds device-scoped capture and directional axis button support
- Adds inverse linked assignment + duplicate binding warning utilities (`InputBindingUtils`)
- Standardizes `ControlsPanel` wiring with `UIComponentUtils` helpers and table rendering
- Removes Analog Inputs section from Controls panel

## Notes
- This is the branch where the remapping behavior and refactor hardening land.
- Keeping this stacked allows PR #129 to be reviewed as foundation only, while this PR carries the larger behavior refinements separately.
