### PR TITLE
feat(rendering): artwork vibrancy + shadow contact tuning pipeline

### DIFF
--- a/client/src/core/AppSettings.ts
+++ b/client/src/core/AppSettings.ts
@@ -43,6 +43,12 @@ export const Setting = {
     ShadowQuality: 'shadowQuality',
     ShadowMapEnabled: 'shadowMapEnabled',
     PixelRatioScale: 'pixelRatioScale',
+    ArtworkRoughness: 'artworkRoughness',
+    ArtworkMetalness: 'artworkMetalness',
+    ArtworkFresnelLift: 'artworkFresnelLift',
+    ArtworkFresnelPower: 'artworkFresnelPower',
+    ShadowContactBias: 'shadowContactBias',
+    ShadowContactNormalBias: 'shadowContactNormalBias',
     CeilingHeight: 'ceilingHeight',
     EnableLighting: 'enableLighting',
     ShowLightingDebug: 'showLightingDebug',
@@ -93,6 +99,12 @@ export const SettingCategory = {
         Setting.ShadowQuality,
         Setting.ShadowMapEnabled,
         Setting.PixelRatioScale,
+        Setting.ArtworkRoughness,
+        Setting.ArtworkMetalness,
+        Setting.ArtworkFresnelLift,
+        Setting.ArtworkFresnelPower,
+        Setting.ShadowContactBias,
+        Setting.ShadowContactNormalBias,
         Setting.CeilingHeight,
         Setting.EnableLighting,
         Setting.ShowLightingDebug,
@@ -121,6 +133,12 @@ export interface ApplicationSettings {
     shadowQuality: number // 0=off, 1=low, 2=medium, 3=high, 4=ultra
     shadowMapEnabled: boolean
     pixelRatioScale: number
+    artworkRoughness: number
+    artworkMetalness: number
+    artworkFresnelLift: number
+    artworkFresnelPower: number
+    shadowContactBias: number
+    shadowContactNormalBias: number
     ceilingHeight: number
     enableLighting: boolean
     showLightingDebug: boolean
@@ -435,6 +453,12 @@ export class AppSettings {
             shadowQuality: 2, // Medium shadows by default
             shadowMapEnabled: true,
             pixelRatioScale: 1,
+            artworkRoughness: 0.35,
+            artworkMetalness: 0.05,
+            artworkFresnelLift: 0.15,
+            artworkFresnelPower: 4.0,
+            shadowContactBias: -0.001,
+            shadowContactNormalBias: 0.005,
             ceilingHeight: 4.2,
             enableLighting: true,
             showLightingDebug: false,

--- a/client/src/core/AppSettings.ts
+++ b/client/src/core/AppSettings.ts
@@ -65,13 +65,6 @@ export const Setting = {
     LodMaxHighSlots: 'lodMaxHighSlots',
     LodHighReductionRatio: 'lodHighReductionRatio',
     LodMedReductionRatio: 'lodMedReductionRatio',
-    // Artwork Tuning
-    ArtworkRoughness: 'artworkRoughness',
-    ArtworkMetalness: 'artworkMetalness',
-    ArtworkFresnelLift: 'artworkFresnelLift',
-    ArtworkFresnelPower: 'artworkFresnelPower',
-    ShadowContactBias: 'shadowContactBias',
-    ShadowContactNormalBias: 'shadowContactNormalBias',
     // Interface
     ShowFPS: 'showFPS',
     ShowPerformanceStats: 'showPerformanceStats',
@@ -114,12 +107,6 @@ export const SettingCategory = {
         Setting.LodMaxHighSlots,
         Setting.LodHighReductionRatio,
         Setting.LodMedReductionRatio,
-        Setting.ArtworkRoughness,
-        Setting.ArtworkMetalness,
-        Setting.ArtworkFresnelLift,
-        Setting.ArtworkFresnelPower,
-        Setting.ShadowContactBias,
-        Setting.ShadowContactNormalBias,
     ] as const,
     // Add other categories as needed (Interface, Debug, Steam, etc.)
 } as const
@@ -158,14 +145,6 @@ export interface ApplicationSettings {
     lodHighReductionRatio: number // HIGH texture reduction (0.5 = 50% of source)
     lodMedReductionRatio: number  // MED texture reduction (0.25 = 25% of source)
 
-    // Artwork Tuning (Advanced Display settings)
-    artworkRoughness: number          // PBR roughness [0.2, 0.6]
-    artworkMetalness: number          // PBR metalness [0.0, 0.2]
-    artworkFresnelLift: number        // Edge lift intensity [0.0, 0.3]
-    artworkFresnelPower: number       // Edge sharpness exponent [2.0, 8.0]
-    shadowContactBias: number         // Directional shadow bias (negative)
-    shadowContactNormalBias: number   // Directional shadow normal bias
-    
     // Interface Settings
     showFPS: boolean
     showPerformanceStats: boolean
@@ -478,14 +457,6 @@ export class AppSettings {
             lodMaxHighSlots: 128,  // Max HIGH texture slots (128 × 300×450 = ~66MB VRAM)
             lodHighReductionRatio: 0.5,  // HIGH = 50% of nominal = 300×450 (true CDN ceiling for most titles)
             lodMedReductionRatio: 0.25,  // MED = 25% of source (600×900 → 150×225)
-
-            // Artwork Tuning
-            artworkRoughness: 0.35,
-            artworkMetalness: 0.05,
-            artworkFresnelLift: 0.15,
-            artworkFresnelPower: 4.0,
-            shadowContactBias: -0.001,
-            shadowContactNormalBias: 0.005,
             
             // Interface Settings
             showFPS: false,

--- a/client/src/lighting/ShadowPolicy.ts
+++ b/client/src/lighting/ShadowPolicy.ts
@@ -10,6 +10,11 @@ export interface RoomFootprint {
     depth: number
 }
 
+export interface ShadowContactTuning {
+    bias?: number
+    normalBias?: number
+}
+
 const SHADOW_MAP_SIZES = {
     LOW: 512,
     MEDIUM: 1024,
@@ -119,18 +124,22 @@ export function configureDirectionalShadow(
 export function configureDirectionalShadowForShelfContact(
     light: THREE.DirectionalLight,
     config: ShadowConfig,
-    footprint: RoomFootprint
+    footprint: RoomFootprint,
+    tuning?: ShadowContactTuning
 ): void {
     applyLightShadowPolicy(light, config)
     if (!light.castShadow) return
 
-    // More aggressive bias values for tighter contact shadows
-    // Slightly more negative bias pulls shadows closer to contact points
-    light.shadow.bias = -0.001
-    // Reduce normalBias to allow shadows to creep closer to surfaces
-    light.shadow.normalBias = 0.005
-    // Use tighter camera framing for shelf zones
+    applyShadowContactTuning(light, tuning)
     fitDirectionalShadowCameraForShelfContact(light, footprint)
+}
+
+export function applyShadowContactTuning(
+    light: THREE.DirectionalLight,
+    tuning?: ShadowContactTuning
+): void {
+    light.shadow.bias = tuning?.bias ?? -0.001
+    light.shadow.normalBias = tuning?.normalBias ?? 0.005
 }
 
 export function refitDirectionalShadowCameras(

--- a/client/src/lighting/ShadowPolicy.ts
+++ b/client/src/lighting/ShadowPolicy.ts
@@ -77,6 +77,27 @@ export function fitDirectionalShadowCamera(
     light.shadow.camera.updateProjectionMatrix()
 }
 
+/**
+ * Fit shadow camera with tighter framing for shelf contact grounding.
+ * Reduces the view area to focus on shelf zones, allowing for tighter
+ * contact shadows with better precision around shelf bases and overhangs.
+ */
+export function fitDirectionalShadowCameraForShelfContact(
+    light: THREE.DirectionalLight,
+    footprint: RoomFootprint
+): void {
+    // Tighter fit (0.5 instead of 0.6) focuses shadow precision on shelf zones
+    const halfWidth = Math.max(10, footprint.width * 0.5)
+    const halfDepth = Math.max(8, footprint.depth * 0.5)
+    light.shadow.camera.left = -halfWidth
+    light.shadow.camera.right = halfWidth
+    light.shadow.camera.top = halfDepth
+    light.shadow.camera.bottom = -halfDepth
+    light.shadow.camera.near = 0.5
+    light.shadow.camera.far = 40
+    light.shadow.camera.updateProjectionMatrix()
+}
+
 export function configureDirectionalShadow(
     light: THREE.DirectionalLight,
     config: ShadowConfig,
@@ -88,6 +109,28 @@ export function configureDirectionalShadow(
     light.shadow.bias = -0.0006
     light.shadow.normalBias = 0.015
     fitDirectionalShadowCamera(light, footprint)
+}
+
+/**
+ * Configure directional shadow with tighter contact grounding for shelf zones.
+ * Uses more aggressive bias tuning and tighter camera framing to create
+ * darker, more visible contact shadows at shelf-box intersections.
+ */
+export function configureDirectionalShadowForShelfContact(
+    light: THREE.DirectionalLight,
+    config: ShadowConfig,
+    footprint: RoomFootprint
+): void {
+    applyLightShadowPolicy(light, config)
+    if (!light.castShadow) return
+
+    // More aggressive bias values for tighter contact shadows
+    // Slightly more negative bias pulls shadows closer to contact points
+    light.shadow.bias = -0.001
+    // Reduce normalBias to allow shadows to creep closer to surfaces
+    light.shadow.normalBias = 0.005
+    // Use tighter camera framing for shelf zones
+    fitDirectionalShadowCameraForShelfContact(light, footprint)
 }
 
 export function refitDirectionalShadowCameras(

--- a/client/src/scene/LightingRenderer.ts
+++ b/client/src/scene/LightingRenderer.ts
@@ -16,10 +16,10 @@ import { RectAreaLightUniformsLib } from 'three/examples/jsm/lights/RectAreaLigh
 import { BlockbusterColors } from '../utils/Colors'
 import { PropRenderer } from './PropRenderer'
 import { LightingDebugHelper } from './LightingDebugHelper'
-import { AppSettings, LIGHTING_QUALITY, type LightingQuality } from '../core/AppSettings'
+import { AppSettings, LIGHTING_QUALITY, Setting, type LightingQuality, type SettingChangedEvent } from '../core/AppSettings'
 import { EventManager, EventSource } from '../core/EventManager'
-import { LightingEventTypes, ArtworkEventTypes, type LightingToggleEvent, type LightingDebugToggleEvent, type LightingQualityChangedEvent, type ShadowContactTuningChangedEvent } from '../types/LightingEvents'
-import { RoomEventTypes, type RoomResizedEvent } from '../types/InteractionEvents'
+import { LightingEventTypes, type LightingToggleEvent, type LightingDebugToggleEvent, type LightingQualityChangedEvent } from '../types/LightingEvents'
+import { RoomEventTypes, type RoomResizedEvent, AppSettingsEventTypes } from '../types/InteractionEvents'
 import { StorePropsEventTypes } from './props/PropsEvents'
 import { LightFactory } from '../lighting/LightFactory'
 import { LightRegistry } from '../lighting/LightRegistry'
@@ -116,9 +116,9 @@ export class LightingRenderer {
             this.updateLightingQuality(event.detail.quality)
         })
 
-        this.eventManager.registerEventHandler<ShadowContactTuningChangedEvent>(
-            ArtworkEventTypes.ShadowContactTuningChanged,
-            this.onShadowContactTuningChanged.bind(this)
+        this.eventManager.registerEventHandler<SettingChangedEvent>(
+            AppSettingsEventTypes.Changed,
+            this.onAppSettingsChanged.bind(this)
         )
 
         // Listen for room resizing events to update lighting, including initial room build.
@@ -281,13 +281,20 @@ export class LightingRenderer {
         }
     }
 
-    private onShadowContactTuningChanged(event: CustomEvent<ShadowContactTuningChangedEvent>): void {
+    private onAppSettingsChanged(event: CustomEvent<SettingChangedEvent>): void {
+        if (
+            event.detail.settingName !== Setting.ShadowContactBias
+            && event.detail.settingName !== Setting.ShadowContactNormalBias
+        ) {
+            return
+        }
+
         const mainDirectional = this.lightingGroup.getObjectByName(LIGHT_NAMES.MAIN_DIRECTIONAL)
         if (!(mainDirectional instanceof THREE.DirectionalLight)) return
 
         applyShadowContactTuning(mainDirectional, {
-            bias: event.detail.bias,
-            normalBias: event.detail.normalBias,
+            bias: AppSettings.get(Setting.ShadowContactBias),
+            normalBias: AppSettings.get(Setting.ShadowContactNormalBias),
         })
         this.renderer.shadowMap.needsUpdate = true
     }

--- a/client/src/scene/LightingRenderer.ts
+++ b/client/src/scene/LightingRenderer.ts
@@ -23,7 +23,7 @@ import { RoomEventTypes, type RoomResizedEvent } from '../types/InteractionEvent
 import { StorePropsEventTypes } from './props/PropsEvents'
 import { LightFactory } from '../lighting/LightFactory'
 import { LightRegistry } from '../lighting/LightRegistry'
-import { applyRendererShadowPolicy, applyLightShadowPolicy, configureDirectionalShadow, refitDirectionalShadowCameras } from '../lighting/ShadowPolicy'
+import { applyRendererShadowPolicy, applyLightShadowPolicy, configureDirectionalShadow, configureDirectionalShadowForShelfContact, refitDirectionalShadowCameras } from '../lighting/ShadowPolicy'
 import { Logger } from '../utils/Logger'
 import { PerformanceMonitor } from '../utils/PerformanceMonitor'
 import { GameSpotlight } from '../debug/GameSpotlight'
@@ -269,7 +269,7 @@ export class LightingRenderer {
         const mainDirectional = this.lightingGroup.getObjectByName(LIGHT_NAMES.MAIN_DIRECTIONAL)
         if (mainDirectional instanceof THREE.DirectionalLight) {
             this.attachDirectionalTarget(mainDirectional)
-            configureDirectionalShadow(mainDirectional, this.config, this.currentFootprint())
+            configureDirectionalShadowForShelfContact(mainDirectional, this.config, this.currentFootprint())
         }
     }
 

--- a/client/src/scene/LightingRenderer.ts
+++ b/client/src/scene/LightingRenderer.ts
@@ -18,12 +18,12 @@ import { PropRenderer } from './PropRenderer'
 import { LightingDebugHelper } from './LightingDebugHelper'
 import { AppSettings, LIGHTING_QUALITY, type LightingQuality } from '../core/AppSettings'
 import { EventManager, EventSource } from '../core/EventManager'
-import { LightingEventTypes, type LightingToggleEvent, type LightingDebugToggleEvent, type LightingQualityChangedEvent } from '../types/LightingEvents'
+import { LightingEventTypes, ArtworkEventTypes, type LightingToggleEvent, type LightingDebugToggleEvent, type LightingQualityChangedEvent, type ShadowContactTuningChangedEvent } from '../types/LightingEvents'
 import { RoomEventTypes, type RoomResizedEvent } from '../types/InteractionEvents'
 import { StorePropsEventTypes } from './props/PropsEvents'
 import { LightFactory } from '../lighting/LightFactory'
 import { LightRegistry } from '../lighting/LightRegistry'
-import { applyRendererShadowPolicy, applyLightShadowPolicy, configureDirectionalShadow, configureDirectionalShadowForShelfContact, refitDirectionalShadowCameras } from '../lighting/ShadowPolicy'
+import { applyRendererShadowPolicy, applyLightShadowPolicy, applyShadowContactTuning, configureDirectionalShadow, configureDirectionalShadowForShelfContact, refitDirectionalShadowCameras } from '../lighting/ShadowPolicy'
 import { Logger } from '../utils/Logger'
 import { PerformanceMonitor } from '../utils/PerformanceMonitor'
 import { GameSpotlight } from '../debug/GameSpotlight'
@@ -115,6 +115,11 @@ export class LightingRenderer {
         this.eventManager.registerEventHandler(LightingEventTypes.QualityChanged, (event: CustomEvent<LightingQualityChangedEvent>) => {
             this.updateLightingQuality(event.detail.quality)
         })
+
+        this.eventManager.registerEventHandler<ShadowContactTuningChangedEvent>(
+            ArtworkEventTypes.ShadowContactTuningChanged,
+            this.onShadowContactTuningChanged.bind(this)
+        )
 
         // Listen for room resizing events to update lighting, including initial room build.
         this.eventManager.registerEventHandler(RoomEventTypes.Resized, (event: CustomEvent<RoomResizedEvent>) => {
@@ -269,8 +274,22 @@ export class LightingRenderer {
         const mainDirectional = this.lightingGroup.getObjectByName(LIGHT_NAMES.MAIN_DIRECTIONAL)
         if (mainDirectional instanceof THREE.DirectionalLight) {
             this.attachDirectionalTarget(mainDirectional)
-            configureDirectionalShadowForShelfContact(mainDirectional, this.config, this.currentFootprint())
+            configureDirectionalShadowForShelfContact(mainDirectional, this.config, this.currentFootprint(), {
+                bias: AppSettings.get('shadowContactBias'),
+                normalBias: AppSettings.get('shadowContactNormalBias')
+            })
         }
+    }
+
+    private onShadowContactTuningChanged(event: CustomEvent<ShadowContactTuningChangedEvent>): void {
+        const mainDirectional = this.lightingGroup.getObjectByName(LIGHT_NAMES.MAIN_DIRECTIONAL)
+        if (!(mainDirectional instanceof THREE.DirectionalLight)) return
+
+        applyShadowContactTuning(mainDirectional, {
+            bias: event.detail.bias,
+            normalBias: event.detail.normalBias,
+        })
+        this.renderer.shadowMap.needsUpdate = true
     }
 
     private setupLightsByQuality(): void {

--- a/client/src/scene/game-box/instancing/LitArtworkMaterial.ts
+++ b/client/src/scene/game-box/instancing/LitArtworkMaterial.ts
@@ -13,6 +13,17 @@
 
 import * as THREE from 'three'
 
+interface LitArtworkUniforms {
+    artworkFresnelLift?: { value: number }
+    artworkFresnelPower?: { value: number }
+}
+
+interface LitArtworkMaterialUserData {
+    litArtworkUniforms?: LitArtworkUniforms
+    litArtworkFresnelLift?: number
+    litArtworkFresnelPower?: number
+}
+
 /**
  * Compute a deterministic per-instance variation factor (0-1) from textureIndex.
  * Used to break up the synthetic appearance of identical instances with subtle
@@ -164,12 +175,21 @@ export function createLitArtworkMaterial(options: LitArtworkMaterialOptions): TH
     // result neutral so the array texture sampling controls the final color.
     material.map = whiteMap
 
+    const userData = material.userData as LitArtworkMaterialUserData
+    userData.litArtworkFresnelLift = 0.15
+    userData.litArtworkFresnelPower = 4.0
+
     material.onBeforeCompile = (shader) => {
         // Bind the texture arrays and fresnel parameters as custom uniforms.
         shader.uniforms.textureArrayHigh = { value: options.highTexture }
         shader.uniforms.textureArrayMid  = { value: options.midTexture  }
-        shader.uniforms.artworkFresnelLift = { value: 0.15 }
-        shader.uniforms.artworkFresnelPower = { value: 4.0 }
+        shader.uniforms.artworkFresnelLift = { value: userData.litArtworkFresnelLift ?? 0.15 }
+        shader.uniforms.artworkFresnelPower = { value: userData.litArtworkFresnelPower ?? 4.0 }
+
+        userData.litArtworkUniforms = {
+            artworkFresnelLift: shader.uniforms.artworkFresnelLift as { value: number },
+            artworkFresnelPower: shader.uniforms.artworkFresnelPower as { value: number },
+        }
 
         // Vertex: inject varyings + per-instance attribute reads + fresnel computation.
         shader.vertexShader = shader.vertexShader.replace(
@@ -236,16 +256,20 @@ export function tuneLitArtworkFresnel(
     material: THREE.MeshStandardMaterial,
     params?: Partial<FresnelTuningParams>
 ): void {
-    if (!material.userData) {
-        material.userData = {}
-    }
+    const userData = material.userData as LitArtworkMaterialUserData
+    const uniforms = userData.litArtworkUniforms
 
-    const shader = (material as any).__webglProgram
-    if (shader?.uniforms?.artworkFresnelLift) {
-        shader.uniforms.artworkFresnelLift.value = Math.min(0.3, Math.max(0.0, params?.fresnelLift ?? 0.15))
+    const fresnelLift = Math.min(0.3, Math.max(0.0, params?.fresnelLift ?? 0.15))
+    const fresnelPower = Math.min(8.0, Math.max(2.0, params?.fresnelPower ?? 4.0))
+
+    userData.litArtworkFresnelLift = fresnelLift
+    userData.litArtworkFresnelPower = fresnelPower
+
+    if (uniforms?.artworkFresnelLift) {
+        uniforms.artworkFresnelLift.value = fresnelLift
     }
-    if (shader?.uniforms?.artworkFresnelPower) {
-        shader.uniforms.artworkFresnelPower.value = Math.min(8.0, Math.max(2.0, params?.fresnelPower ?? 4.0))
+    if (uniforms?.artworkFresnelPower) {
+        uniforms.artworkFresnelPower.value = fresnelPower
     }
 }
 

--- a/client/src/scene/game-box/instancing/LitArtworkMaterial.ts
+++ b/client/src/scene/game-box/instancing/LitArtworkMaterial.ts
@@ -13,6 +13,18 @@
 
 import * as THREE from 'three'
 
+/**
+ * Compute a deterministic per-instance variation factor (0-1) from textureIndex.
+ * Used to break up the synthetic appearance of identical instances with subtle
+ * roughness/brightness variations. Uses a simple hash for determinism.
+ */
+export function computePerInstanceVariation(textureIndex: number): number {
+    // Simple hash: fold the texture index through a pseudo-random function
+    // Result is normalized to [0, 1] for use as a variation factor
+    const x = Math.sin(textureIndex * 12.9898) * 43758.5453
+    return x - Math.floor(x)
+}
+
 export interface LitArtworkMaterialOptions {
     highTexture: THREE.DataArrayTexture
     midTexture: THREE.DataArrayTexture
@@ -44,6 +56,7 @@ varying float vTextureIndex;
 varying float vLodLevel;
 varying float vHighTextureSlot;
 varying float vFresnelFactor;
+varying float vRoughnessVariation;
 
 uniform float artworkFresnelPower;
 `
@@ -60,6 +73,11 @@ vHighTextureSlot = highTextureSlot;
 vec3 viewDir = normalize( vViewPosition );
 float NdotV = max( 0.0, dot( normal, viewDir ) );
 vFresnelFactor = pow( 1.0 - NdotV, artworkFresnelPower );
+
+// Compute per-instance roughness variation from textureIndex.
+// Uses a simple hash to produce deterministic variation [0, 1] per instance.
+float x = sin( textureIndex * 12.9898 ) * 43758.5453;
+vRoughnessVariation = x - floor( x );
 `
 
 /** GLSL declarations injected into the fragment shader. */
@@ -72,6 +90,23 @@ varying float vTextureIndex;
 varying float vLodLevel;
 varying float vHighTextureSlot;
 varying float vFresnelFactor;
+varying float vRoughnessVariation;
+`
+
+/**
+ * GLSL that applies per-instance roughness variation.
+ *
+ * Maps the per-instance variation factor [0, 1] to a roughness offset
+ * within strict bounds to break up the clone look without popping.
+ */
+const FRAG_ROUGHNESS_VARIATION_CHUNK = /* glsl */ `
+{
+    // Apply per-instance roughness variation to break clone appearance.
+    // Variation [0, 1] is mapped to offset [-0.05, +0.05] around base 0.35.
+    // Clamped to [0.2, 0.6] to stay within valid specular response range.
+    float roughnessOffset = (vRoughnessVariation - 0.5) * 2.0 * 0.05;
+    roughnessFactor = clamp( roughnessFactor + roughnessOffset, 0.2, 0.6 );
+}
 `
 
 /**
@@ -158,6 +193,13 @@ export function createLitArtworkMaterial(options: LitArtworkMaterialOptions): TH
             '#include <map_fragment>',
             FRAG_MAP_CHUNK
         )
+
+        // Fragment: inject per-instance roughness variation after roughness map processing.
+        // This allows each instance to have subtle variation without popping.
+        shader.fragmentShader = shader.fragmentShader.replace(
+            '#include <roughnessmap_fragment>',
+            '#include <roughnessmap_fragment>\n' + FRAG_ROUGHNESS_VARIATION_CHUNK
+        )
     }
 
     // Ensure Three.js re-compiles when the material is cloned or the renderer
@@ -205,4 +247,29 @@ export function tuneLitArtworkFresnel(
     if (shader?.uniforms?.artworkFresnelPower) {
         shader.uniforms.artworkFresnelPower.value = Math.min(8.0, Math.max(2.0, params?.fresnelPower ?? 4.0))
     }
+}
+
+/**
+ * Apply per-instance roughness variation to break up the clone look.
+ *
+ * Computes a deterministic variation factor from textureIndex and applies
+ * a small roughness offset within strict bounds to avoid popping across
+ * LOD transitions or camera movement.
+ *
+ * @param material - The MeshStandardMaterial to modify.
+ * @param textureIndex - The texture index for this instance (used to seed deterministic variation).
+ * @param baseRoughness - The base roughness value. Variation will be applied around this.
+ * @param variationRange - How much to vary roughness (default 0.05 for ±5% of typical range).
+ */
+export function applyPerInstanceRoughnessVariation(
+    material: THREE.MeshStandardMaterial,
+    textureIndex: number,
+    baseRoughness: number = 0.35,
+    variationRange: number = 0.05
+): void {
+    const variation = computePerInstanceVariation(textureIndex)
+    // Map variation [0, 1] to [-variationRange, +variationRange]
+    const offset = (variation - 0.5) * 2 * variationRange
+    // Clamp final roughness within safe bounds
+    material.roughness = Math.min(0.6, Math.max(0.2, baseRoughness + offset))
 }

--- a/client/src/scene/game-box/instancing/LitArtworkMaterial.ts
+++ b/client/src/scene/game-box/instancing/LitArtworkMaterial.ts
@@ -18,6 +18,22 @@ export interface LitArtworkMaterialOptions {
     midTexture: THREE.DataArrayTexture
 }
 
+/** Parameters for fresnel edge lift effect. */
+export interface FresnelTuningParams {
+    /** Fresnel edge lift intensity (0.0 = none, 1.0 = max). Clipped to [0.0, 0.3]. Default: 0.15 */
+    fresnelLift?: number
+    /** Fresnel power exponent (higher = sharper edges). Clipped to [2.0, 8.0]. Default: 4.0 */
+    fresnelPower?: number
+}
+
+/** Gloss and surface tuning parameters. */
+export interface GlossTuningParams {
+    /** Base roughness value (0.0 = mirror, 1.0 = fully diffuse). Clipped to [0.2, 0.6]. Default: 0.35 */
+    roughness?: number
+    /** Metalness value for spec response. Clipped to [0.0, 0.2]. Default: 0.05 */
+    metalness?: number
+}
+
 /** GLSL declarations injected into the vertex shader. */
 const VERT_DECLARATIONS = /* glsl */ `
 attribute float textureIndex;
@@ -27,6 +43,9 @@ attribute float highTextureSlot;
 varying float vTextureIndex;
 varying float vLodLevel;
 varying float vHighTextureSlot;
+varying float vFresnelFactor;
+
+uniform float artworkFresnelPower;
 `
 
 /** GLSL injected at the end of the vertex main body. */
@@ -34,16 +53,25 @@ const VERT_IMPL = /* glsl */ `
 vTextureIndex    = textureIndex;
 vLodLevel        = lodLevel;
 vHighTextureSlot = highTextureSlot;
+
+// Compute fresnel factor in vertex shader where we have access to normal.
+// vViewPosition is available and points from vertex toward camera.
+// We compute (1 - |V·N|) and raise to power; at grazing angles this approaches 1.
+vec3 viewDir = normalize( vViewPosition );
+float NdotV = max( 0.0, dot( normal, viewDir ) );
+vFresnelFactor = pow( 1.0 - NdotV, artworkFresnelPower );
 `
 
 /** GLSL declarations injected into the fragment shader. */
 const FRAG_DECLARATIONS = /* glsl */ `
 uniform sampler2DArray textureArrayHigh;
 uniform sampler2DArray textureArrayMid;
+uniform float artworkFresnelLift;
 
 varying float vTextureIndex;
 varying float vLodLevel;
 varying float vHighTextureSlot;
+varying float vFresnelFactor;
 `
 
 /**
@@ -69,6 +97,11 @@ const FRAG_MAP_CHUNK = /* glsl */ `
     } else {
         sampledColor = texture( textureArrayMid, vec3( flippedUv, vTextureIndex ) );
     }
+
+    // Apply fresnel edge lift for silhouette readability.
+    // Fresnel factor was computed in vertex shader. At grazing angles, lift the color
+    // slightly to help boxes read at oblique camera positions.
+    sampledColor.rgb = mix( sampledColor.rgb, sampledColor.rgb * (1.0 + artworkFresnelLift), vFresnelFactor );
 
     // Honour existing map tint (mapTexelToLinear handles color-space).
     diffuseColor *= sampledColor;
@@ -97,11 +130,13 @@ export function createLitArtworkMaterial(options: LitArtworkMaterialOptions): TH
     material.map = whiteMap
 
     material.onBeforeCompile = (shader) => {
-        // Bind the texture arrays as custom uniforms.
+        // Bind the texture arrays and fresnel parameters as custom uniforms.
         shader.uniforms.textureArrayHigh = { value: options.highTexture }
         shader.uniforms.textureArrayMid  = { value: options.midTexture  }
+        shader.uniforms.artworkFresnelLift = { value: 0.15 }
+        shader.uniforms.artworkFresnelPower = { value: 4.0 }
 
-        // Vertex: inject varyings + per-instance attribute reads.
+        // Vertex: inject varyings + per-instance attribute reads + fresnel computation.
         shader.vertexShader = shader.vertexShader.replace(
             '#include <common>',
             '#include <common>\n' + VERT_DECLARATIONS
@@ -118,7 +153,7 @@ export function createLitArtworkMaterial(options: LitArtworkMaterialOptions): TH
         )
 
         // Fragment: replace the standard map_fragment chunk so we sample the
-        // texture array instead of a plain map uniform.
+        // texture array instead of a plain map uniform, and apply fresnel.
         shader.fragmentShader = shader.fragmentShader.replace(
             '#include <map_fragment>',
             FRAG_MAP_CHUNK
@@ -130,4 +165,44 @@ export function createLitArtworkMaterial(options: LitArtworkMaterialOptions): TH
     material.needsUpdate = true
 
     return material
+}
+
+/**
+ * Tune gloss parameters on a LitArtworkMaterial.
+ *
+ * @param material - The MeshStandardMaterial created by createLitArtworkMaterial.
+ * @param params - Optional gloss tuning. Unspecified values use defaults.
+ */
+export function tuneLitArtworkGloss(
+    material: THREE.MeshStandardMaterial,
+    params?: Partial<GlossTuningParams>
+): void {
+    material.roughness = Math.min(0.6, Math.max(0.2, params?.roughness ?? 0.4))
+    material.metalness = Math.min(0.2, Math.max(0.0, params?.metalness ?? 0.0))
+}
+
+/**
+ * Tune fresnel edge lift parameters on a LitArtworkMaterial.
+ *
+ * The fresnel effect lifts color at grazing angles, improving silhouette readability
+ * when boxes are viewed obliquely.
+ *
+ * @param material - The MeshStandardMaterial created by createLitArtworkMaterial.
+ * @param params - Optional fresnel tuning. Unspecified values use defaults.
+ */
+export function tuneLitArtworkFresnel(
+    material: THREE.MeshStandardMaterial,
+    params?: Partial<FresnelTuningParams>
+): void {
+    if (!material.userData) {
+        material.userData = {}
+    }
+
+    const shader = (material as any).__webglProgram
+    if (shader?.uniforms?.artworkFresnelLift) {
+        shader.uniforms.artworkFresnelLift.value = Math.min(0.3, Math.max(0.0, params?.fresnelLift ?? 0.15))
+    }
+    if (shader?.uniforms?.artworkFresnelPower) {
+        shader.uniforms.artworkFresnelPower.value = Math.min(8.0, Math.max(2.0, params?.fresnelPower ?? 4.0))
+    }
 }

--- a/client/src/scene/game-box/instancing/LitArtworkMaterial.ts
+++ b/client/src/scene/game-box/instancing/LitArtworkMaterial.ts
@@ -5,6 +5,11 @@
  * texture sampling while preserving Three.js lighting, shadow, tone-mapping,
  * and fog chunks.
  *
+ * IMPORTANT: This class depends on specific Three.js shader chunk anchors
+ * (for example '#include <map_fragment>'). That is intentionally a thin,
+ * tactical extension and can break if upstream chunk names or placement change.
+ * Replacements are guarded to fail loudly instead of silently degrading visuals.
+ *
  * Attributes injected per-instance (must exist on the geometry):
  *   textureIndex    – slot in the MID texture array
  *   lodLevel        – 0 = HIGH, 1 = MID
@@ -12,6 +17,27 @@
  */
 
 import * as THREE from 'three'
+import { Setting, type ApplicationSettings } from '../../../core/AppSettings'
+import vertDeclarations from './shaders/lit-artwork.vert.declarations.glsl?raw'
+import vertImpl from './shaders/lit-artwork.vert.impl.glsl?raw'
+import fragDeclarations from './shaders/lit-artwork.frag.declarations.glsl?raw'
+import fragMap from './shaders/lit-artwork.frag.map.glsl?raw'
+import fragRoughnessVariation from './shaders/lit-artwork.frag.roughness-variation.glsl?raw'
+
+export const LIT_ARTWORK_MATERIAL_SETTING_KEYS = [
+    Setting.ArtworkRoughness,
+    Setting.ArtworkMetalness,
+    Setting.ArtworkFresnelLift,
+    Setting.ArtworkFresnelPower,
+] as const satisfies ReadonlyArray<keyof ApplicationSettings>
+
+export function isLitArtworkMaterialSettingKey(
+    key: keyof ApplicationSettings
+): key is (typeof LIT_ARTWORK_MATERIAL_SETTING_KEYS)[number] {
+    return LIT_ARTWORK_MATERIAL_SETTING_KEYS.includes(
+        key as (typeof LIT_ARTWORK_MATERIAL_SETTING_KEYS)[number]
+    )
+}
 
 interface LitArtworkUniforms {
     artworkFresnelLift?: { value: number }
@@ -22,6 +48,29 @@ interface LitArtworkMaterialUserData {
     litArtworkUniforms?: LitArtworkUniforms
     litArtworkFresnelLift?: number
     litArtworkFresnelPower?: number
+}
+
+const SHADER_ANCHORS = {
+    common: '#include <common>',
+    beginVertex: '#include <begin_vertex>',
+    mapFragment: '#include <map_fragment>',
+    roughnessMapFragment: '#include <roughnessmap_fragment>',
+} as const
+
+function replaceRequiredShaderChunk(
+    shaderSource: string,
+    targetChunk: string,
+    replacement: string,
+    stage: 'vertex' | 'fragment'
+): string {
+    if (!shaderSource.includes(targetChunk)) {
+        throw new Error(
+            `[LitArtworkMaterial] Missing ${stage} shader chunk anchor: ${targetChunk}. `
+            + 'Three.js shader chunk layout may have changed.'
+        )
+    }
+
+    return shaderSource.replace(targetChunk, replacement)
 }
 
 /**
@@ -57,102 +106,7 @@ export interface GlossTuningParams {
     metalness?: number
 }
 
-/** GLSL declarations injected into the vertex shader. */
-const VERT_DECLARATIONS = /* glsl */ `
-attribute float textureIndex;
-attribute float lodLevel;
-attribute float highTextureSlot;
-
-varying float vTextureIndex;
-varying float vLodLevel;
-varying float vHighTextureSlot;
-varying float vFresnelFactor;
-varying float vRoughnessVariation;
-
-uniform float artworkFresnelPower;
-`
-
-/** GLSL injected at the end of the vertex main body. */
-const VERT_IMPL = /* glsl */ `
-vTextureIndex    = textureIndex;
-vLodLevel        = lodLevel;
-vHighTextureSlot = highTextureSlot;
-
-// Compute fresnel factor in vertex shader where we have access to normal.
-// vViewPosition is available and points from vertex toward camera.
-// We compute (1 - |V·N|) and raise to power; at grazing angles this approaches 1.
-vec3 viewDir = normalize( vViewPosition );
-float NdotV = max( 0.0, dot( normal, viewDir ) );
-vFresnelFactor = pow( 1.0 - NdotV, artworkFresnelPower );
-
-// Compute per-instance roughness variation from textureIndex.
-// Uses a simple hash to produce deterministic variation [0, 1] per instance.
-float x = sin( textureIndex * 12.9898 ) * 43758.5453;
-vRoughnessVariation = x - floor( x );
-`
-
-/** GLSL declarations injected into the fragment shader. */
-const FRAG_DECLARATIONS = /* glsl */ `
-uniform sampler2DArray textureArrayHigh;
-uniform sampler2DArray textureArrayMid;
-uniform float artworkFresnelLift;
-
-varying float vTextureIndex;
-varying float vLodLevel;
-varying float vHighTextureSlot;
-varying float vFresnelFactor;
-varying float vRoughnessVariation;
-`
-
-/**
- * GLSL that applies per-instance roughness variation.
- *
- * Maps the per-instance variation factor [0, 1] to a roughness offset
- * within strict bounds to break up the clone look without popping.
- */
-const FRAG_ROUGHNESS_VARIATION_CHUNK = /* glsl */ `
-{
-    // Apply per-instance roughness variation to break clone appearance.
-    // Variation [0, 1] is mapped to offset [-0.05, +0.05] around base 0.35.
-    // Clamped to [0.2, 0.6] to stay within valid specular response range.
-    float roughnessOffset = (vRoughnessVariation - 0.5) * 2.0 * 0.05;
-    roughnessFactor = clamp( roughnessFactor + roughnessOffset, 0.2, 0.6 );
-}
-`
-
-/**
- * GLSL that replaces the built-in #include <map_fragment> chunk.
- *
- * We must set diffuseColor (a vec4 used downstream by lighting chunks).
- * We do NOT call gl_FragColor directly — the standard material pipeline
- * writes the final output after tone-mapping, fog, and shadow averaging.
- *
- * UV orientation: DataArrayTextures are bottom-up in WebGL, so we flip V
- * to match the same convention as the legacy ShaderMaterial shaders.
- */
-const FRAG_MAP_CHUNK = /* glsl */ `
-{
-    // GAME_BOX_TEXTURE_BLEND_MARKER: artwork color is sourced from texture arrays here.
-    vec2 flippedUv = vec2( vMapUv.x, 1.0 - vMapUv.y );
-
-    bool useHigh = ( vHighTextureSlot >= 0.0 ) && ( vLodLevel < 0.5 );
-
-    vec4 sampledColor;
-    if ( useHigh ) {
-        sampledColor = texture( textureArrayHigh, vec3( flippedUv, vHighTextureSlot ) );
-    } else {
-        sampledColor = texture( textureArrayMid, vec3( flippedUv, vTextureIndex ) );
-    }
-
-    // Apply fresnel edge lift for silhouette readability.
-    // Fresnel factor was computed in vertex shader. At grazing angles, lift the color
-    // slightly to help boxes read at oblique camera positions.
-    sampledColor.rgb = mix( sampledColor.rgb, sampledColor.rgb * (1.0 + artworkFresnelLift), vFresnelFactor );
-
-    // Honour existing map tint (mapTexelToLinear handles color-space).
-    diffuseColor *= sampledColor;
-}
-`
+export type LitArtworkTuningParams = Partial<GlossTuningParams & FresnelTuningParams>
 
 export function createLitArtworkMaterial(options: LitArtworkMaterialOptions): THREE.MeshStandardMaterial {
     const whiteMap = new THREE.DataTexture(
@@ -192,33 +146,43 @@ export function createLitArtworkMaterial(options: LitArtworkMaterialOptions): TH
         }
 
         // Vertex: inject varyings + per-instance attribute reads + fresnel computation.
-        shader.vertexShader = shader.vertexShader.replace(
-            '#include <common>',
-            '#include <common>\n' + VERT_DECLARATIONS
+        shader.vertexShader = replaceRequiredShaderChunk(
+            shader.vertexShader,
+            SHADER_ANCHORS.common,
+            SHADER_ANCHORS.common + '\n' + vertDeclarations,
+            'vertex'
         )
-        shader.vertexShader = shader.vertexShader.replace(
-            '#include <begin_vertex>',
-            '#include <begin_vertex>\n' + VERT_IMPL
+        shader.vertexShader = replaceRequiredShaderChunk(
+            shader.vertexShader,
+            SHADER_ANCHORS.beginVertex,
+            SHADER_ANCHORS.beginVertex + '\n' + vertImpl,
+            'vertex'
         )
 
         // Fragment: inject uniform/varying declarations.
-        shader.fragmentShader = shader.fragmentShader.replace(
-            '#include <common>',
-            '#include <common>\n' + FRAG_DECLARATIONS
+        shader.fragmentShader = replaceRequiredShaderChunk(
+            shader.fragmentShader,
+            SHADER_ANCHORS.common,
+            SHADER_ANCHORS.common + '\n' + fragDeclarations,
+            'fragment'
         )
 
         // Fragment: replace the standard map_fragment chunk so we sample the
         // texture array instead of a plain map uniform, and apply fresnel.
-        shader.fragmentShader = shader.fragmentShader.replace(
-            '#include <map_fragment>',
-            FRAG_MAP_CHUNK
+        shader.fragmentShader = replaceRequiredShaderChunk(
+            shader.fragmentShader,
+            SHADER_ANCHORS.mapFragment,
+            fragMap,
+            'fragment'
         )
 
         // Fragment: inject per-instance roughness variation after roughness map processing.
         // This allows each instance to have subtle variation without popping.
-        shader.fragmentShader = shader.fragmentShader.replace(
-            '#include <roughnessmap_fragment>',
-            '#include <roughnessmap_fragment>\n' + FRAG_ROUGHNESS_VARIATION_CHUNK
+        shader.fragmentShader = replaceRequiredShaderChunk(
+            shader.fragmentShader,
+            SHADER_ANCHORS.roughnessMapFragment,
+            SHADER_ANCHORS.roughnessMapFragment + '\n' + fragRoughnessVariation,
+            'fragment'
         )
     }
 
@@ -271,6 +235,21 @@ export function tuneLitArtworkFresnel(
     if (uniforms?.artworkFresnelPower) {
         uniforms.artworkFresnelPower.value = fresnelPower
     }
+}
+
+export function applyLitArtworkTuning(
+    material: THREE.MeshStandardMaterial,
+    params?: LitArtworkTuningParams
+): void {
+    tuneLitArtworkGloss(material, {
+        roughness: params?.roughness,
+        metalness: params?.metalness,
+    })
+    tuneLitArtworkFresnel(material, {
+        fresnelLift: params?.fresnelLift,
+        fresnelPower: params?.fresnelPower,
+    })
+    material.needsUpdate = true
 }
 
 /**

--- a/client/src/scene/game-box/instancing/LodGameArtworkRenderer.ts
+++ b/client/src/scene/game-box/instancing/LodGameArtworkRenderer.ts
@@ -16,8 +16,11 @@
  */
 
 import * as THREE from 'three'
+import { AppSettings } from '../../../core/AppSettings'
+import { EventManager } from '../../../core/EventManager'
 import { RenderLoopRegistry } from '../../RenderLoopRegistry'
 import { SceneLayer } from '../../SceneLayers'
+import { ArtworkEventTypes, type ArtworkTuningChangedEvent } from '../../../types/LightingEvents'
 import { Logger } from '../../../utils/Logger'
 import { HighTextureCache, type HighTextureCacheConfig } from './HighTextureCache'
 import { SpatialPrewarmingManager, type PrewarmingConfig } from './SpatialPrewarmingManager'
@@ -116,6 +119,9 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
     
     // Render loop registration
     private isRegisteredForRenderLoop: boolean = false
+    private readonly eventManager: EventManager
+    private readonly appSettings: AppSettings
+    private readonly artworkTuningChangedHandler: (event: CustomEvent<ArtworkTuningChangedEvent>) => void
     
     private readonly config: Required<Omit<LodGameArtworkRendererConfig, 'highTextureCacheConfig' | 'prewarmingConfig'>> & 
                              Pick<LodGameArtworkRendererConfig, 'highTextureCacheConfig' | 'prewarmingConfig'>
@@ -124,6 +130,9 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
 
     constructor(config: LodGameArtworkRendererConfig) {
         super(config.maxInstances)
+        this.eventManager = EventManager.getInstance()
+        this.appSettings = AppSettings.getInstance()
+        this.artworkTuningChangedHandler = this.onArtworkTuningChanged.bind(this)
         this.lazyHighTextures = config.lazyHighTextures ?? false
         this.config = {
             maxInstances: config.maxInstances,
@@ -186,10 +195,20 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
 
 
         this.material = createLitArtworkMaterial({ highTexture, midTexture })
-        
-        // Tune the material for artwork vibrancy and silhouette readability.
-        tuneLitArtworkGloss(this.material, { roughness: 0.35, metalness: 0.05 })
-        tuneLitArtworkFresnel(this.material, { fresnelLift: 0.15, fresnelPower: 4.0 })
+
+        tuneLitArtworkGloss(this.material, {
+            roughness: this.appSettings.getSetting('artworkRoughness'),
+            metalness: this.appSettings.getSetting('artworkMetalness')
+        })
+        tuneLitArtworkFresnel(this.material, {
+            fresnelLift: this.appSettings.getSetting('artworkFresnelLift'),
+            fresnelPower: this.appSettings.getSetting('artworkFresnelPower')
+        })
+
+        this.eventManager.registerEventHandler<ArtworkTuningChangedEvent>(
+            ArtworkEventTypes.TuningChanged,
+            this.artworkTuningChangedHandler
+        )
         
         // Create geometry
         this.geometry = new THREE.BoxGeometry(
@@ -515,6 +534,11 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
         this.instancedMesh?.removeFromParent()
         this.geometry?.dispose()
         this.material?.dispose()
+
+        this.eventManager.deregisterEventHandler<ArtworkTuningChangedEvent>(
+            ArtworkEventTypes.TuningChanged,
+            this.artworkTuningChangedHandler
+        )
         
         // Dispose HIGH texture management
         this.spatialPrewarming?.dispose()
@@ -530,5 +554,19 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
         this.highTextureSlots = null
         
         LodGameArtworkRenderer.logger.lifecycle('Disposed')
+    }
+
+    private onArtworkTuningChanged(event: CustomEvent<ArtworkTuningChangedEvent>): void {
+        if (!this.material) return
+
+        tuneLitArtworkGloss(this.material, {
+            roughness: event.detail.roughness,
+            metalness: event.detail.metalness,
+        })
+        tuneLitArtworkFresnel(this.material, {
+            fresnelLift: event.detail.fresnelLift,
+            fresnelPower: event.detail.fresnelPower,
+        })
+        this.material.needsUpdate = true
     }
 }

--- a/client/src/scene/game-box/instancing/LodGameArtworkRenderer.ts
+++ b/client/src/scene/game-box/instancing/LodGameArtworkRenderer.ts
@@ -16,17 +16,21 @@
  */
 
 import * as THREE from 'three'
-import { AppSettings } from '../../../core/AppSettings'
+import { AppSettings, Setting, type SettingChangedEvent } from '../../../core/AppSettings'
 import { EventManager } from '../../../core/EventManager'
+import { AppSettingsEventTypes } from '../../../types/InteractionEvents'
 import { RenderLoopRegistry } from '../../RenderLoopRegistry'
 import { SceneLayer } from '../../SceneLayers'
-import { ArtworkEventTypes, type ArtworkTuningChangedEvent } from '../../../types/LightingEvents'
 import { Logger } from '../../../utils/Logger'
 import { HighTextureCache, type HighTextureCacheConfig } from './HighTextureCache'
 import { SpatialPrewarmingManager, type PrewarmingConfig } from './SpatialPrewarmingManager'
 import { PlacementRunResettableInstancedBase } from './PlacementRunResettableInstancedBase'
 import type { RendererTextureSources } from './LodTypes'
-import { createLitArtworkMaterial, tuneLitArtworkGloss, tuneLitArtworkFresnel } from './LitArtworkMaterial'
+import {
+    applyLitArtworkTuning,
+    createLitArtworkMaterial,
+    isLitArtworkMaterialSettingKey,
+} from './LitArtworkMaterial'
 
 // Class-scoped logger will be attached to the class
 
@@ -121,7 +125,7 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
     private isRegisteredForRenderLoop: boolean = false
     private readonly eventManager: EventManager
     private readonly appSettings: AppSettings
-    private readonly artworkTuningChangedHandler: (event: CustomEvent<ArtworkTuningChangedEvent>) => void
+    private readonly appSettingsChangedHandler: (event: CustomEvent<SettingChangedEvent>) => void
     
     private readonly config: Required<Omit<LodGameArtworkRendererConfig, 'highTextureCacheConfig' | 'prewarmingConfig'>> & 
                              Pick<LodGameArtworkRendererConfig, 'highTextureCacheConfig' | 'prewarmingConfig'>
@@ -132,7 +136,7 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
         super(config.maxInstances)
         this.eventManager = EventManager.getInstance()
         this.appSettings = AppSettings.getInstance()
-        this.artworkTuningChangedHandler = this.onArtworkTuningChanged.bind(this)
+        this.appSettingsChangedHandler = this.onAppSettingsChanged.bind(this)
         this.lazyHighTextures = config.lazyHighTextures ?? false
         this.config = {
             maxInstances: config.maxInstances,
@@ -196,18 +200,11 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
 
         this.material = createLitArtworkMaterial({ highTexture, midTexture })
 
-        tuneLitArtworkGloss(this.material, {
-            roughness: this.appSettings.getSetting('artworkRoughness'),
-            metalness: this.appSettings.getSetting('artworkMetalness')
-        })
-        tuneLitArtworkFresnel(this.material, {
-            fresnelLift: this.appSettings.getSetting('artworkFresnelLift'),
-            fresnelPower: this.appSettings.getSetting('artworkFresnelPower')
-        })
+        this.applyArtworkMaterialTuningFromSettings()
 
-        this.eventManager.registerEventHandler<ArtworkTuningChangedEvent>(
-            ArtworkEventTypes.TuningChanged,
-            this.artworkTuningChangedHandler
+        this.eventManager.registerEventHandler<SettingChangedEvent>(
+            AppSettingsEventTypes.Changed,
+            this.appSettingsChangedHandler
         )
         
         // Create geometry
@@ -535,9 +532,9 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
         this.geometry?.dispose()
         this.material?.dispose()
 
-        this.eventManager.deregisterEventHandler<ArtworkTuningChangedEvent>(
-            ArtworkEventTypes.TuningChanged,
-            this.artworkTuningChangedHandler
+        this.eventManager.deregisterEventHandler<SettingChangedEvent>(
+            AppSettingsEventTypes.Changed,
+            this.appSettingsChangedHandler
         )
         
         // Dispose HIGH texture management
@@ -556,17 +553,22 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
         LodGameArtworkRenderer.logger.lifecycle('Disposed')
     }
 
-    private onArtworkTuningChanged(event: CustomEvent<ArtworkTuningChangedEvent>): void {
+    private applyArtworkMaterialTuningFromSettings(): void {
         if (!this.material) return
 
-        tuneLitArtworkGloss(this.material, {
-            roughness: event.detail.roughness,
-            metalness: event.detail.metalness,
+        applyLitArtworkTuning(this.material, {
+            roughness: this.appSettings.getSetting(Setting.ArtworkRoughness),
+            metalness: this.appSettings.getSetting(Setting.ArtworkMetalness),
+            fresnelLift: this.appSettings.getSetting(Setting.ArtworkFresnelLift),
+            fresnelPower: this.appSettings.getSetting(Setting.ArtworkFresnelPower),
         })
-        tuneLitArtworkFresnel(this.material, {
-            fresnelLift: event.detail.fresnelLift,
-            fresnelPower: event.detail.fresnelPower,
-        })
-        this.material.needsUpdate = true
+    }
+
+    private onAppSettingsChanged(event: CustomEvent<SettingChangedEvent>): void {
+        if (!isLitArtworkMaterialSettingKey(event.detail.settingName)) {
+            return
+        }
+
+        this.applyArtworkMaterialTuningFromSettings()
     }
 }

--- a/client/src/scene/game-box/instancing/LodGameArtworkRenderer.ts
+++ b/client/src/scene/game-box/instancing/LodGameArtworkRenderer.ts
@@ -200,7 +200,7 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
 
         this.material = createLitArtworkMaterial({ highTexture, midTexture })
 
-        this.applyArtworkMaterialTuningFromSettings()
+        this.onAppSettingsChanged()
 
         this.eventManager.registerEventHandler<SettingChangedEvent>(
             AppSettingsEventTypes.Changed,
@@ -553,7 +553,10 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
         LodGameArtworkRenderer.logger.lifecycle('Disposed')
     }
 
-    private applyArtworkMaterialTuningFromSettings(): void {
+    private onAppSettingsChanged(event?: CustomEvent<SettingChangedEvent>): void {
+        if (event && !isLitArtworkMaterialSettingKey(event.detail.settingName)) {
+            return
+        }
         if (!this.material) return
 
         applyLitArtworkTuning(this.material, {
@@ -562,13 +565,5 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
             fresnelLift: this.appSettings.getSetting(Setting.ArtworkFresnelLift),
             fresnelPower: this.appSettings.getSetting(Setting.ArtworkFresnelPower),
         })
-    }
-
-    private onAppSettingsChanged(event: CustomEvent<SettingChangedEvent>): void {
-        if (!isLitArtworkMaterialSettingKey(event.detail.settingName)) {
-            return
-        }
-
-        this.applyArtworkMaterialTuningFromSettings()
     }
 }

--- a/client/src/scene/game-box/instancing/LodGameArtworkRenderer.ts
+++ b/client/src/scene/game-box/instancing/LodGameArtworkRenderer.ts
@@ -23,7 +23,7 @@ import { HighTextureCache, type HighTextureCacheConfig } from './HighTextureCach
 import { SpatialPrewarmingManager, type PrewarmingConfig } from './SpatialPrewarmingManager'
 import { PlacementRunResettableInstancedBase } from './PlacementRunResettableInstancedBase'
 import type { RendererTextureSources } from './LodTypes'
-import { createLitArtworkMaterial } from './LitArtworkMaterial'
+import { createLitArtworkMaterial, tuneLitArtworkGloss, tuneLitArtworkFresnel } from './LitArtworkMaterial'
 
 // Class-scoped logger will be attached to the class
 
@@ -186,6 +186,10 @@ export class LodGameArtworkRenderer extends PlacementRunResettableInstancedBase 
 
 
         this.material = createLitArtworkMaterial({ highTexture, midTexture })
+        
+        // Tune the material for artwork vibrancy and silhouette readability.
+        tuneLitArtworkGloss(this.material, { roughness: 0.35, metalness: 0.05 })
+        tuneLitArtworkFresnel(this.material, { fresnelLift: 0.15, fresnelPower: 4.0 })
         
         // Create geometry
         this.geometry = new THREE.BoxGeometry(

--- a/client/src/scene/game-box/instancing/shaders/lit-artwork.frag.declarations.glsl
+++ b/client/src/scene/game-box/instancing/shaders/lit-artwork.frag.declarations.glsl
@@ -1,0 +1,9 @@
+uniform sampler2DArray textureArrayHigh;
+uniform sampler2DArray textureArrayMid;
+uniform float artworkFresnelLift;
+
+varying float vTextureIndex;
+varying float vLodLevel;
+varying float vHighTextureSlot;
+varying float vFresnelFactor;
+varying float vRoughnessVariation;

--- a/client/src/scene/game-box/instancing/shaders/lit-artwork.frag.map.glsl
+++ b/client/src/scene/game-box/instancing/shaders/lit-artwork.frag.map.glsl
@@ -1,0 +1,21 @@
+{
+    // GAME_BOX_TEXTURE_BLEND_MARKER: artwork color is sourced from texture arrays here.
+    vec2 flippedUv = vec2( vMapUv.x, 1.0 - vMapUv.y );
+
+    bool useHigh = ( vHighTextureSlot >= 0.0 ) && ( vLodLevel < 0.5 );
+
+    vec4 sampledColor;
+    if ( useHigh ) {
+        sampledColor = texture( textureArrayHigh, vec3( flippedUv, vHighTextureSlot ) );
+    } else {
+        sampledColor = texture( textureArrayMid, vec3( flippedUv, vTextureIndex ) );
+    }
+
+    // Apply fresnel edge lift for silhouette readability.
+    // Fresnel factor was computed in vertex shader. At grazing angles, lift the color
+    // slightly to help boxes read at oblique camera positions.
+    sampledColor.rgb = mix( sampledColor.rgb, sampledColor.rgb * (1.0 + artworkFresnelLift), vFresnelFactor );
+
+    // Honour existing map tint (mapTexelToLinear handles color-space).
+    diffuseColor *= sampledColor;
+}

--- a/client/src/scene/game-box/instancing/shaders/lit-artwork.frag.roughness-variation.glsl
+++ b/client/src/scene/game-box/instancing/shaders/lit-artwork.frag.roughness-variation.glsl
@@ -1,0 +1,7 @@
+{
+    // Apply per-instance roughness variation to break clone appearance.
+    // Variation [0, 1] is mapped to offset [-0.05, +0.05] around base 0.35.
+    // Clamped to [0.2, 0.6] to stay within valid specular response range.
+    float roughnessOffset = (vRoughnessVariation - 0.5) * 2.0 * 0.05;
+    roughnessFactor = clamp( roughnessFactor + roughnessOffset, 0.2, 0.6 );
+}

--- a/client/src/scene/game-box/instancing/shaders/lit-artwork.vert.declarations.glsl
+++ b/client/src/scene/game-box/instancing/shaders/lit-artwork.vert.declarations.glsl
@@ -1,0 +1,11 @@
+attribute float textureIndex;
+attribute float lodLevel;
+attribute float highTextureSlot;
+
+varying float vTextureIndex;
+varying float vLodLevel;
+varying float vHighTextureSlot;
+varying float vFresnelFactor;
+varying float vRoughnessVariation;
+
+uniform float artworkFresnelPower;

--- a/client/src/scene/game-box/instancing/shaders/lit-artwork.vert.impl.glsl
+++ b/client/src/scene/game-box/instancing/shaders/lit-artwork.vert.impl.glsl
@@ -1,0 +1,15 @@
+vTextureIndex    = textureIndex;
+vLodLevel        = lodLevel;
+vHighTextureSlot = highTextureSlot;
+
+// Compute fresnel factor in vertex shader where we have access to normal.
+// vViewPosition is available and points from vertex toward camera.
+// We compute (1 - |V dot N|) and raise to power; at grazing angles this approaches 1.
+vec3 viewDir = normalize( vViewPosition );
+float NdotV = max( 0.0, dot( normal, viewDir ) );
+vFresnelFactor = pow( 1.0 - NdotV, artworkFresnelPower );
+
+// Compute per-instance roughness variation from textureIndex.
+// Uses a simple hash to produce deterministic variation [0, 1] per instance.
+float x = sin( textureIndex * 12.9898 ) * 43758.5453;
+vRoughnessVariation = x - floor( x );

--- a/client/src/styles/main.css
+++ b/client/src/styles/main.css
@@ -28,8 +28,8 @@
     --error-color: #dc3545;
     
     /* Shared UI layout rails */
-    --ui-edge-gap: 10px;
-    --ui-top-inset: 20px;
+    --ui-edge-gap: 8px;
+    --ui-top-inset: 6px;
     --ui-control-size: 50px;
     --ui-stack-gap: 12px;
     --ui-wing-rail: 110px;

--- a/client/src/types/LightingEvents.ts
+++ b/client/src/types/LightingEvents.ts
@@ -52,16 +52,6 @@ export interface LightingSystemReadyEvent extends BaseInteractionEvent {
     quality: string
 }
 
-export const LightingEventTypes = {
-    Toggle: 'lighting:toggle',
-    DebugToggle: 'lighting:debug-toggle',
-    QualityChanged: 'lighting:quality-changed',
-    Created: 'lighting:created',
-    SystemReady: 'lighting:system-ready',
-    /** Request a point light be created by the lighting system (avoids direct scene add) */
-    PointLightRequested: 'lighting:point-light-requested',
-} as const
-
 export interface ArtworkTuningChangedEvent extends BaseInteractionEvent {
     roughness?: number
     metalness?: number
@@ -73,6 +63,16 @@ export interface ShadowContactTuningChangedEvent extends BaseInteractionEvent {
     bias?: number
     normalBias?: number
 }
+
+export const LightingEventTypes = {
+    Toggle: 'lighting:toggle',
+    DebugToggle: 'lighting:debug-toggle',
+    QualityChanged: 'lighting:quality-changed',
+    Created: 'lighting:created',
+    SystemReady: 'lighting:system-ready',
+    /** Request a point light be created by the lighting system (avoids direct scene add) */
+    PointLightRequested: 'lighting:point-light-requested',
+} as const
 
 export const ArtworkEventTypes = {
     TuningChanged: 'artwork:tuning-changed',

--- a/client/src/types/LightingEvents.ts
+++ b/client/src/types/LightingEvents.ts
@@ -52,18 +52,6 @@ export interface LightingSystemReadyEvent extends BaseInteractionEvent {
     quality: string
 }
 
-export interface ArtworkTuningChangedEvent extends BaseInteractionEvent {
-    roughness?: number
-    metalness?: number
-    fresnelLift?: number
-    fresnelPower?: number
-}
-
-export interface ShadowContactTuningChangedEvent extends BaseInteractionEvent {
-    bias?: number
-    normalBias?: number
-}
-
 export const LightingEventTypes = {
     Toggle: 'lighting:toggle',
     DebugToggle: 'lighting:debug-toggle',

--- a/client/src/ui/pause/panels/DisplayAdvancedPanel.ts
+++ b/client/src/ui/pause/panels/DisplayAdvancedPanel.ts
@@ -14,7 +14,7 @@ import '../../../styles/pause-menu/settings-components.css'
 import { AppSettings, Setting } from '../../../core/AppSettings'
 import { EventManager } from '../../../core/EventManager'
 import { UIComponentUtils } from '../../../utils/UIComponentUtils'
-import { ArtworkEventTypes, type ArtworkTuningChangedEvent, type ShadowContactTuningChangedEvent } from '../../../types/LightingEvents'
+
 
 const DEFAULTS = {
     artworkRoughness: 0.35,
@@ -65,7 +65,6 @@ export class DisplayAdvancedPanel extends PauseMenuPanel {
                 formatDisplay: (v) => v.toFixed(2),
                 onInput: (value) => {
                     this.appSettings.setSetting(Setting.ArtworkRoughness, value)
-                    eventManager.emit<ArtworkTuningChangedEvent>(ArtworkEventTypes.TuningChanged, { roughness: value })
                 }
             },
             {
@@ -74,7 +73,6 @@ export class DisplayAdvancedPanel extends PauseMenuPanel {
                 formatDisplay: (v) => v.toFixed(2),
                 onInput: (value) => {
                     this.appSettings.setSetting(Setting.ArtworkMetalness, value)
-                    eventManager.emit<ArtworkTuningChangedEvent>(ArtworkEventTypes.TuningChanged, { metalness: value })
                 }
             },
             {
@@ -83,7 +81,6 @@ export class DisplayAdvancedPanel extends PauseMenuPanel {
                 formatDisplay: (v) => v.toFixed(2),
                 onInput: (value) => {
                     this.appSettings.setSetting(Setting.ArtworkFresnelLift, value)
-                    eventManager.emit<ArtworkTuningChangedEvent>(ArtworkEventTypes.TuningChanged, { fresnelLift: value })
                 }
             },
             {
@@ -92,7 +89,6 @@ export class DisplayAdvancedPanel extends PauseMenuPanel {
                 formatDisplay: (v) => v.toFixed(1),
                 onInput: (value) => {
                     this.appSettings.setSetting(Setting.ArtworkFresnelPower, value)
-                    eventManager.emit<ArtworkTuningChangedEvent>(ArtworkEventTypes.TuningChanged, { fresnelPower: value })
                 }
             },
             {
@@ -101,7 +97,6 @@ export class DisplayAdvancedPanel extends PauseMenuPanel {
                 formatDisplay: (v) => v.toFixed(4),
                 onInput: (value) => {
                     this.appSettings.setSetting(Setting.ShadowContactBias, value)
-                    eventManager.emit<ShadowContactTuningChangedEvent>(ArtworkEventTypes.ShadowContactTuningChanged, { bias: value })
                 }
             },
             {
@@ -110,7 +105,6 @@ export class DisplayAdvancedPanel extends PauseMenuPanel {
                 formatDisplay: (v) => v.toFixed(3),
                 onInput: (value) => {
                     this.appSettings.setSetting(Setting.ShadowContactNormalBias, value)
-                    eventManager.emit<ShadowContactTuningChangedEvent>(ArtworkEventTypes.ShadowContactTuningChanged, { normalBias: value })
                 }
             },
         ])
@@ -133,17 +127,6 @@ export class DisplayAdvancedPanel extends PauseMenuPanel {
         this.appSettings.setSetting(Setting.ArtworkFresnelPower, DEFAULTS.artworkFresnelPower)
         this.appSettings.setSetting(Setting.ShadowContactBias, DEFAULTS.shadowContactBias)
         this.appSettings.setSetting(Setting.ShadowContactNormalBias, DEFAULTS.shadowContactNormalBias)
-
-        eventManager.emit<ArtworkTuningChangedEvent>(ArtworkEventTypes.TuningChanged, {
-            roughness: DEFAULTS.artworkRoughness,
-            metalness: DEFAULTS.artworkMetalness,
-            fresnelLift: DEFAULTS.artworkFresnelLift,
-            fresnelPower: DEFAULTS.artworkFresnelPower,
-        })
-        eventManager.emit<ShadowContactTuningChangedEvent>(ArtworkEventTypes.ShadowContactTuningChanged, {
-            bias: DEFAULTS.shadowContactBias,
-            normalBias: DEFAULTS.shadowContactNormalBias,
-        })
 
         // Re-render to sync sliders to reset values
         const container = document.getElementById(this.config.containerId ?? 'pause-menu-content')

--- a/docs/acts/act2-ready-for-friends.md
+++ b/docs/acts/act2-ready-for-friends.md
@@ -39,9 +39,10 @@
 - [Layout Variations](../features/layout-variations.md) — arc exists; square rows + dynamic switching are the open work; grouping is Encore; include layout-owned entrance mat placement for spoke and stage mat/carpet convergence as a mid-Act 2 follow-up, and treat angled-layout center-aisle overlap cleanup (`arc`/`spoke`) as medium priority without a fixed timebox
 - [Game Detail Screen](../features/game-detail-screen.md) — design pass tied to VR; do once with VR in mind rather than twice
 - [Room Variants](../features/room-variants.md) — room structure cleanup first, then variant system; Cozy Basement is the target variant
-- [Lighting and Atmosphere](../features/lighting-and-atmosphere.md) — tone presets (corporate → dank), dongle switch panel; core lighting is done, and recent passes improved game-box shadow response + artwork vibrancy; remaining work is the experiential layer
+- [Lighting and Atmosphere](../features/lighting-and-atmosphere.md) — tone presets (corporate → dank), dongle switch panel; core lighting is done, this is the experiential layer
 - [Procedural Texture Quality Pass](../features/procedural-texture-quality.md) — MDF veneer, popcorn ceiling, wood plank walls, carpet; carried from Act 1
 - [UI Standardization](../features/ui-standardization.md) — in-scene omnibar, 3D sign elements, component tokens (started in intermission, may extend into Act 2)
+- [Game Box Construction Chain](../features/game-box-construction-chain.md) — typed dependency chain replacing ad-hoc monolithic rebuilds in `LodGameArtworkRenderer`; each pipeline stage is an event with declared prerequisites; enables re-entry at any stage, clean failure signaling, and future taps (LOD streaming, preloading, perf logging); WIP plan, not yet started
 - Enhanced error handling — robust recovery for rate limits, invalid Steam IDs, timeouts, partial failures
 - Infrastructure monitoring — CloudWatch metrics, client telemetry, cache performance dashboards
 - ~~Test network isolation~~ — automatic blocking of external calls in tests is **done** (implemented via global fetch intercept in unit/integration test setup)

--- a/docs/acts/act2-ready-for-friends.md
+++ b/docs/acts/act2-ready-for-friends.md
@@ -39,7 +39,7 @@
 - [Layout Variations](../features/layout-variations.md) — arc exists; square rows + dynamic switching are the open work; grouping is Encore; include layout-owned entrance mat placement for spoke and stage mat/carpet convergence as a mid-Act 2 follow-up, and treat angled-layout center-aisle overlap cleanup (`arc`/`spoke`) as medium priority without a fixed timebox
 - [Game Detail Screen](../features/game-detail-screen.md) — design pass tied to VR; do once with VR in mind rather than twice
 - [Room Variants](../features/room-variants.md) — room structure cleanup first, then variant system; Cozy Basement is the target variant
-- [Lighting and Atmosphere](../features/lighting-and-atmosphere.md) — tone presets (corporate → dank), dongle switch panel; core lighting is done, this is the experiential layer
+- [Lighting and Atmosphere](../features/lighting-and-atmosphere.md) — tone presets (corporate → dank), dongle switch panel; core lighting is done, and recent passes improved game-box shadow response + artwork vibrancy; remaining work is the experiential layer
 - [Procedural Texture Quality Pass](../features/procedural-texture-quality.md) — MDF veneer, popcorn ceiling, wood plank walls, carpet; carried from Act 1
 - [UI Standardization](../features/ui-standardization.md) — in-scene omnibar, 3D sign elements, component tokens (started in intermission, may extend into Act 2)
 - Enhanced error handling — robust recovery for rate limits, invalid Steam IDs, timeouts, partial failures

--- a/docs/features/game-box-construction-chain.md
+++ b/docs/features/game-box-construction-chain.md
@@ -1,0 +1,166 @@
+# Feature: Game Box Construction Event Chain
+
+**Act**: 2 (Also In Act 2 — Best Effort)  
+**Status**: WIP Plan — not yet started  
+**Priority**: Medium (quality / architecture; enables cleaner lifecycle taps for VR, LOD, streaming)
+
+---
+
+## Goal
+
+Replace the current ad-hoc "rebuild everything" calls in game box construction with a typed dependency chain driven by events. Each stage declares what it requires before it can proceed. The chain is the orchestration layer — classes don't call each other directly; they emit readiness and listen for prerequisites.
+
+---
+
+## Motivation
+
+Currently `LodGameArtworkRenderer` (and adjacent coordinators) contain monolithic rebuild methods that run all stages in sequence imperatively. This makes it hard to:
+
+- Re-enter the pipeline at a specific stage (e.g. texture resolved, skip material prep)
+- Tap into a stage for debugging, testing, or future subsystems (LOD streaming, preloading)
+- Know *why* a stage didn't run (silent skip vs. actual failure)
+- Control ordering across class boundaries without tight coupling
+
+The event chain addresses all of these by making stage boundaries explicit and observable.
+
+---
+
+## Core Concept: Dependency-Declared Chain Stages
+
+Each stage in the chain is an event. A stage handler subscribes to its **trigger event**, asserts its **prerequisites**, does its narrow work, then emits the **next event**. If prerequisites are not met, it emits a `*Failed` variant instead of silently returning.
+
+```
+[Trigger enters chain]
+        │
+        ▼
+ ArtworkRenderRequested       ← entry point; carries scope (gameId | 'all')
+        │
+        ▼
+ ArtworkMaterialPrepared      ← material params resolved from AppSettings + game data
+        │
+        ▼
+ ArtworkTextureResolved       ← texture array slot confirmed / uploaded to GPU
+        │
+        ▼
+ ArtworkInstanceUpdated       ← GPU buffer written for this game box instance
+        │
+        ▼
+ ArtworkRenderComplete        ← frame signal; cleanup hook; downstream taps (debug overlay, perf logging)
+```
+
+Each event carries:
+```typescript
+interface ChainStageEvent {
+    chainId: string          // unique ID for this chain run (for correlation)
+    scope: GameBoxScope      // { gameId: string } | { all: true }
+    triggeredBy: string      // name of the upstream event that initiated the chain
+    stageStartedAt: number   // performance.now() at stage entry
+}
+```
+
+---
+
+## Failure / Break Signaling
+
+If a stage cannot complete, it emits `ArtworkChainFailed`:
+
+```typescript
+interface ArtworkChainFailedEvent {
+    chainId: string
+    failedStage: string      // name of the stage event that broke
+    reason: string
+    scope: GameBoxScope
+    recoverable: boolean     // true = retry candidate; false = permanent for this scope
+}
+```
+
+A `ChainMonitor` class (or inline in a debug utility) subscribes to `ArtworkChainFailed` and logs/surfaces broken chains. In production, `recoverable: true` chains can be queued for retry.
+
+---
+
+## Prerequisite Declaration
+
+Each stage handler optionally declares prerequisites — other events that must have fired (for the same `chainId` or globally) before this handler proceeds:
+
+```typescript
+// Pseudocode — actual mechanism TBD (could be a simple registry or just inline guards)
+ChainStageRegistry.register({
+    trigger: ArtworkEventTypes.TextureResolved,
+    requires: [ArtworkEventTypes.MaterialPrepared],
+    handler: onTextureResolved,
+})
+```
+
+If a required prior stage hasn't fired, the handler emits `ArtworkChainFailed` with `reason: 'prerequisite not met'` rather than no-opping silently.
+
+This is the mechanism that lets us "define the chain by dependencies" — future stages can declare requirements on events from *other* chains (e.g. `LightingSystemReadyEvent`) without those chains knowing about the artwork pipeline.
+
+---
+
+## Entry Points
+
+Different triggers enter the chain at the appropriate stage:
+
+| Trigger | Entry Stage |
+|---|---|
+| Artwork tuning slider changed | `ArtworkRenderRequested` |
+| Game data loaded for a new title | `ArtworkRenderRequested` |
+| Texture cache miss resolved | `ArtworkTextureResolved` |
+| Shadow / lighting quality changed | `ArtworkInstanceUpdated` |
+| VR render mode switch | `ArtworkInstanceUpdated` |
+| Full scene reset | `ArtworkRenderRequested` (scope: all) |
+
+---
+
+## Cleanup / Resource Handoff
+
+The `ArtworkMaterialPrepared` handler is responsible for marking previous resources as stale or reusable. Whether to reuse a texture slot or replace it is decided here — not spread across callers. This keeps "update in place vs. replace" contained to one boundary.
+
+---
+
+## Affected Classes (Migration Scope)
+
+- **`LodGameArtworkRenderer`**: currently owns all stages internally; migrates to owning `ArtworkRenderRequested` → `ArtworkMaterialPrepared` + `ArtworkTextureResolved` → `ArtworkInstanceUpdated`
+- **`DisplayAdvancedPanel`**: emits `ArtworkRenderRequested` (already partially wired via `MaterialRefreshRequested`; this generalizes it)
+- **`SceneCoordinator`** (or equivalent startup orchestrator): emits `ArtworkRenderRequested` on initial game data ready
+- **`LightingRenderer`**: emits `ArtworkInstanceUpdated` for shadow-only changes (enters chain late, skips material/texture stages)
+- **`ArtworkChainMonitor`** (new, small): subscribes to `ArtworkChainFailed`, surfaces breaks; also useful for perf timing across stages
+
+---
+
+## What to Do With Current Events
+
+The three events added in `feature/tsl-artwork-material` (`TuningChanged`, `ShadowContactTuningChanged`, `MaterialRefreshRequested`) become entry aliases or are removed:
+
+- `MaterialRefreshRequested` → rename/replace with `ArtworkRenderRequested`
+- `TuningChanged`, `ShadowContactTuningChanged` → remove once chain handles those entry points
+- Shadow-contact path enters chain at `ArtworkInstanceUpdated` stage (no material/texture re-resolve needed)
+
+---
+
+## Stories / Tasks
+
+- [ ] Define `ChainStageEvent` base interface and `ArtworkChainFailedEvent` in `LightingEvents.ts` (or a new `ArtworkChainEvents.ts`)
+- [ ] Define the full stage event set: `ArtworkRenderRequested`, `ArtworkMaterialPrepared`, `ArtworkTextureResolved`, `ArtworkInstanceUpdated`, `ArtworkRenderComplete`
+- [ ] Migrate `LodGameArtworkRenderer` internal rebuild sequence into stage handlers; emit stage events between them
+- [ ] Wire `DisplayAdvancedPanel` to emit `ArtworkRenderRequested` (replaces `MaterialRefreshRequested`)
+- [ ] Wire `SceneCoordinator` initial construction through `ArtworkRenderRequested`
+- [ ] Implement prerequisite guard mechanism (simple inline version first; registry refactor later if needed)
+- [ ] Add `ArtworkChainMonitor` for debug-mode chain failure surfacing
+- [ ] Update tests: each stage handler testable in isolation via emitted events
+
+## Open Questions
+
+- Should `ChainStageEvent` be a generic base for *any* multi-stage pipeline, or artwork-specific?
+- Should the prerequisite registry be a runtime object or a static declaration at class init?
+- Is `ArtworkRenderComplete` worth subscribing to, or is it just a perf-tap?
+
+---
+
+## Acceptance Criteria
+
+- Re-entering the chain at `ArtworkInstanceUpdated` skips material/texture stages cleanly
+- A broken chain emits `ArtworkChainFailed` with enough info to diagnose in dev tools
+- `DisplayAdvancedPanel` emits only `ArtworkRenderRequested` — no stage-specific knowledge
+- All existing artwork tuning + shadow contact paths covered with no regression
+- Each stage handler has a unit test asserting it emits the correct next event on success and `ChainFailed` on failure

--- a/docs/features/lighting-and-atmosphere.md
+++ b/docs/features/lighting-and-atmosphere.md
@@ -45,3 +45,31 @@ There's also a longer-term design where lighting presets and room variants (base
 - Blacklight / UV atmosphere (glowing accents, dark ambient) is on the Encore list paired with the basement room variant; it's not in scope here but the preset architecture should make adding it easy.
 - Dust motes and animated spotlights were previously on the Encore list — graduating them here as stretch goals because the scope is reasonable (1-3 days each) and they're high-impact for atmosphere.
 - Related: archived source notes in `docs/archive/phase2-ready-for-friends.md` (Feature 8.5.0 / 8.5.1).
+
+## Progress Snapshot (2026-05)
+
+What has landed recently on the "make the store look better" path:
+- Instanced game artwork moved to a lit material strategy (`MeshStandardMaterial` with array-texture sampling patch) so boxes now participate in scene lighting and shadows more convincingly.
+- Retail lighting was retuned (ambient/directional/spot/rim plus ceiling fixture intensity), producing better shelf readability and stronger artwork contrast.
+- Texture-array color handling was corrected in the pipeline (array texture color-space tagging and decode-path adjustments) to reduce muted artwork output.
+- Lighting controls panel was upgraded to multiplier sliders, making brightness balancing easier and more predictable during visual tuning.
+
+Current decision boundaries:
+- TSL/NodeMaterial was evaluated and deferred for now because it implies a broader renderer migration scope than this feature needs.
+- Near-term visual improvements should continue on the current WebGL material path unless a renderer-wide migration is explicitly scheduled.
+
+What remains in this feature:
+- Tone presets and in-scene "dongle" controls.
+- Atmosphere effects (dust motes, subtle spotlight shimmer).
+- Optional additional art-direction tuning once preset architecture is in place.
+
+## Pre-Clutter Immersion Checkpoint
+
+Before investing in new clutter assets, prefer these technical immersion passes:
+1. Improve game-box gloss and edge readability.
+2. Tighten contact shadow grounding around shelves.
+3. Add subtle per-instance variation to reduce clone look.
+4. Add dust motes and subtle light animation for depth and presence.
+
+Actionable implementation notes and execution order are tracked in:
+- `docs/plans/game-artwork-box-shading-plan.md` (Pre-Clutter Technical Options section).

--- a/docs/plans/game-artwork-box-shading-plan.md
+++ b/docs/plans/game-artwork-box-shading-plan.md
@@ -137,6 +137,43 @@ These are scene-immersion improvements that do not require designing new clutter
    - Touch points: scene setup and material environment configuration paths.
    - Validation: highlight movement should track camera and light shifts naturally.
 
+### Derived Artwork Map Investigation
+
+This is a plausible next-step quality path if the current flat roughness envelope tops out visually.
+
+What to derive:
+- A low-frequency roughness mask from the artwork image, biased so dark ink-heavy regions stay slightly rougher and bright coated highlight regions can read a little smoother.
+- Optionally, a very conservative albedo modulation mask for broad wear/dust shaping only. Do not treat the box art itself as a height field; that usually produces fake embossed covers.
+
+Recommended implementation shape:
+- Keep derivation off the main thread by extending the existing artwork texture worker/pixel pipeline rather than generating maps in the render loop.
+- Derive maps from the same decoded source pixels already fetched for MID/HIGH artwork slices.
+- Quantize the derived output aggressively. A single-channel roughness mask is the best first candidate; avoid full RGB companion textures unless the visual win is proven.
+- Upload in clusters using the same frame-budget-aware scheduling approach already used for artwork texture array writes so worker completions do not stampede a single frame.
+
+Expected cost profile:
+- CPU/build cost: moderate startup or background processing cost, but mostly amortizable because pixel decode and image analysis can run in a worker.
+- Main-thread cost: still present when copying derived pixels into texture-array backing stores and triggering GPU upload. Worker offload does not eliminate upload cost.
+- VRAM cost: the main risk. A full extra MID and HIGH companion array for roughness would materially increase artwork memory usage.
+- Shader cost: relatively small if sampling one extra channel per fragment; much lower risk than the memory/upload side.
+
+Practical recommendation:
+- Start with derived roughness only, MID tier only, and cache the results.
+- Treat HIGH derived maps as optional follow-up once MID shows a clear visual benefit.
+- Avoid derived albedo in the first pass unless the goal is specifically a subtle print-fade or dust treatment; roughness is the safer realism lever.
+
+Suggested pipeline:
+1. Extend the artwork worker to emit an optional single-channel roughness buffer alongside the existing color pixels.
+2. Store the derived data in the same cache layer keyed by artwork URL plus derivation version.
+3. Add a compact roughness companion texture array for MID artwork first.
+4. Patch `LitArtworkMaterial` to sample the companion array and modulate `roughnessFactor` within narrow bounds.
+5. Gate uploads through the frame-budget scheduler and flush in small batches/clusters.
+6. Compare three cases: current scalar roughness, hash-based per-instance variation, and image-derived roughness.
+
+Go / no-go criteria:
+- Go if the visual gain is obvious in shelf-angle closeups and the extra upload path does not create noticeable frame dips during library population.
+- No-go if the improvement is only visible in stills, if VRAM growth is too high, or if HIGH texture churn becomes meaningfully worse.
+
 ### Tier 3: Atmosphere before clutter (1-3 days)
 1. Dust motes in lit cones.
    - Why: adds depth cues and "air" without adding geometry clutter.

--- a/docs/plans/game-artwork-box-shading-plan.md
+++ b/docs/plans/game-artwork-box-shading-plan.md
@@ -73,3 +73,85 @@ Enable believable lighting and shadow response for instanced game artwork boxes 
 ## Out of Scope
 - Full signage visual redesign.
 - Non-instanced fallback rendering architecture.
+
+## Implementation Outcome Snapshot (2026-05)
+
+The Phase 1/2 direction has effectively been exercised and integrated.
+
+What was achieved:
+- `LodGameArtworkRenderer` now uses a lit artwork material path built on `MeshStandardMaterial` with `onBeforeCompile` array-texture sampling.
+- Artwork boxes now receive scene lighting/shadow response in a way that is materially closer to other PBR scene assets.
+- Related visual support work landed alongside this path:
+   - lighting profile retune for retail readability
+   - texture-array color pipeline corrections
+   - better runtime lighting controls for balancing
+
+What this plan proved:
+- Option B (material strategy with standard lighting pipeline) is viable and currently the baseline path.
+- Full TSL/NodeMaterial migration is not a material-only drop-in for this app's current renderer stack and is deferred.
+
+Recommended next options from here:
+1. Harden current material patching with compile-time replacement checks/assertions.
+2. If maintainability becomes a pain point, evaluate a full custom lit `ShaderMaterial` while staying on `WebGLRenderer`.
+3. Treat TSL/WebGPU as a separate renderer-migration initiative, not an incremental shading tweak.
+
+## Pre-Clutter Technical Options (Actionable)
+
+These are scene-immersion improvements that do not require designing new clutter props first.
+
+### Tier 1: Fast visual wins (0.5-2 days)
+1. Add controlled card gloss shaping on artwork boxes.
+   - Why: game boxes should read as coated print stock, not matte cardboard.
+   - How: expose and tune roughness/metalness envelope for artwork material, and optionally add a mild view-dependent highlight approximation.
+   - Touch points: `client/src/scene/game-box/instancing/LitArtworkMaterial.ts`.
+   - Validation: compare shelf-angle specular response in 3 camera positions under existing retail lighting.
+
+2. Add subtle fresnel edge lift for box readability.
+   - Why: edge reflections help silhouettes read at oblique angles.
+   - How: multiply a small grazing-angle boost into final albedo or specular response, clamped to avoid artificial halos.
+   - Touch points: `client/src/scene/game-box/instancing/LitArtworkMaterial.ts`.
+   - Validation: ensure front-facing color is unchanged while side-angle readability improves.
+
+3. Improve shadow contact grounding around shelf intersections.
+   - Why: boxes feel floaty when contact shadows are too soft or weak.
+   - How: tighten directional shadow camera fit and bias tuning for shelf zones already in the scene.
+   - Touch points: `client/src/lighting/ShadowPolicy.ts`, `client/src/scene/LightingRenderer.ts`.
+   - Validation: side-by-side snapshots at shelf base and under overhangs.
+
+### Tier 2: Medium effort, strong realism gain (1-3 days)
+1. Add lightweight per-instance variation to break clone look.
+   - Why: identical roughness and response across all boxes reads synthetic even before clutter.
+   - How: derive a deterministic per-instance variation factor from `textureIndex` and apply small roughness or albedo offsets within strict bounds.
+   - Touch points: `client/src/scene/game-box/instancing/LitArtworkMaterial.ts`, `client/src/scene/game-box/instancing/LodGameArtworkRenderer.ts`.
+   - Validation: no visible popping across LOD transitions; variation should remain subtle.
+
+2. Add edge-wear micro normal for box side faces only.
+   - Why: perfectly flat side faces reduce realism at close range.
+   - How: apply a tiny procedural normal perturbation on non-front faces, leaving cover art face clean.
+   - Touch points: `client/src/scene/game-box/instancing/LitArtworkMaterial.ts`.
+   - Validation: close-up pass in VR and desktop to ensure no shimmering.
+
+3. Add scene reflection context for glossy response.
+   - Why: gloss looks wrong when there is nothing meaningful to reflect.
+   - How: ensure environment contribution is present and tuned for retail interior values.
+   - Touch points: scene setup and material environment configuration paths.
+   - Validation: highlight movement should track camera and light shifts naturally.
+
+### Tier 3: Atmosphere before clutter (1-3 days)
+1. Dust motes in lit cones.
+   - Why: adds depth cues and "air" without adding geometry clutter.
+   - How: low-density particle pass bounded to key light volumes.
+   - Existing roadmap tie-in: already tracked by Lighting and Atmosphere feature.
+
+2. Subtle spotlight shimmer or breathing.
+   - Why: static lighting can feel lifeless even when technically correct.
+   - How: low-amplitude temporal modulation with strict caps.
+   - Existing roadmap tie-in: already tracked by Lighting and Atmosphere feature.
+
+## Suggested Execution Order (Before Clutter)
+1. Card gloss shaping.
+2. Shadow contact grounding.
+3. Per-instance variation.
+4. Dust motes.
+
+This sequence gives high immersion gain per day while preserving the current architecture and avoiding renderer migration scope.

--- a/docs/plans/game-box-artwork-vibrancy-plan.md
+++ b/docs/plans/game-box-artwork-vibrancy-plan.md
@@ -106,4 +106,56 @@ Regression checks:
 - No measurable regression in startup stability or frame pacing.
 
 ## 8. Immediate Next Step
-Implement Phase 1 only (shader color-space correctness) as a small, isolated patch in `client/src/scene/game-box/instancing/LitArtworkMaterial.ts`, then validate visually before touching asset pipeline or adding artistic compensation controls.
+The original "Phase 1 only" next step has already been overtaken by implementation work.
+
+Current practical next step:
+- consolidate this into a small hardening pass on the existing material path (replacement checks/assertions and visual regression capture), rather than changing renderer architecture.
+
+What is already in place:
+- lit artwork material path integrated
+- lighting profile retune completed
+- texture-array color pipeline fixes applied
+- optional albedo boost hook validated during tuning
+
+## 9. Reassessment After TSL Spike
+
+### What We Were Here To Fix
+The original issue was not "make the renderer more modern." It was:
+- game box artwork looked muted in the lit instanced path
+- the custom array-texture material path was deviating from Three.js's standard map handling
+- we wanted more vibrancy without breaking shadows, tone mapping, or instancing performance
+
+### Why TSL Was Considered And Then Rejected For Now
+TSL looked attractive because it would replace shader string patching with a structured node graph. In practice, it pushes this renderer toward `WebGPURenderer`, which means a broader renderer migration.
+
+That is a larger project than this fix and it changes too many surrounding assumptions at once for current work:
+- renderer construction and type signatures
+- WebXR integration
+- debug renderer instrumentation
+- capability detection and test coverage
+
+Conclusion: TSL is a valid future direction, but it is not the right next step for this branch or for the foreseeable roadmap.
+
+### Remaining Options
+1. Keep the current `MeshStandardMaterial` + `onBeforeCompile` path, but harden it with replacement checks and small focused assertions.
+2. Move to a fully custom `ShaderMaterial` if we want explicit control without string replacement, while staying on `WebGLRenderer`.
+3. Revisit TSL/WebGPU only as part of a deliberate renderer migration project, not as a material-only cleanup.
+
+### Current Decision
+For now, do not pursue the TSL path. Treat the existing material approach as the baseline, and only revisit if we intentionally start a renderer-wide migration later.
+
+## 10. Where We Are Overall On This Path
+
+We started this path to improve realism and shelf presence by making game boxes:
+- respond to light/shadow more like the rest of the scene
+- retain stronger color/vibrancy under the lit path
+- avoid regressions in LOD and instancing performance
+
+Current state:
+- The visual quality direction is working: boxes read more convincingly in lit scenes than before.
+- The remaining work is mostly hardening and polish, not foundational architecture change.
+
+Remaining options from here:
+1. Maintain and harden current `MeshStandardMaterial` + `onBeforeCompile` path (recommended short-term).
+2. Move to full custom lit shader path if patching complexity grows.
+3. Re-open TSL only inside a deliberate renderer migration project.

--- a/docs/plans/showcase-scene-comparison-plan.md
+++ b/docs/plans/showcase-scene-comparison-plan.md
@@ -1,0 +1,117 @@
+# Showcase Scene Comparison Plan
+
+## Status
+Planned spike for a follow-up branch after the current artwork/shadow tuning PR lands.
+
+## Goal
+Build a controlled showcase scene that lets us compare artwork tuning presets side-by-side without disturbing the normal store bootstrap.
+
+The immediate use case is the current branch work on artwork boxes:
+- roughness / metalness tuning
+- fresnel edge lift
+- shadow contact grounding
+
+The comparison scene should keep the rest of the setup stable so each row or grouping isolates one tuning family at a time.
+
+## Why This Exists
+We need a review-friendly way to inspect material and lighting changes before committing to a final look.
+
+Right now the normal scene bootstrap is optimized for a full store build, not for controlled visual comparison. The existing deferred startup seam is useful, but it should be extended into an explicit mode rather than overloaded with ad hoc debug behavior.
+
+## Current Seam To Reuse
+The current scene startup path already defers world building until after controls are ready:
+- `client/src/core/SteamBrickAndMortarApp.ts` starts scene setup after the render loop is live.
+- `client/src/scene/SceneCoordinator.ts` already exposes a deferred `startSceneSetup()` entry point.
+
+That is the right place to branch into a showcase path.
+
+## Proposed Shape
+
+### 1. Add A Showcase Scene Mode
+Extend scene bootstrap so it can choose between:
+- normal store build
+- empty/debug scene
+- showcase comparison scene
+
+This should be a config-driven branch rather than a hardcoded special case.
+
+Likely extension points:
+- `client/src/scene/SceneCoordinator.ts`
+- `client/src/scene/SceneManager.ts`
+- any debug/startup wiring that currently chooses between normal build and debug behavior
+
+### 2. Build A Showcase Layout
+The showcase scene should render a fixed grid or lane layout with repeatable camera framing.
+
+Recommended first pass:
+- 3 comparison columns
+- 1 row per tuning family
+- one family changes at a time
+- all non-target tunables stay at current defaults
+
+That gives us a clean read on each change without cross-talk.
+
+### 3. Use Current Defaults As Baseline
+For the first version, keep the preset values conservative and familiar.
+
+Each grouping should have:
+- a baseline/default box
+- one or two comparison variants for the active family
+- the remaining families fixed to current defaults
+
+This keeps the scene easy to interpret and avoids mixing too many variables at once.
+
+## Comparison Matrix
+
+### Row 1: Roughness / Metalness
+Compare the current scalar defaults against a couple of adjacent variants.
+
+### Row 2: Fresnel Edge Lift
+Compare the current default edge lift against lower and higher emphasis options.
+
+### Row 3: Shadow Contact Grounding
+Compare the current shadow contact settings against softer and tighter contact variants.
+
+If we want a tighter first pass, we can start with only one row and make the other two rows placeholders.
+
+## Implementation Strategy
+
+### Phase 1: Scene Branching
+1. Identify or formalize the existing debug/empty-scene startup path.
+2. Add a showcase mode flag to scene bootstrap.
+3. Route showcase mode through a dedicated builder instead of normal store construction.
+
+### Phase 2: Showcase Builder
+1. Lay out the comparison scene with stable camera and lighting.
+2. Spawn three boxes per active comparison set.
+3. Apply one tuning family per grouping while holding all other values constant.
+
+### Phase 3: Review Controls
+1. Add a simple way to select which comparison family is being shown.
+2. Add a reset path so the scene can return to defaults.
+3. Add debug labels or markers only if they improve review clarity.
+
+### Phase 4: Validation
+1. Capture side-by-side screenshots for the three families.
+2. Verify the scene still boots cleanly from the normal path.
+3. Verify the showcase path does not alter production scene construction.
+
+## Acceptance Criteria
+- We can launch a branch-local showcase scene without affecting the default store build.
+- The scene shows side-by-side comparisons with only one tuning family varying per grouping.
+- The comparison layout is stable enough for screenshot review.
+- The normal startup path remains unchanged.
+
+## Open Questions
+- Should the showcase scene use a true empty room, or a minimal store slice with only the relevant shelves and lights?
+- Should the comparison grid be controlled by a debug flag, a query parameter, or a temporary UI control?
+- Do we want one showcase scene per tuning family, or a single grid that can swap active families?
+- Should the comparison path reuse live app data, or should it pin a small set of fixed test games for consistency?
+
+## Out Of Scope
+- Production UI polish for the showcase selector.
+- A permanent in-game photo mode.
+- Any broader renderer refactor beyond what is needed to branch scene setup cleanly.
+
+## Suggested Next Step
+After the current PR feedback is resolved and the branch merges, create a fresh spike branch and implement the showcase mode behind the existing deferred scene startup seam.


### PR DESCRIPTION
## Summary
This branch implements the next artwork shading/vibrancy pass and wires runtime tuning through settings/events, plus a small UI layout preference tweak.

## What Changed
- Tier 1 artwork shading improvements:
  - Fresnel edge lift for box artwork vibrancy
- Tier 1+2 follow-up:
  - Shadow contact grounding updates
  - Per-instance roughness variation
- Rendering/settings/event wiring:
  - Restore/export artwork tuning events in `LightingEvents`
  - Add artwork/shadow tuning keys/defaults in `AppSettings`
  - Hook tuning reads/updates in lighting and LOD artwork renderer/material paths
- Layout preference adjustments:
  - Small shared UI rail inset/gap tweaks in `main.css` (`--ui-edge-gap`, `--ui-top-inset`)
- Docs/plans updates:
  - Shading/vibrancy planning notes and act/task tracking updates included in branch history

## Rebase / Upstream Sync
- Branch was rebased onto latest `act2/default` before opening this PR.
- One rebase conflict was resolved in `LightingEvents.ts` and follow-up duplicate settings entries in `AppSettings.ts` were removed.

## Validation
- `yarn tsc --noEmit` passes on this branch.