### PR TITLE
feat(ui): Display Advanced sub-tab and shared settings style layer

### DIFF
--- a/client/src/core/AppSettings.ts
+++ b/client/src/core/AppSettings.ts
@@ -59,6 +59,13 @@ export const Setting = {
     LodMaxHighSlots: 'lodMaxHighSlots',
     LodHighReductionRatio: 'lodHighReductionRatio',
     LodMedReductionRatio: 'lodMedReductionRatio',
+    // Artwork Tuning
+    ArtworkRoughness: 'artworkRoughness',
+    ArtworkMetalness: 'artworkMetalness',
+    ArtworkFresnelLift: 'artworkFresnelLift',
+    ArtworkFresnelPower: 'artworkFresnelPower',
+    ShadowContactBias: 'shadowContactBias',
+    ShadowContactNormalBias: 'shadowContactNormalBias',
     // Interface
     ShowFPS: 'showFPS',
     ShowPerformanceStats: 'showPerformanceStats',
@@ -95,6 +102,12 @@ export const SettingCategory = {
         Setting.LodMaxHighSlots,
         Setting.LodHighReductionRatio,
         Setting.LodMedReductionRatio,
+        Setting.ArtworkRoughness,
+        Setting.ArtworkMetalness,
+        Setting.ArtworkFresnelLift,
+        Setting.ArtworkFresnelPower,
+        Setting.ShadowContactBias,
+        Setting.ShadowContactNormalBias,
     ] as const,
     // Add other categories as needed (Interface, Debug, Steam, etc.)
 } as const
@@ -126,6 +139,14 @@ export interface ApplicationSettings {
     lodMaxHighSlots: number      // Max HIGH texture slots (affects VRAM)
     lodHighReductionRatio: number // HIGH texture reduction (0.5 = 50% of source)
     lodMedReductionRatio: number  // MED texture reduction (0.25 = 25% of source)
+
+    // Artwork Tuning (Advanced Display settings)
+    artworkRoughness: number          // PBR roughness [0.2, 0.6]
+    artworkMetalness: number          // PBR metalness [0.0, 0.2]
+    artworkFresnelLift: number        // Edge lift intensity [0.0, 0.3]
+    artworkFresnelPower: number       // Edge sharpness exponent [2.0, 8.0]
+    shadowContactBias: number         // Directional shadow bias (negative)
+    shadowContactNormalBias: number   // Directional shadow normal bias
     
     // Interface Settings
     showFPS: boolean
@@ -433,6 +454,14 @@ export class AppSettings {
             lodMaxHighSlots: 128,  // Max HIGH texture slots (128 × 300×450 = ~66MB VRAM)
             lodHighReductionRatio: 0.5,  // HIGH = 50% of nominal = 300×450 (true CDN ceiling for most titles)
             lodMedReductionRatio: 0.25,  // MED = 25% of source (600×900 → 150×225)
+
+            // Artwork Tuning
+            artworkRoughness: 0.35,
+            artworkMetalness: 0.05,
+            artworkFresnelLift: 0.15,
+            artworkFresnelPower: 4.0,
+            shadowContactBias: -0.001,
+            shadowContactNormalBias: 0.005,
             
             // Interface Settings
             showFPS: false,

--- a/client/src/styles/pause-menu/application-panel.css
+++ b/client/src/styles/pause-menu/application-panel.css
@@ -1,5 +1,5 @@
 /* Application Panel Styles */
-@import './shared-components.css';
+@import './settings-components.css';
 
 #panel-application .setting-item {
     margin-bottom: 0;

--- a/client/src/styles/pause-menu/cache-management-panel.css
+++ b/client/src/styles/pause-menu/cache-management-panel.css
@@ -1,9 +1,9 @@
 /**
  * Cache Management Panel Styles
- * Uses shared components from shared-components.css
+ * Uses shared settings components from settings-components.css
  */
 
-@import './shared-components.css';
+@import './settings-components.css';
 
 /* Cache-specific sections — layout handled by shared .cache-section alias in shared-components */
 

--- a/client/src/styles/pause-menu/game-settings-panel.css
+++ b/client/src/styles/pause-menu/game-settings-panel.css
@@ -1,4 +1,4 @@
-@import './shared-components.css';
+@import './settings-components.css';
 
 /* Game Settings Panel Styles */
 .game-settings-content {

--- a/client/src/styles/pause-menu/graphics-settings-panel.css
+++ b/client/src/styles/pause-menu/graphics-settings-panel.css
@@ -1,3 +1,5 @@
+@import './settings-components.css';
+
 /**
  * Graphics Settings Panel Styles
  * Following the established pause menu design patterns
@@ -51,60 +53,6 @@
   scrollbar-color: var(--accent-color) transparent;
 }
 
-.graphics-settings-panel .setting-section {
-  margin-bottom: 1.1rem;
-}
-
-.graphics-settings-panel .setting-section:last-child {
-  margin-bottom: 0.5rem;
-}
-
-/* Setting Groups */
-.graphics-settings-panel .setting-group {
-  background: rgba(0, 0, 0, 0.2);
-  border: 1px solid var(--color-border, #333);
-  border-radius: 6px;
-  padding: 0.9rem 1rem;
-}
-
-.graphics-settings-panel .setting-label {
-  display: block;
-  font-weight: bold;
-  color: var(--text-primary);
-  font-size: 1rem;
-  margin-bottom: 0.5rem;
-}
-
-/* Setting behavior hints - subtle informational badges */
-.graphics-settings-panel .setting-hint-badge {
-  font-size: 0.7rem;
-  font-weight: normal;
-  padding: 0.15rem 0.4rem;
-  border-radius: 3px;
-  margin-left: 0.5rem;
-  opacity: 0.7;
-  transition: all 0.3s ease;
-}
-
-.graphics-settings-panel .hint-reload {
-  color: var(--panel-text-muted, #8f98a0);
-  background: rgba(255, 255, 255, 0.08);
-}
-
-.graphics-settings-panel .hint-disabled {
-  color: inherit;
-  background: transparent;
-  border: 1px dashed currentColor;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  opacity: 0.85;
-}
-
-.graphics-settings-panel .hint-instant {
-  color: #4caf50;
-  background: rgba(102, 170, 102, 0.15);
-}
-
 /* Disabled setting controls */
 .graphics-settings-panel .disabled-setting {
   opacity: 0.55;
@@ -127,18 +75,6 @@
   opacity: 1;
 }
 
-.graphics-settings-panel .setting-description {
-  margin: 0 0 1rem 0;
-  color: var(--text-secondary);
-  font-size: 0.85rem;
-  line-height: 1.4;
-}
-
-.graphics-settings-panel .setting-control {
-  margin-top: 0.75rem;
-}
-
-/* Select Controls */
 .graphics-settings-panel .setting-select {
   width: 100%;
   padding: 0.75rem;
@@ -168,22 +104,9 @@
   padding: 0.5rem;
 }
 
-.graphics-settings-panel .setting-slider {
-  margin-bottom: 0.5rem;
-}
-
-.graphics-settings-panel .slider-labels {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.8rem;
-  color: #67c1f5;
-  font-weight: 500;
-  margin-top: 0.25rem;
-}
-
 /* =============================================================================
    RELOAD INDICATOR SYSTEM
-   
+
    Uses two data attributes for pure CSS control:
    - data-requires-reload: Static, declared in HTML on controls that need reload
    - data-changed: Dynamic, set by JS when value differs from initial

--- a/client/src/styles/pause-menu/settings-components.css
+++ b/client/src/styles/pause-menu/settings-components.css
@@ -1,0 +1,97 @@
+@import './shared-components.css';
+
+/* ===== SETTINGS PANEL PRIMITIVES =====
+ * Shared styles for settings-oriented pause menu panels.
+ */
+
+/* Setting item layout */
+.setting-item {
+    margin-bottom: 16px;
+}
+
+.setting-label {
+    display: block;
+    font-weight: bold;
+    color: var(--text-primary, #fff);
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.settings-sections {
+    scrollbar-width: thin;
+    scrollbar-color: var(--accent-color) transparent;
+}
+
+.setting-section {
+    margin-bottom: 1.1rem;
+}
+
+.setting-section:last-child {
+    margin-bottom: 0.5rem;
+}
+
+.setting-group {
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--color-border, #333);
+    border-radius: 6px;
+    padding: 0.9rem 1rem;
+}
+
+/* Alternating row backgrounds */
+.setting-section:nth-child(even) .setting-group {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.setting-description {
+    margin: 0 0 1rem 0;
+    color: var(--text-secondary, #8f98a0);
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+
+.setting-control {
+    margin-top: 0.75rem;
+}
+
+.setting-slider {
+    margin-bottom: 0.5rem;
+}
+
+.slider-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.8rem;
+    color: #67c1f5;
+    font-weight: 500;
+    margin-top: 0.25rem;
+}
+
+/* Behavior hint badges */
+.setting-hint-badge {
+    font-size: 0.7rem;
+    font-weight: normal;
+    padding: 0.15rem 0.4rem;
+    border-radius: 3px;
+    margin-left: 0.5rem;
+    opacity: 0.7;
+    transition: all 0.3s ease;
+}
+
+.hint-reload {
+    color: var(--panel-text-muted, #8f98a0);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.hint-disabled {
+    color: inherit;
+    background: transparent;
+    border: 1px dashed currentColor;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    opacity: 0.85;
+}
+
+.hint-instant {
+    color: #4caf50;
+    background: rgba(102, 170, 102, 0.15);
+}

--- a/client/src/styles/pause-menu/shared-components.css
+++ b/client/src/styles/pause-menu/shared-components.css
@@ -220,19 +220,6 @@
     font-size: 13px;
 }
 
-/* Setting item layout */
-.setting-item {
-    margin-bottom: 16px;
-}
-
-.setting-label {
-    display: block;
-    color: #ccc;
-    font-size: 13px;
-    margin-bottom: 6px;
-    font-weight: 500;
-}
-
 /* Button groups */
 .btn-group {
     display: flex;
@@ -385,3 +372,4 @@
         gap: 4px;
     }
 }
+

--- a/client/src/templates/pause-menu/display-advanced-panel.html
+++ b/client/src/templates/pause-menu/display-advanced-panel.html
@@ -1,0 +1,165 @@
+<!-- DisplayAdvancedPanel Template - Artwork material and shadow contact tuning -->
+<div class="display-advanced-panel">
+  <div class="settings-sections">
+
+    <!-- Artwork Material Tuning -->
+    <section class="setting-section">
+      <div class="setting-group">
+        <label class="setting-label">🎨 Artwork Material</label>
+        <p class="setting-description">
+          PBR surface properties for game box artwork. Roughness controls how matte vs. glossy
+          the surface reads; metalness adds specular character. Changes apply immediately.
+        </p>
+
+        <div class="setting-control">
+          <label class="setting-label" for="artwork-roughness" style="font-weight: normal; font-size: 0.9rem;">
+            Roughness: <span id="artwork-roughness-value" class="value-display">{{artworkRoughnessLabel}}</span>
+          </label>
+          <input
+            type="range"
+            id="artwork-roughness"
+            class="setting-slider pause-slider"
+            min="0.2"
+            max="0.6"
+            step="0.01"
+            value="{{artworkRoughness}}"
+          >
+          <div class="slider-labels">
+            <span>0.2 (glossy)</span>
+            <span>0.6 (matte)</span>
+          </div>
+        </div>
+
+        <div class="setting-control" style="margin-top: 1rem;">
+          <label class="setting-label" for="artwork-metalness" style="font-weight: normal; font-size: 0.9rem;">
+            Metalness: <span id="artwork-metalness-value" class="value-display">{{artworkMetalnessLabel}}</span>
+          </label>
+          <input
+            type="range"
+            id="artwork-metalness"
+            class="setting-slider pause-slider"
+            min="0.0"
+            max="0.2"
+            step="0.01"
+            value="{{artworkMetalness}}"
+          >
+          <div class="slider-labels">
+            <span>0.0 (none)</span>
+            <span>0.2 (max)</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Fresnel Edge Lift -->
+    <section class="setting-section">
+      <div class="setting-group">
+        <label class="setting-label">✨ Fresnel Edge Lift</label>
+        <p class="setting-description">
+          Brightens box silhouettes at oblique camera angles so artwork reads at the sides of
+          shelves. Lift controls brightness boost intensity; Power controls falloff sharpness.
+        </p>
+
+        <div class="setting-control">
+          <label class="setting-label" for="artwork-fresnel-lift" style="font-weight: normal; font-size: 0.9rem;">
+            Lift: <span id="artwork-fresnel-lift-value" class="value-display">{{artworkFresnelLiftLabel}}</span>
+          </label>
+          <input
+            type="range"
+            id="artwork-fresnel-lift"
+            class="setting-slider pause-slider"
+            min="0.0"
+            max="0.3"
+            step="0.01"
+            value="{{artworkFresnelLift}}"
+          >
+          <div class="slider-labels">
+            <span>0.0 (off)</span>
+            <span>0.3 (max)</span>
+          </div>
+        </div>
+
+        <div class="setting-control" style="margin-top: 1rem;">
+          <label class="setting-label" for="artwork-fresnel-power" style="font-weight: normal; font-size: 0.9rem;">
+            Power: <span id="artwork-fresnel-power-value" class="value-display">{{artworkFresnelPowerLabel}}</span>
+          </label>
+          <input
+            type="range"
+            id="artwork-fresnel-power"
+            class="setting-slider pause-slider"
+            min="2.0"
+            max="8.0"
+            step="0.1"
+            value="{{artworkFresnelPower}}"
+          >
+          <div class="slider-labels">
+            <span>2.0 (wide)</span>
+            <span>8.0 (sharp)</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Shadow Contact Grounding -->
+    <section class="setting-section">
+      <div class="setting-group">
+        <label class="setting-label">🌓 Shadow Contact Grounding</label>
+        <p class="setting-description">
+          Controls how tightly shadows hug surfaces at shelf-box intersections.
+          More negative Bias pulls shadow contact closer; lower Normal Bias tightens the
+          contact zone. Changes apply immediately.
+        </p>
+
+        <div class="setting-control">
+          <label class="setting-label" for="shadow-contact-bias" style="font-weight: normal; font-size: 0.9rem;">
+            Bias: <span id="shadow-contact-bias-value" class="value-display">{{shadowContactBiasLabel}}</span>
+          </label>
+          <input
+            type="range"
+            id="shadow-contact-bias"
+            class="setting-slider pause-slider"
+            min="-0.005"
+            max="-0.0001"
+            step="0.0001"
+            value="{{shadowContactBias}}"
+          >
+          <div class="slider-labels">
+            <span>−0.005 (tighter)</span>
+            <span>−0.0001 (looser)</span>
+          </div>
+        </div>
+
+        <div class="setting-control" style="margin-top: 1rem;">
+          <label class="setting-label" for="shadow-contact-normal-bias" style="font-weight: normal; font-size: 0.9rem;">
+            Normal Bias: <span id="shadow-contact-normal-bias-value" class="value-display">{{shadowContactNormalBiasLabel}}</span>
+          </label>
+          <input
+            type="range"
+            id="shadow-contact-normal-bias"
+            class="setting-slider pause-slider"
+            min="0.0"
+            max="0.03"
+            step="0.001"
+            value="{{shadowContactNormalBias}}"
+          >
+          <div class="slider-labels">
+            <span>0.0 (tight)</span>
+            <span>0.03 (loose)</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Reset -->
+    <section class="setting-section">
+      <div class="setting-group">
+        <div class="setting-control">
+          <button id="reset-display-advanced" class="pause-btn secondary">
+            Reset to Defaults
+          </button>
+        </div>
+      </div>
+    </section>
+
+  </div>
+</div>

--- a/client/src/types/LightingEvents.ts
+++ b/client/src/types/LightingEvents.ts
@@ -61,3 +61,20 @@ export const LightingEventTypes = {
     /** Request a point light be created by the lighting system (avoids direct scene add) */
     PointLightRequested: 'lighting:point-light-requested',
 } as const
+
+export interface ArtworkTuningChangedEvent extends BaseInteractionEvent {
+    roughness?: number
+    metalness?: number
+    fresnelLift?: number
+    fresnelPower?: number
+}
+
+export interface ShadowContactTuningChangedEvent extends BaseInteractionEvent {
+    bias?: number
+    normalBias?: number
+}
+
+export const ArtworkEventTypes = {
+    TuningChanged: 'artwork:tuning-changed',
+    ShadowContactTuningChanged: 'artwork:shadow-contact-tuning-changed',
+} as const

--- a/client/src/ui/pause/PauseMenuManager.ts
+++ b/client/src/ui/pause/PauseMenuManager.ts
@@ -17,6 +17,7 @@ import { ApplicationPanel } from './panels/ApplicationPanel'
 import { GameSettingsPanel } from './panels/GameSettingsPanel'
 import { GraphicsSettingsPanel } from './panels/GraphicsSettingsPanel'
 import { CameraSettingsPanel } from './panels/CameraSettingsPanel'
+import { DisplayAdvancedPanel } from './panels/DisplayAdvancedPanel'
 import type { PerformanceMonitorUI } from '../PerformanceMonitor'
 import { EventManager } from '../../core/EventManager'
 import { SteamEventTypes } from '../../types/InteractionEvents'
@@ -173,7 +174,7 @@ export class PauseMenuManager {
             title: 'Display',
             icon: '🖥️',
             // TODO(act3-ui-normalization): add 'ui-settings' child panel when UI Scale slider is implemented.
-            childPanelIds: ['graphics-settings', 'camera-settings'],
+            childPanelIds: ['graphics-settings', 'camera-settings', 'display-advanced'],
             defaultChildPanelId: 'graphics-settings'
         })
         
@@ -186,6 +187,9 @@ export class PauseMenuManager {
 
         // Register camera settings panel
         this.registerPanel(new CameraSettingsPanel({}, this.appSettings))
+
+        // Register advanced display tuning panel
+        this.registerPanel(new DisplayAdvancedPanel({}, this.appSettings))
     
         const debugPanel = new DebugPanel({}, this.performanceMonitor)
         this.registerPanel(debugPanel)

--- a/client/src/ui/pause/panels/DisplayAdvancedPanel.ts
+++ b/client/src/ui/pause/panels/DisplayAdvancedPanel.ts
@@ -1,0 +1,155 @@
+/**
+ * Display Advanced Panel - Artwork material and shadow contact tuning
+ *
+ * Provides sub-tab controls for expert-level visual settings:
+ * - Artwork PBR roughness / metalness
+ * - Fresnel edge lift (intensity and falloff)
+ * - Shadow contact grounding (bias / normalBias)
+ */
+
+import { PauseMenuPanel, type PauseMenuPanelConfig } from '../PauseMenuPanel'
+import { renderTemplate } from '../../../utils/TemplateEngine'
+import displayAdvancedPanelTemplate from '../../../templates/pause-menu/display-advanced-panel.html?raw'
+import '../../../styles/pause-menu/settings-components.css'
+import { AppSettings, Setting } from '../../../core/AppSettings'
+import { EventManager } from '../../../core/EventManager'
+import { UIComponentUtils } from '../../../utils/UIComponentUtils'
+import { ArtworkEventTypes, type ArtworkTuningChangedEvent, type ShadowContactTuningChangedEvent } from '../../../types/LightingEvents'
+
+const DEFAULTS = {
+    artworkRoughness: 0.35,
+    artworkMetalness: 0.05,
+    artworkFresnelLift: 0.15,
+    artworkFresnelPower: 4.0,
+    shadowContactBias: -0.001,
+    shadowContactNormalBias: 0.005,
+} as const
+
+export class DisplayAdvancedPanel extends PauseMenuPanel {
+    readonly id = 'display-advanced'
+    readonly title = 'Advanced'
+    readonly icon = '🔬'
+
+    private appSettings: AppSettings
+
+    constructor(config: PauseMenuPanelConfig = {}, appSettings: AppSettings) {
+        super(config)
+        this.appSettings = appSettings
+    }
+
+    render(): string {
+        const s = this.appSettings
+        return renderTemplate(displayAdvancedPanelTemplate, {
+            artworkRoughness: s.getSetting('artworkRoughness'),
+            artworkRoughnessLabel: s.getSetting('artworkRoughness').toFixed(2),
+            artworkMetalness: s.getSetting('artworkMetalness'),
+            artworkMetalnessLabel: s.getSetting('artworkMetalness').toFixed(2),
+            artworkFresnelLift: s.getSetting('artworkFresnelLift'),
+            artworkFresnelLiftLabel: s.getSetting('artworkFresnelLift').toFixed(2),
+            artworkFresnelPower: s.getSetting('artworkFresnelPower'),
+            artworkFresnelPowerLabel: s.getSetting('artworkFresnelPower').toFixed(1),
+            shadowContactBias: s.getSetting('shadowContactBias'),
+            shadowContactBiasLabel: s.getSetting('shadowContactBias').toFixed(4),
+            shadowContactNormalBias: s.getSetting('shadowContactNormalBias'),
+            shadowContactNormalBiasLabel: s.getSetting('shadowContactNormalBias').toFixed(3),
+        })
+    }
+
+    attachEvents(): void {
+        const eventManager = EventManager.getInstance()
+
+        UIComponentUtils.setupSliders(this.container, [
+            {
+                sliderId: 'artwork-roughness',
+                valueDisplayId: 'artwork-roughness-value',
+                formatDisplay: (v) => v.toFixed(2),
+                onInput: (value) => {
+                    this.appSettings.setSetting(Setting.ArtworkRoughness, value)
+                    eventManager.emit<ArtworkTuningChangedEvent>(ArtworkEventTypes.TuningChanged, { roughness: value })
+                }
+            },
+            {
+                sliderId: 'artwork-metalness',
+                valueDisplayId: 'artwork-metalness-value',
+                formatDisplay: (v) => v.toFixed(2),
+                onInput: (value) => {
+                    this.appSettings.setSetting(Setting.ArtworkMetalness, value)
+                    eventManager.emit<ArtworkTuningChangedEvent>(ArtworkEventTypes.TuningChanged, { metalness: value })
+                }
+            },
+            {
+                sliderId: 'artwork-fresnel-lift',
+                valueDisplayId: 'artwork-fresnel-lift-value',
+                formatDisplay: (v) => v.toFixed(2),
+                onInput: (value) => {
+                    this.appSettings.setSetting(Setting.ArtworkFresnelLift, value)
+                    eventManager.emit<ArtworkTuningChangedEvent>(ArtworkEventTypes.TuningChanged, { fresnelLift: value })
+                }
+            },
+            {
+                sliderId: 'artwork-fresnel-power',
+                valueDisplayId: 'artwork-fresnel-power-value',
+                formatDisplay: (v) => v.toFixed(1),
+                onInput: (value) => {
+                    this.appSettings.setSetting(Setting.ArtworkFresnelPower, value)
+                    eventManager.emit<ArtworkTuningChangedEvent>(ArtworkEventTypes.TuningChanged, { fresnelPower: value })
+                }
+            },
+            {
+                sliderId: 'shadow-contact-bias',
+                valueDisplayId: 'shadow-contact-bias-value',
+                formatDisplay: (v) => v.toFixed(4),
+                onInput: (value) => {
+                    this.appSettings.setSetting(Setting.ShadowContactBias, value)
+                    eventManager.emit<ShadowContactTuningChangedEvent>(ArtworkEventTypes.ShadowContactTuningChanged, { bias: value })
+                }
+            },
+            {
+                sliderId: 'shadow-contact-normal-bias',
+                valueDisplayId: 'shadow-contact-normal-bias-value',
+                formatDisplay: (v) => v.toFixed(3),
+                onInput: (value) => {
+                    this.appSettings.setSetting(Setting.ShadowContactNormalBias, value)
+                    eventManager.emit<ShadowContactTuningChangedEvent>(ArtworkEventTypes.ShadowContactTuningChanged, { normalBias: value })
+                }
+            },
+        ])
+
+        UIComponentUtils.setupButton(this.container, {
+            buttonId: 'reset-display-advanced',
+            onClick: this.resetToDefaults.bind(this)
+        })
+    }
+
+    onShow(): void {}
+    onHide(): void {}
+
+    private resetToDefaults(): void {
+        const eventManager = EventManager.getInstance()
+
+        this.appSettings.setSetting(Setting.ArtworkRoughness, DEFAULTS.artworkRoughness)
+        this.appSettings.setSetting(Setting.ArtworkMetalness, DEFAULTS.artworkMetalness)
+        this.appSettings.setSetting(Setting.ArtworkFresnelLift, DEFAULTS.artworkFresnelLift)
+        this.appSettings.setSetting(Setting.ArtworkFresnelPower, DEFAULTS.artworkFresnelPower)
+        this.appSettings.setSetting(Setting.ShadowContactBias, DEFAULTS.shadowContactBias)
+        this.appSettings.setSetting(Setting.ShadowContactNormalBias, DEFAULTS.shadowContactNormalBias)
+
+        eventManager.emit<ArtworkTuningChangedEvent>(ArtworkEventTypes.TuningChanged, {
+            roughness: DEFAULTS.artworkRoughness,
+            metalness: DEFAULTS.artworkMetalness,
+            fresnelLift: DEFAULTS.artworkFresnelLift,
+            fresnelPower: DEFAULTS.artworkFresnelPower,
+        })
+        eventManager.emit<ShadowContactTuningChangedEvent>(ArtworkEventTypes.ShadowContactTuningChanged, {
+            bias: DEFAULTS.shadowContactBias,
+            normalBias: DEFAULTS.shadowContactNormalBias,
+        })
+
+        // Re-render to sync sliders to reset values
+        const container = document.getElementById(this.config.containerId ?? 'pause-menu-content')
+        if (container) {
+            container.innerHTML = this.render()
+            this.attachEvents()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a new Display > Advanced pause-menu panel for artwork and shadow tuning controls
- Split generic pause-menu styles from settings-specific primitives by introducing `settings-components.css`
- Keep `shared-components.css` focused on non-settings shared UI primitives
- Wire settings panel/style imports to the new settings shared layer

## Included
- New `DisplayAdvancedPanel` and template
- Pause menu registration for the new Display sub-tab panel
- Settings/events/app-settings wiring required for UI controls
- Settings styling refactor with alternating section backgrounds

## Notes
- This PR isolates UI iteration work so it can merge independently before additional rendering/material follow-up changes.