### PR TITLE
Read game artwork from Steam's local librarycache before hitting the network

### DIFF
--- a/client/src/scene/game-box/instancing/GameArtworkProvider.ts
+++ b/client/src/scene/game-box/instancing/GameArtworkProvider.ts
@@ -26,6 +26,7 @@ import { TextureWorker } from './TextureWorker'
 import { PixelDataCache } from './PixelDataCache'
 import { GameArtworkRequest } from './GameArtworkRequest'
 import { resizePixels } from './ArtworkPixelUtils'
+import { LocalLibraryArtReader, type LocalArtSlot, type LocalLibraryArtEntry } from '../../../steam/LocalLibraryArtReader'
 
 // Class-scoped logger will be attached to the class
 
@@ -128,6 +129,7 @@ export class GameArtworkProvider {
     private pixelCache: PixelDataCache | null = null
     private readonly failureCache = new Map<string, RuntimeArtworkCacheEntry>()
     private readonly successCache = new Map<string, RuntimeArtworkCacheEntry>()
+    private readonly localArtIndex = new Map<number, LocalLibraryArtEntry>()
 
     // Skip tracking (per session)
     private skipStats: Map<FailureReason, number> = new Map()
@@ -231,6 +233,82 @@ export class GameArtworkProvider {
         return urls
     }
     
+    /**
+     * Registers this session's local-librarycache scan results (see LocalLibraryArtReader) -
+     * called once from the local-scan startup pass. A no-op call (empty array, or never called at
+     * all on the web build) just means fetchPixelsFromLocalDisk always misses, falling through to
+     * the normal URL strategy - not an error state.
+     */
+    public registerLocalArtIndex(entries: readonly LocalLibraryArtEntry[]): void {
+        for (const entry of entries) {
+            this.localArtIndex.set(entry.appid, entry)
+        }
+    }
+
+    private getLocalArtSlot(appId: number, format: ArtworkFormat): LocalArtSlot | undefined {
+        if (format !== 'library' && format !== 'header') {
+            return undefined
+        }
+        return this.localArtIndex.get(appId)?.[format]
+    }
+
+    /**
+     * Read pixels straight from Steam's own local librarycache, zero network - see
+     * docs/plans/startup-artwork-resolution-plan.md, Root Cause D. Returns null (not a rejected
+     * promise) whenever this isn't available for the appId/format, so callers can fall through to
+     * the normal URL strategy the same way a cache miss would: no local index entry, no matching
+     * slot, or the disk read/decode itself fails for any reason (file moved, permissions, etc.).
+     */
+    public async fetchPixelsFromLocalDisk(
+        appId: number,
+        format: ArtworkFormat,
+        targetWidth: number,
+        targetHeight: number
+    ): Promise<PixelDataResult | null> {
+        const slot = this.getLocalArtSlot(appId, format)
+        if (!slot) {
+            return null
+        }
+
+        // No `?t=` instability here (it's not a real URL) - stable per appId/asset by construction.
+        const cacheKeyUrl = `local://${appId}/${slot.relative_path}`
+        const sizedCacheUrl = `${cacheKeyUrl}@${targetWidth}x${targetHeight}`
+
+        if (this.pixelCache) {
+            const cached = await this.pixelCache.get(sizedCacheUrl)
+            if (cached) {
+                if (cached.width === targetWidth && cached.height === targetHeight) {
+                    return { pixels: cached.pixelData, width: cached.width, height: cached.height, fromCache: true }
+                }
+                const resized = resizePixels(cached.pixelData, cached.width, cached.height, targetWidth, targetHeight)
+                return { pixels: resized, width: targetWidth, height: targetHeight, fromCache: true }
+            }
+        }
+
+        try {
+            const bytes = await LocalLibraryArtReader.readArtBytes(appId, slot.relative_path)
+            if (!bytes) {
+                return null
+            }
+
+            const result = await this.textureWorker.processLocalBytes(
+                bytes, slot.relative_path, 0, `${appId}-${format}`,
+                { textureWidth: targetWidth, textureHeight: targetHeight }
+            )
+
+            if (this.pixelCache) {
+                await this.pixelCache.put(sizedCacheUrl, result.imageData, targetWidth, targetHeight)
+            }
+
+            return { pixels: result.imageData, width: targetWidth, height: targetHeight, fromCache: false }
+        } catch (err) {
+            GameArtworkProvider.logger.warn(
+                `Local disk art read/decode failed for appId ${appId} (${slot.relative_path}), falling back to network:`, err
+            )
+            return null
+        }
+    }
+
     /**
      * Fetch pixel data for a URL, with caching.
      */

--- a/client/src/scene/game-box/instancing/GameArtworkRequest.ts
+++ b/client/src/scene/game-box/instancing/GameArtworkRequest.ts
@@ -50,9 +50,18 @@ export class GameArtworkRequest implements GameArtwork {
     
     async getPixelsAtSize(width: number, height: number): Promise<PixelDataResult> {
         // If we already loaded and it's the same size, return cached
-        if (this.cachedPixels?.width === width && 
+        if (this.cachedPixels?.width === width &&
             this.cachedPixels.height === height) {
             return this.cachedPixels
+        }
+
+        // Zero-network, ahead of everything else - Steam's own already-validated local art beats
+        // any URL strategy, guessed or hinted. A miss (no local index entry, no matching slot, or
+        // a disk read/decode failure) returns null and falls straight through below - not an error.
+        const localResult = await this.provider.fetchPixelsFromLocalDisk(this.appId, this.format, width, height)
+        if (localResult) {
+            this.cachedPixels = localResult
+            return localResult
         }
 
         const cachedSelection = SteamArtworkStateManager.getState(this.appId)

--- a/client/src/scene/game-box/instancing/TextureWorker.ts
+++ b/client/src/scene/game-box/instancing/TextureWorker.ts
@@ -8,6 +8,7 @@
 import type {
     TextureProcessingMessage,
     TextureFetchMessage,
+    TextureLocalBlobMessage,
     TextureProcessingResult,
     TextureProcessingError,
     ArtworkPackDecodeMessage,
@@ -42,7 +43,7 @@ export interface FetchAndProcessOptions {
     timeout?: number
 }
 
-type TWIn = TextureProcessingMessage | TextureFetchMessage | ArtworkPackDecodeMessage
+type TWIn = TextureProcessingMessage | TextureFetchMessage | TextureLocalBlobMessage | ArtworkPackDecodeMessage
 type TWOut = TextureProcessingResult | TextureProcessingError | ArtworkPackDecodeResult
 
 export class TextureWorker extends ManagedWorker<TWIn, TWOut> {
@@ -135,6 +136,45 @@ export class TextureWorker extends ManagedWorker<TWIn, TWOut> {
         } catch (err) {
             this.includeBlobFor.delete(messageId)
             throw err
+        }
+    }
+
+    /**
+     * Process image bytes already read from local disk (Tauri, not the network) - same flexible
+     * dimensions/native-size handling as fetchAndProcessWithOptions, minus the network fetch.
+     * `formatHint` (e.g. "library_600x900.jpg") stands in for a URL in the worker's high-res-check
+     * filename match, since there's no real URL for a local file.
+     */
+    public async processLocalBytes(
+        bytes: Uint8Array<ArrayBuffer>,
+        formatHint: string,
+        textureIndex: number,
+        gameName: string,
+        options: FetchAndProcessOptions = {}
+    ): Promise<FetchAndProcessResult> {
+        const messageId = this.nextMsgId(`local_${textureIndex}`)
+        const blob = new Blob([bytes])
+        const result = await this.send<TextureProcessingResult>({
+            type: 'PROCESS_LOCAL_BLOB',
+            blob,
+            formatHint,
+            textureWidth: options.textureWidth,
+            textureHeight: options.textureHeight,
+            useNativeSize: options.useNativeSize,
+            textureIndex,
+            messageId,
+            gameName
+        } as TextureLocalBlobMessage)
+
+        if (result.type !== 'TEXTURE_PROCESSED') {
+            throw new Error((result as unknown as TextureProcessingError).error)
+        }
+
+        return {
+            imageData: result.imageData,
+            processingTime: result.processingTime,
+            width: result.width,
+            height: result.height
         }
     }
 

--- a/client/src/scene/game-box/instancing/texture-processing.worker.ts
+++ b/client/src/scene/game-box/instancing/texture-processing.worker.ts
@@ -228,6 +228,22 @@ function getExpectedNativeWidth(url: string): number | undefined {
     return undefined
 }
 
+// Fires once per matching image, and every local-librarycache read is one of these by
+// construction (Steam's own library_600x900.jpg files are genuinely 600×900, not the CDN's
+// downscaled 300×450) - one line per occurrence would mean one line per placed game box.
+// Logged as a running count instead of per-occurrence noise.
+const HIGH_RES_LOG_INTERVAL = 25
+let highResImageCount = 0
+
+function logHighResImageIfDue(nativeWidth: number, nativeHeight: number, expectedWidth: number): void {
+    highResImageCount++
+    if (highResImageCount % HIGH_RES_LOG_INTERVAL !== 0) return
+    console.debug(
+        `[TextureWorker] High-res CDN image detected ${highResImageCount} times so far ` +
+        `(most recent: native ${nativeWidth}×${nativeHeight}, expected ~${expectedWidth}px wide for this artwork type)`
+    )
+}
+
 async function processBlobWithDimensions(
     blob: Blob,
     url: string,
@@ -258,7 +274,7 @@ async function processBlobWithDimensions(
 
     const expectedNativeWidth = getExpectedNativeWidth(url)
     if (expectedNativeWidth !== undefined && imageBitmap.width > expectedNativeWidth) {
-        console.debug(`[TextureWorker] High-res CDN image detected: native ${imageBitmap.width}×${imageBitmap.height} (expected ~${expectedNativeWidth}px wide for this artwork type)`)
+        logHighResImageIfDue(imageBitmap.width, imageBitmap.height, expectedNativeWidth)
     }
     
     ensureCanvas(width, height)

--- a/client/src/scene/game-box/instancing/texture-processing.worker.ts
+++ b/client/src/scene/game-box/instancing/texture-processing.worker.ts
@@ -46,6 +46,24 @@ export interface TextureFetchMessage {
     timeout?: number
 }
 
+/**
+ * Process a Blob that's already local (read from disk via Tauri, not fetched over the network) -
+ * same flexible-dimensions processing FETCH_AND_PROCESS uses, minus the network fetch.
+ * `formatHint` stands in for `url` in the high-res-check filename match (see
+ * getExpectedNativeWidth) since there's no real URL for a local file.
+ */
+export interface TextureLocalBlobMessage {
+    type: 'PROCESS_LOCAL_BLOB'
+    blob: Blob
+    formatHint: string
+    textureWidth?: number
+    textureHeight?: number
+    useNativeSize?: boolean
+    textureIndex: number
+    messageId: string
+    gameName: string
+}
+
 /** One tile's position within an artwork pack grid image. */
 export interface ArtworkPackEntry {
     appid: number
@@ -105,7 +123,7 @@ export interface TextureProcessingError {
     gameName?: string
 }
 
-export type WorkerMessage = TextureProcessingMessage | TextureFetchMessage | ArtworkPackDecodeMessage
+export type WorkerMessage = TextureProcessingMessage | TextureFetchMessage | TextureLocalBlobMessage | ArtworkPackDecodeMessage
 export type WorkerResponse = TextureProcessingResult | TextureProcessingError | ArtworkPackDecodeResult
 
 // Worker state
@@ -395,6 +413,30 @@ ctx.onmessage = async (event: MessageEvent<WorkerMessage>): Promise<void> => {
             }
             
             // Transfer the ArrayBuffer to avoid copying
+            ctx.postMessage(result, [processed.imageData.buffer])
+
+        } else if (type === 'PROCESS_LOCAL_BLOB') {
+            // Local disk mode: no network fetch, same flexible-dimensions processing otherwise
+            const { blob, formatHint, textureWidth, textureHeight, useNativeSize, textureIndex, gameName } = event.data as TextureLocalBlobMessage
+
+            const processed = (useNativeSize || (textureWidth && textureHeight))
+                ? await processBlobWithDimensions(blob, formatHint, textureWidth, textureHeight, useNativeSize)
+                : await processBlobWithDimensions(blob, formatHint, undefined, undefined, true)
+
+            const processingTime = performance.now() - startTime
+
+            const result: TextureProcessingResult = {
+                type: 'TEXTURE_PROCESSED',
+                imageData: processed.imageData,
+                textureIndex: textureIndex,
+                messageId: messageId,
+                processingTime: processingTime,
+                width: processed.width,
+                height: processed.height,
+                gameName: gameName,
+                blob: blob
+            }
+
             ctx.postMessage(result, [processed.imageData.buffer])
 
         } else if (type === 'DECODE_ARTWORK_PACK') {

--- a/client/src/steam-integration/SteamIntegration.ts
+++ b/client/src/steam-integration/SteamIntegration.ts
@@ -35,7 +35,7 @@ import type {
 import type { GameDataReadyEvent } from '../types/EnvironmentEvents'
 import { DataManager, DataDomain } from '../core/data'
 import '../scene/batch/BatchCoordinator'
-import { loadLocalSteamLibrary } from '../steam/LocalSteamLibraryLoader'
+import { loadLocalSteamLibrary, registerLocalLibraryArt } from '../steam/LocalSteamLibraryLoader'
 import { StorePropsEventTypes } from '../scene/props/PropsEvents'
 import type { StorePropsLibraryReloadRequestEvent } from '../scene/props/PropsEvents'
 
@@ -255,6 +255,14 @@ export class SteamIntegration {
      */
     private async applyLibrary(library: Library): Promise<boolean> {
         try {
+            // Every real source (cache, local-scan, online) funnels through here - the startup
+            // waterfall's most common case is a persisted-library cache hit, which never runs
+            // loadLocalSteamLibrary() at all, so this can't live there (see
+            // registerLocalLibraryArt's own doc comment). Awaited before anything else below so
+            // GameArtworkProvider's local-art index is populated before placement starts
+            // requesting textures, not racing it.
+            await registerLocalLibraryArt(new Set(library.games.map(g => g.appid)))
+
             const currentGames = this.gameLibrary.getState().userData?.games
             if (currentGames?.length) {
                 const diff = computeLibraryDiff(library.games, currentGames)

--- a/client/src/steam/LocalLibraryArtReader.ts
+++ b/client/src/steam/LocalLibraryArtReader.ts
@@ -28,11 +28,18 @@ export class LocalLibraryArtReader {
         return invoke<LocalLibraryArtEntry[]>('find_local_library_art', { appids })
     }
 
+    /**
+     * The Rust side returns a raw `tauri::ipc::Response` (an ArrayBuffer here), not JSON - a
+     * plain `Vec<u8>` return goes over Tauri's default JSON IPC as a comma-separated array of
+     * numbers, which measurably dominated startup time on a real desktop session once this ran
+     * once per placed game box (see the Rust command's own doc comment, and
+     * docs/plans/startup-artwork-resolution-plan.md).
+     */
     public static async readArtBytes(appid: number, relativePath: string): Promise<Uint8Array<ArrayBuffer> | null> {
         if (!isTauri()) {
             return null
         }
-        const bytes = await invoke<number[]>('read_local_library_art_bytes', { appid, relativePath })
+        const bytes = await invoke<ArrayBuffer>('read_local_library_art_bytes', { appid, relativePath })
         return new Uint8Array(bytes)
     }
 }

--- a/client/src/steam/LocalLibraryArtReader.ts
+++ b/client/src/steam/LocalLibraryArtReader.ts
@@ -1,0 +1,38 @@
+/**
+ * Reads Steam's own rendered library-art cache (appcache/librarycache/<appid>/) via the desktop
+ * app's Rust commands - see desktop/tauri-app/src/steam/librarycache.rs and
+ * docs/plans/startup-artwork-resolution-plan.md, Root Cause D. No-ops on the web build (isTauri()
+ * is false there).
+ */
+
+import { invoke, isTauri } from '@tauri-apps/api/core'
+
+export interface LocalArtSlot {
+    /** Relative to appcache/librarycache/<appid>/ - pass to readArtBytes to load it. */
+    relative_path: string
+    /** Present only for the hash-migrated on-disk convention - the same hash Steam's CDN URLs use. */
+    hash?: string
+}
+
+export interface LocalLibraryArtEntry {
+    appid: number
+    library?: LocalArtSlot
+    header?: LocalArtSlot
+}
+
+export class LocalLibraryArtReader {
+    public static async findLocalArt(appids: number[]): Promise<LocalLibraryArtEntry[]> {
+        if (!isTauri() || appids.length === 0) {
+            return []
+        }
+        return invoke<LocalLibraryArtEntry[]>('find_local_library_art', { appids })
+    }
+
+    public static async readArtBytes(appid: number, relativePath: string): Promise<Uint8Array<ArrayBuffer> | null> {
+        if (!isTauri()) {
+            return null
+        }
+        const bytes = await invoke<number[]>('read_local_library_art_bytes', { appid, relativePath })
+        return new Uint8Array(bytes)
+    }
+}

--- a/client/src/steam/LocalSteamLibraryLoader.ts
+++ b/client/src/steam/LocalSteamLibraryLoader.ts
@@ -76,7 +76,6 @@ export async function loadLocalSteamLibrary(): Promise<LocalScanResult> {
     }
 
     await LocalSteamDataWriter.writeLocalAppMetadata()
-    await registerLocalLibraryArt(candidateAppids)
     await resolveRemainingAppidsFromNetwork(candidateAppids)
     // Covers collection members writeLocalAppMetadata's own pass can't - see its docs.
     await LocalSteamDataWriter.mergeCollectionsForAppids(candidateAppids, collectionsByAppid)
@@ -101,15 +100,21 @@ export async function loadLocalSteamLibrary(): Promise<LocalScanResult> {
 /**
  * Scans Steam's own local librarycache once for the whole candidate set and registers whatever it
  * finds directly on GameArtworkProvider's singleton - see docs/plans/startup-artwork-resolution-plan.md,
- * Root Cause D. A direct call, not an event: GameArtworkProvider is accessed via getInstance()
- * everywhere else in this codebase (never event-driven), and getInstance() is idempotent/lazy, so
- * there's no ordering hazard to solve regardless of whether the provider singleton already exists
- * yet - unlike a plain EventManager.emit(), which has no late-subscriber replay (see the TODO in
+ * Root Cause D. Called from SteamIntegration.applyLibrary(), not from loadLocalSteamLibrary() above
+ * - the startup waterfall's far more common case is a persisted-library cache hit, which returns
+ * before loadLocalSteamLibrary() ever runs, and this needs to fire for every source (cache,
+ * local-scan, online), not just the one-time local-scan branch, or the index stays empty on every
+ * subsequent launch. Exported for that reason; not just an internal step of this file's own function.
+ *
+ * A direct call, not an event: GameArtworkProvider is accessed via getInstance() everywhere else
+ * in this codebase (never event-driven), and getInstance() is idempotent/lazy, so there's no
+ * ordering hazard to solve regardless of whether the provider singleton already exists yet -
+ * unlike a plain EventManager.emit(), which has no late-subscriber replay (see the TODO in
  * EventManager.ts) and would silently drop this if the provider hadn't been constructed yet.
  * Best-effort: a scan failure just means this session gets no local-disk art, same as before this
  * existed.
  */
-async function registerLocalLibraryArt(candidateAppids: ReadonlySet<number>): Promise<void> {
+export async function registerLocalLibraryArt(candidateAppids: ReadonlySet<number>): Promise<void> {
     try {
         const entries = await LocalLibraryArtReader.findLocalArt([...candidateAppids])
         GameArtworkProvider.getInstance().registerLocalArtIndex(entries)

--- a/client/src/steam/LocalSteamLibraryLoader.ts
+++ b/client/src/steam/LocalSteamLibraryLoader.ts
@@ -24,6 +24,8 @@ import type { AppDetailsData } from './batch/BatchAppDetailsClient'
 import { LocalSteamDataWriter } from './LocalSteamDataWriter'
 import { AppDetailsCache } from './cache/AppDetailsCache'
 import { SteamApiClient } from './SteamApiClient'
+import { LocalLibraryArtReader } from './LocalLibraryArtReader'
+import { GameArtworkProvider } from '../scene/game-box/instancing/GameArtworkProvider'
 import { Logger } from '../utils/Logger'
 
 interface SteamIdentity {
@@ -74,6 +76,7 @@ export async function loadLocalSteamLibrary(): Promise<LocalScanResult> {
     }
 
     await LocalSteamDataWriter.writeLocalAppMetadata()
+    await registerLocalLibraryArt(candidateAppids)
     await resolveRemainingAppidsFromNetwork(candidateAppids)
     // Covers collection members writeLocalAppMetadata's own pass can't - see its docs.
     await LocalSteamDataWriter.mergeCollectionsForAppids(candidateAppids, collectionsByAppid)
@@ -92,6 +95,29 @@ export async function loadLocalSteamLibrary(): Promise<LocalScanResult> {
             games,
             provenance: { channel: 'local-scan', capturedAt: new Date().toISOString() },
         },
+    }
+}
+
+/**
+ * Scans Steam's own local librarycache once for the whole candidate set and registers whatever it
+ * finds directly on GameArtworkProvider's singleton - see docs/plans/startup-artwork-resolution-plan.md,
+ * Root Cause D. A direct call, not an event: GameArtworkProvider is accessed via getInstance()
+ * everywhere else in this codebase (never event-driven), and getInstance() is idempotent/lazy, so
+ * there's no ordering hazard to solve regardless of whether the provider singleton already exists
+ * yet - unlike a plain EventManager.emit(), which has no late-subscriber replay (see the TODO in
+ * EventManager.ts) and would silently drop this if the provider hadn't been constructed yet.
+ * Best-effort: a scan failure just means this session gets no local-disk art, same as before this
+ * existed.
+ */
+async function registerLocalLibraryArt(candidateAppids: ReadonlySet<number>): Promise<void> {
+    try {
+        const entries = await LocalLibraryArtReader.findLocalArt([...candidateAppids])
+        GameArtworkProvider.getInstance().registerLocalArtIndex(entries)
+        if (entries.length > 0) {
+            logger.info(`Local librarycache scan: ${entries.length}/${candidateAppids.size} appid(s) have cached art on disk`)
+        }
+    } catch (error) {
+        logger.warn('Failed to scan local librarycache, proceeding without it:', error)
     }
 }
 

--- a/client/src/steam/batch/BatchAppDetailsClient.ts
+++ b/client/src/steam/batch/BatchAppDetailsClient.ts
@@ -26,6 +26,15 @@ export interface AppDetailsData extends SteamGameMetadata {
         capsule_v5: string | null;
         background: string | null;
         background_raw: string | null;
+        /**
+         * Real library-art CDN URL, validated (never a guess) - the Steam Store API has no field
+         * for this at all, so the only source is a locally-discovered librarycache hash (see
+         * desktop/tauri-app/src/steam/librarycache.rs) confirmed live before being written here.
+         * Optional (not `string | null` like the fields above) so the many existing `artwork`
+         * object literals that predate this field don't all need updating - most entries simply
+         * don't have one yet.
+         */
+        library?: string;
     };
     // Additional fields from Steam Store API
     full_data?: Record<string, unknown>;

--- a/client/src/steam/cache/AppDetailsCache.ts
+++ b/client/src/steam/cache/AppDetailsCache.ts
@@ -266,6 +266,7 @@ function mergeAppDetails(
             capsule_v5: prefer(incoming.artwork.capsule_v5, existing.artwork.capsule_v5, isDefined) ?? null,
             background: prefer(incoming.artwork.background, existing.artwork.background, isDefined) ?? null,
             background_raw: prefer(incoming.artwork.background_raw, existing.artwork.background_raw, isDefined) ?? null,
+            library: prefer(incoming.artwork.library, existing.artwork.library, isDefined),
         },
         developers: prefer(incoming.developers, existing.developers, isNonEmptyArray),
         publishers: prefer(incoming.publishers, existing.publishers, isNonEmptyArray),

--- a/client/test/unit/scene/instancing/GameArtworkProvider.test.ts
+++ b/client/test/unit/scene/instancing/GameArtworkProvider.test.ts
@@ -39,8 +39,21 @@ vi.mock('../../../../src/scene/game-box/instancing/TextureWorker', () => ({
                 ? Promise.reject(new Error('HTTP 404: Not Found'))
                 : Promise.resolve({ imageData: new Uint8ClampedArray(300 * 450 * 4).fill(128) })
         ),
+        processLocalBytes: vi.fn(() =>
+            Promise.resolve({ imageData: new Uint8ClampedArray(300 * 450 * 4).fill(64), processingTime: 1, width: 300, height: 450 })
+        ),
         dispose: vi.fn()
     } })
+}))
+
+const { readArtBytesMock } = vi.hoisted(() => ({
+    readArtBytesMock: vi.fn(),
+}))
+
+vi.mock('../../../../src/steam/LocalLibraryArtReader', () => ({
+    LocalLibraryArtReader: {
+        readArtBytes: readArtBytesMock,
+    },
 }))
 
 // Mock PixelDataCache
@@ -73,6 +86,7 @@ describe('GameArtworkProvider', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
+        readArtBytesMock.mockReset().mockResolvedValue(null)
         setupIndexedDBMock()
         AppDetailsCache.resetForTesting()
         DataManager.resetInstance()
@@ -341,6 +355,69 @@ describe('GameArtworkProvider', () => {
             await artwork.getPixelsAtSize(dims.width, dims.height)
 
             expect(await AppDetailsCache.get(999999)).toBeNull()
+        })
+    })
+
+    describe('Local disk art (registerLocalArtIndex / fetchPixelsFromLocalDisk)', () => {
+        it('returns null when nothing is registered for the appId', async () => {
+            const dims = ARTWORK_DIMENSIONS.library
+            const result = await provider.fetchPixelsFromLocalDisk(12345, 'library', dims.width, dims.height)
+            expect(result).toBeNull()
+            expect(readArtBytesMock).not.toHaveBeenCalled()
+        })
+
+        it('returns null for capsule format - no local slot exists for it', async () => {
+            provider.registerLocalArtIndex([
+                { appid: 12345, library: { relative_path: 'library_600x900.jpg' } },
+            ])
+            const dims = ARTWORK_DIMENSIONS.capsule
+            const result = await provider.fetchPixelsFromLocalDisk(12345, 'capsule', dims.width, dims.height)
+            expect(result).toBeNull()
+        })
+
+        it('reads bytes and decodes via the worker when a matching slot is registered', async () => {
+            provider.registerLocalArtIndex([
+                { appid: 12345, library: { relative_path: 'library_600x900.jpg' } },
+            ])
+            readArtBytesMock.mockResolvedValue(new Uint8Array([1, 2, 3]))
+
+            const dims = ARTWORK_DIMENSIONS.library
+            const result = await provider.fetchPixelsFromLocalDisk(12345, 'library', dims.width, dims.height)
+
+            expect(readArtBytesMock).toHaveBeenCalledWith(12345, 'library_600x900.jpg')
+            expect(result?.fromCache).toBe(false)
+            expect(result?.width).toBe(dims.width)
+            expect(result?.height).toBe(dims.height)
+        })
+
+        it('falls through to null (not a thrown error) when the disk read fails', async () => {
+            provider.registerLocalArtIndex([
+                { appid: 12345, header: { relative_path: 'header.jpg' } },
+            ])
+            readArtBytesMock.mockRejectedValue(new Error('file moved'))
+
+            const dims = ARTWORK_DIMENSIONS.header
+            const result = await provider.fetchPixelsFromLocalDisk(12345, 'header', dims.width, dims.height)
+
+            expect(result).toBeNull()
+        })
+
+        it('GameArtworkRequest prefers local disk over the network URL strategy', async () => {
+            provider.registerLocalArtIndex([
+                { appid: 12345, library: { relative_path: 'library_600x900.jpg', hash: 'abc123' } },
+            ])
+            readArtBytesMock.mockResolvedValue(new Uint8Array([1, 2, 3]))
+
+            const artwork = provider.getArtwork(12345, 'Test Game', 'library', { library: 'https://example.com/art.jpg' })
+            const dims = ARTWORK_DIMENSIONS.library
+            const result = await artwork.getPixelsAtSize(dims.width, dims.height)
+
+            expect(result.fromCache).toBe(false)
+            expect(readArtBytesMock).toHaveBeenCalled()
+            // Local disk resolution never pins SteamArtworkStateManager's selectedUrl (no real URL
+            // to pin) - unaffected either way, just confirms the network strategy was never reached.
+            const state = SteamArtworkStateManager.getState(12345)
+            expect(state?.selectedUrl).toBeUndefined()
         })
     })
 })

--- a/client/test/unit/steam-integration/SteamIntegration-startup-waterfall.test.ts
+++ b/client/test/unit/steam-integration/SteamIntegration-startup-waterfall.test.ts
@@ -37,6 +37,7 @@ vi.mock('../../../src/steam-integration/LibraryStore', () => ({
 
 vi.mock('../../../src/steam/LocalSteamLibraryLoader', () => ({
     loadLocalSteamLibrary: vi.fn(),
+    registerLocalLibraryArt: vi.fn(),
 }))
 
 vi.mock('../../../src/steam-integration/OnlineLibraryLoader', () => ({
@@ -50,7 +51,7 @@ vi.mock('../../../src/steam-integration/DemoLibraryLoader', () => ({
 
 import { SteamIntegration } from '../../../src/steam-integration/SteamIntegration'
 import { loadPersistedLibrary, persistLibrary } from '../../../src/steam-integration/LibraryStore'
-import { loadLocalSteamLibrary } from '../../../src/steam/LocalSteamLibraryLoader'
+import { loadLocalSteamLibrary, registerLocalLibraryArt } from '../../../src/steam/LocalSteamLibraryLoader'
 import { loadOnlineLibrary } from '../../../src/steam-integration/OnlineLibraryLoader'
 import { loadDemoLibrary } from '../../../src/steam-integration/DemoLibraryLoader'
 
@@ -82,6 +83,20 @@ describe('SteamIntegration startup waterfall', () => {
         expect(loadDemoLibrary).not.toHaveBeenCalled()
     })
 
+    test('scans the local librarycache even on a persisted-cache hit - the common case loadLocalSteamLibrary never runs for', async () => {
+        // Regression coverage: registerLocalLibraryArt used to live inside loadLocalSteamLibrary,
+        // which this branch never calls - the local-art index silently stayed empty on every
+        // subsequent launch (confirmed against a real desktop session's log). Moved to
+        // applyLibrary() specifically so every source scans, not just a fresh local-scan.
+        vi.mocked(loadPersistedLibrary).mockReturnValue(makeLibrary({
+            games: [{ appid: 440, name: 'Team Fortress 2', playtimeForever: 100 }, { appid: 620, name: 'Portal 2', playtimeForever: 50 }],
+        }))
+
+        await steamIntegration['handleGameStart']()
+
+        expect(registerLocalLibraryArt).toHaveBeenCalledWith(new Set([440, 620]))
+    })
+
     test('falls to local disk scan when no cache, persists the resolved library, and skips online/demo', async () => {
         vi.mocked(loadPersistedLibrary).mockReturnValue(null)
         const scannedLibrary = makeLibrary()
@@ -92,6 +107,7 @@ describe('SteamIntegration startup waterfall', () => {
         expect(persistLibrary).toHaveBeenCalledWith(scannedLibrary)
         expect(loadOnlineLibrary).not.toHaveBeenCalled()
         expect(loadDemoLibrary).not.toHaveBeenCalled()
+        expect(registerLocalLibraryArt).toHaveBeenCalledWith(new Set([440]))
     })
 
     test('falls to an online fetch when local scan resolves an identity but no games, without calling demo directly', async () => {

--- a/client/test/unit/steam/LocalSteamLibraryLoader.test.ts
+++ b/client/test/unit/steam/LocalSteamLibraryLoader.test.ts
@@ -78,7 +78,7 @@ vi.mock('../../../src/scene/game-box/instancing/GameArtworkProvider', () => ({
     },
 }))
 
-import { loadLocalSteamLibrary, buildLibraryGames } from '../../../src/steam/LocalSteamLibraryLoader'
+import { loadLocalSteamLibrary, buildLibraryGames, registerLocalLibraryArt } from '../../../src/steam/LocalSteamLibraryLoader'
 import type { AppDetailsData } from '../../../src/steam/batch/BatchAppDetailsClient'
 
 const NO_ARTWORK: AppDetailsData['artwork'] = {
@@ -250,44 +250,6 @@ describe('LocalSteamLibraryLoader', () => {
             expect(result.library!.owner.steamId).toBeUndefined()
         })
 
-        it('registers the local librarycache scan results on GameArtworkProvider', async () => {
-            isTauriMock.mockReturnValue(true)
-            invokeMock.mockImplementation((command: string) => {
-                if (command === 'read_steam_identity') return Promise.resolve({ steamid64: '1', account_name: 'a', persona_name: 'A', most_recent: true })
-                if (command === 'read_steam_playtimes') {
-                    return Promise.resolve([{ appid: 620, last_played: 1000, playtime_minutes: 60 }])
-                }
-                if (command === 'read_steam_collections') return Promise.resolve([])
-                throw new Error(`unexpected command ${command}`)
-            })
-            getManyMock.mockResolvedValue(new Map<number, AppDetailsData>([[620, makeEntry('Portal 2')]]))
-            const entries = [{ appid: 620, library: { relative_path: 'library_600x900.jpg' } }]
-            findLocalArtMock.mockResolvedValue(entries)
-
-            await loadLocalSteamLibrary()
-
-            expect(findLocalArtMock).toHaveBeenCalledWith(expect.arrayContaining([620]))
-            expect(registerLocalArtIndexMock).toHaveBeenCalledWith(entries)
-        })
-
-        it('proceeds without local art when the librarycache scan fails', async () => {
-            isTauriMock.mockReturnValue(true)
-            invokeMock.mockImplementation((command: string) => {
-                if (command === 'read_steam_identity') return Promise.resolve({ steamid64: '1', account_name: 'a', persona_name: 'A', most_recent: true })
-                if (command === 'read_steam_playtimes') {
-                    return Promise.resolve([{ appid: 620, last_played: 1000, playtime_minutes: 60 }])
-                }
-                if (command === 'read_steam_collections') return Promise.resolve([])
-                throw new Error(`unexpected command ${command}`)
-            })
-            getManyMock.mockResolvedValue(new Map<number, AppDetailsData>([[620, makeEntry('Portal 2')]]))
-            findLocalArtMock.mockRejectedValue(new Error('scan failed'))
-
-            const result = await loadLocalSteamLibrary()
-
-            expect(result.library).not.toBeNull()
-            expect(registerLocalArtIndexMock).not.toHaveBeenCalled()
-        })
 
         it('returns a null library when no candidate appid ends up with a resolved entry', async () => {
             isTauriMock.mockReturnValue(true)
@@ -305,6 +267,30 @@ describe('LocalSteamLibraryLoader', () => {
 
             expect(result.library).toBeNull()
             expect(result.steamId).toBe('1')
+        })
+    })
+
+    describe('registerLocalLibraryArt', () => {
+        // Exported and called directly from SteamIntegration.applyLibrary() rather than from
+        // loadLocalSteamLibrary() above - the startup waterfall's most common case (a persisted-
+        // library cache hit) never runs loadLocalSteamLibrary() at all, so testing this via that
+        // function would miss the case that actually matters on a returning user's launch.
+        it('scans local librarycache for the given appids and registers whatever is found', async () => {
+            const entries = [{ appid: 620, library: { relative_path: 'library_600x900.jpg' } }]
+            findLocalArtMock.mockResolvedValue(entries)
+
+            await registerLocalLibraryArt(new Set([620, 440]))
+
+            expect(findLocalArtMock).toHaveBeenCalledWith(expect.arrayContaining([620, 440]))
+            expect(registerLocalArtIndexMock).toHaveBeenCalledWith(entries)
+        })
+
+        it('proceeds without throwing when the librarycache scan fails', async () => {
+            findLocalArtMock.mockRejectedValue(new Error('scan failed'))
+
+            await expect(registerLocalLibraryArt(new Set([620]))).resolves.toBeUndefined()
+
+            expect(registerLocalArtIndexMock).not.toHaveBeenCalled()
         })
     })
 })

--- a/client/test/unit/steam/LocalSteamLibraryLoader.test.ts
+++ b/client/test/unit/steam/LocalSteamLibraryLoader.test.ts
@@ -56,6 +56,28 @@ vi.mock('../../../src/steam/SteamApiClient', () => ({
     },
 }))
 
+const { findLocalArtMock } = vi.hoisted(() => ({
+    findLocalArtMock: vi.fn(),
+}))
+
+vi.mock('../../../src/steam/LocalLibraryArtReader', () => ({
+    LocalLibraryArtReader: {
+        findLocalArt: findLocalArtMock,
+    },
+}))
+
+const { registerLocalArtIndexMock } = vi.hoisted(() => ({
+    registerLocalArtIndexMock: vi.fn(),
+}))
+
+vi.mock('../../../src/scene/game-box/instancing/GameArtworkProvider', () => ({
+    GameArtworkProvider: {
+        getInstance: () => ({
+            registerLocalArtIndex: registerLocalArtIndexMock,
+        }),
+    },
+}))
+
 import { loadLocalSteamLibrary, buildLibraryGames } from '../../../src/steam/LocalSteamLibraryLoader'
 import type { AppDetailsData } from '../../../src/steam/batch/BatchAppDetailsClient'
 
@@ -76,6 +98,8 @@ describe('LocalSteamLibraryLoader', () => {
         getManyMock.mockReset().mockResolvedValue(new Map())
         findMissingArtworkMock.mockReset().mockResolvedValue([])
         fetchAndCacheAppDetailsMock.mockReset().mockResolvedValue(new Map())
+        findLocalArtMock.mockReset().mockResolvedValue([])
+        registerLocalArtIndexMock.mockReset()
     })
 
     describe('buildLibraryGames', () => {
@@ -224,6 +248,45 @@ describe('LocalSteamLibraryLoader', () => {
             expect(result.library).not.toBeNull()
             expect(result.library!.owner.displayName).toBeUndefined()
             expect(result.library!.owner.steamId).toBeUndefined()
+        })
+
+        it('registers the local librarycache scan results on GameArtworkProvider', async () => {
+            isTauriMock.mockReturnValue(true)
+            invokeMock.mockImplementation((command: string) => {
+                if (command === 'read_steam_identity') return Promise.resolve({ steamid64: '1', account_name: 'a', persona_name: 'A', most_recent: true })
+                if (command === 'read_steam_playtimes') {
+                    return Promise.resolve([{ appid: 620, last_played: 1000, playtime_minutes: 60 }])
+                }
+                if (command === 'read_steam_collections') return Promise.resolve([])
+                throw new Error(`unexpected command ${command}`)
+            })
+            getManyMock.mockResolvedValue(new Map<number, AppDetailsData>([[620, makeEntry('Portal 2')]]))
+            const entries = [{ appid: 620, library: { relative_path: 'library_600x900.jpg' } }]
+            findLocalArtMock.mockResolvedValue(entries)
+
+            await loadLocalSteamLibrary()
+
+            expect(findLocalArtMock).toHaveBeenCalledWith(expect.arrayContaining([620]))
+            expect(registerLocalArtIndexMock).toHaveBeenCalledWith(entries)
+        })
+
+        it('proceeds without local art when the librarycache scan fails', async () => {
+            isTauriMock.mockReturnValue(true)
+            invokeMock.mockImplementation((command: string) => {
+                if (command === 'read_steam_identity') return Promise.resolve({ steamid64: '1', account_name: 'a', persona_name: 'A', most_recent: true })
+                if (command === 'read_steam_playtimes') {
+                    return Promise.resolve([{ appid: 620, last_played: 1000, playtime_minutes: 60 }])
+                }
+                if (command === 'read_steam_collections') return Promise.resolve([])
+                throw new Error(`unexpected command ${command}`)
+            })
+            getManyMock.mockResolvedValue(new Map<number, AppDetailsData>([[620, makeEntry('Portal 2')]]))
+            findLocalArtMock.mockRejectedValue(new Error('scan failed'))
+
+            const result = await loadLocalSteamLibrary()
+
+            expect(result.library).not.toBeNull()
+            expect(registerLocalArtIndexMock).not.toHaveBeenCalled()
         })
 
         it('returns a null library when no candidate appid ends up with a resolved entry', async () => {

--- a/desktop/tauri-app/Cargo.lock
+++ b/desktop/tauri-app/Cargo.lock
@@ -721,6 +721,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,6 +1660,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2443,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,6 +2828,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tempfile",
  "winreg 0.56.0",
 ]
 
@@ -3165,6 +3195,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/desktop/tauri-app/Cargo.toml
+++ b/desktop/tauri-app/Cargo.toml
@@ -20,3 +20,6 @@ serde_json = "1"
 [target."cfg(windows)".dependencies]
 parselnk = "0.1.1"
 winreg = "0.56.0"
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/desktop/tauri-app/src/lib.rs
+++ b/desktop/tauri-app/src/lib.rs
@@ -10,6 +10,8 @@ pub fn run() {
             steam::appinfo::read_local_app_metadata,
             steam::screenshots::read_local_screenshots,
             steam::screenshots::read_local_screenshot_bytes,
+            steam::librarycache::find_local_library_art,
+            steam::librarycache::read_local_library_art_bytes,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/tauri-app/src/steam/librarycache.rs
+++ b/desktop/tauri-app/src/steam/librarycache.rs
@@ -1,0 +1,258 @@
+//! Reads Steam's own rendered library-art cache from `appcache/librarycache/<appid>/` - see
+//! docs/plans/startup-artwork-resolution-plan.md, Root Cause D. Mirrors both on-disk conventions
+//! confirmed against a real install:
+//!
+//! - **legacy (flat)**: `<appid>/library_600x900.jpg`, `<appid>/header.jpg` - no hash, no
+//!   subfolder.
+//! - **hash-migrated**: `<appid>/<hash40>/library_600x900.jpg`,
+//!   `<appid>/<hash40>/library_header.jpg` - one hash-named subfolder per asset "slot", filenames
+//!   differ from the flat convention (`library_header.jpg`, not `header.jpg`). The hash is
+//!   byte-identical to the hash segment Steam's own CDN URLs use for the same asset (confirmed
+//!   against live `store.steampowered.com/api/appdetails` responses and direct CDN requests - see
+//!   the plan doc), so callers can build a real CDN URL from it without any network round trip.
+//!
+//! Only `library` (`library_600x900.jpg`) and `header` slots are wired up - `library_capsule.jpg`
+//! (hash-migrated only) is a different asset than the Store API's `capsule_image`/`capsule_imagev5`
+//! fields, unverified as anything else, and out of scope; `library_hero`/`logo`/the small root-level
+//! icon aren't rendered by anything yet.
+
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Identical filename in both conventions - only `header` differs by convention (see below).
+const LIBRARY_FILENAME: &str = "library_600x900.jpg";
+const HEADER_FLAT_FILENAME: &str = "header.jpg";
+const HEADER_HASHED_FILENAME: &str = "library_header.jpg";
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct LocalArtSlot {
+    /// Relative to `appcache/librarycache/<appid>/` - pass to `read_local_library_art_bytes`.
+    pub relative_path: String,
+    /// The hash-migrated convention's subfolder name - lets the caller construct a real CDN URL
+    /// without a second disk touch. Absent for the legacy flat convention (nothing to derive one
+    /// from).
+    pub hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct LocalLibraryArtEntry {
+    pub appid: u32,
+    pub library: Option<LocalArtSlot>,
+    pub header: Option<LocalArtSlot>,
+}
+
+fn librarycache_dir(steam_root: &Path) -> PathBuf {
+    steam_root.join("appcache").join("librarycache")
+}
+
+/// Batched discovery - one directory listing pass per candidate appid, no file reads. Only
+/// appids with at least one slot found are included in the result; absence is a free, instant
+/// "Steam's client never cached this one" signal, not worth a payload entry.
+#[tauri::command]
+pub fn find_local_library_art(appids: Vec<u32>) -> Result<Vec<LocalLibraryArtEntry>, String> {
+    let steam_root = super::paths::find_steam_root().ok_or("Steam install not found")?;
+    let base = librarycache_dir(&steam_root);
+    Ok(appids
+        .into_iter()
+        .filter_map(|appid| find_entry(&base, appid))
+        .collect())
+}
+
+fn find_entry(base: &Path, appid: u32) -> Option<LocalLibraryArtEntry> {
+    let appid_dir = base.join(appid.to_string());
+    if !appid_dir.is_dir() {
+        return None;
+    }
+
+    let library = find_slot(&appid_dir, LIBRARY_FILENAME, LIBRARY_FILENAME);
+    let header = find_slot(&appid_dir, HEADER_FLAT_FILENAME, HEADER_HASHED_FILENAME);
+
+    if library.is_none() && header.is_none() {
+        return None;
+    }
+
+    Some(LocalLibraryArtEntry { appid, library, header })
+}
+
+/// Checks the legacy flat filename first, then scans hash-named subfolders for the hash-migrated
+/// filename - see module doc for the two conventions.
+fn find_slot(appid_dir: &Path, flat_filename: &str, hashed_filename: &str) -> Option<LocalArtSlot> {
+    let flat_path = appid_dir.join(flat_filename);
+    if flat_path.is_file() {
+        return Some(LocalArtSlot { relative_path: flat_filename.to_string(), hash: None });
+    }
+
+    let entries = fs::read_dir(appid_dir).ok()?;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(hash) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !is_hash_dirname(hash) {
+            continue;
+        }
+        if path.join(hashed_filename).is_file() {
+            return Some(LocalArtSlot {
+                relative_path: format!("{hash}/{hashed_filename}"),
+                hash: Some(hash.to_string()),
+            });
+        }
+    }
+    None
+}
+
+/// Steam's asset-revision hashes observed on real installs are 40 lowercase hex characters
+/// (SHA1-shaped) - distinguishes an asset-slot subfolder from anything else that might exist
+/// under an appid's librarycache folder.
+fn is_hash_dirname(name: &str) -> bool {
+    name.len() == 40 && name.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// `relative_path` must be one returned by `find_local_library_art` (forward-slash-separated,
+/// relative to `appcache/librarycache/<appid>/`) - rejects any path containing `..` so this
+/// command can't be used to escape that folder, same guard `read_local_screenshot_bytes` uses for
+/// the same reason.
+#[tauri::command]
+pub fn read_local_library_art_bytes(appid: u32, relative_path: String) -> Result<Vec<u8>, String> {
+    if relative_path.contains("..") {
+        return Err(format!("rejected suspicious library art path: {relative_path}"));
+    }
+    let steam_root = super::paths::find_steam_root().ok_or("Steam install not found")?;
+    let path = librarycache_dir(&steam_root).join(appid.to_string()).join(&relative_path);
+    fs::read(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_fixture_file(path: &Path) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, b"fake jpeg bytes").unwrap();
+    }
+
+    #[test]
+    fn finds_legacy_flat_library_and_header() {
+        let dir = TempDir::new().unwrap();
+        write_fixture_file(&dir.path().join("440").join(LIBRARY_FILENAME));
+        write_fixture_file(&dir.path().join("440").join(HEADER_FLAT_FILENAME));
+
+        let entry = find_entry(dir.path(), 440).unwrap();
+        assert_eq!(entry.library, Some(LocalArtSlot {
+            relative_path: LIBRARY_FILENAME.to_string(),
+            hash: None,
+        }));
+        assert_eq!(entry.header, Some(LocalArtSlot {
+            relative_path: HEADER_FLAT_FILENAME.to_string(),
+            hash: None,
+        }));
+    }
+
+    #[test]
+    fn finds_hash_migrated_library_and_header() {
+        let dir = TempDir::new().unwrap();
+        let library_hash = "b6cabe1940c55119820eee4ed2d0b604bd5b3af4";
+        let header_hash = "a157aa8de4bd9070194ddffb27c31636355dca05";
+        write_fixture_file(&dir.path().join("2062430").join(library_hash).join(LIBRARY_FILENAME));
+        write_fixture_file(&dir.path().join("2062430").join(header_hash).join(HEADER_HASHED_FILENAME));
+
+        let entry = find_entry(dir.path(), 2062430).unwrap();
+        assert_eq!(entry.library, Some(LocalArtSlot {
+            relative_path: format!("{library_hash}/{LIBRARY_FILENAME}"),
+            hash: Some(library_hash.to_string()),
+        }));
+        assert_eq!(entry.header, Some(LocalArtSlot {
+            relative_path: format!("{header_hash}/{HEADER_HASHED_FILENAME}"),
+            hash: Some(header_hash.to_string()),
+        }));
+    }
+
+    #[test]
+    fn prefers_flat_over_hash_dir_when_both_somehow_present() {
+        let dir = TempDir::new().unwrap();
+        let hash = "b6cabe1940c55119820eee4ed2d0b604bd5b3af4";
+        write_fixture_file(&dir.path().join("10").join(LIBRARY_FILENAME));
+        write_fixture_file(&dir.path().join("10").join(hash).join(LIBRARY_FILENAME));
+
+        let entry = find_entry(dir.path(), 10).unwrap();
+        assert_eq!(entry.library.unwrap().hash, None);
+    }
+
+    #[test]
+    fn returns_none_for_appid_with_no_cached_art_at_all() {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join("999")).unwrap();
+        assert_eq!(find_entry(dir.path(), 999), None);
+    }
+
+    #[test]
+    fn returns_none_for_appid_dir_that_does_not_exist() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(find_entry(dir.path(), 12345), None);
+    }
+
+    #[test]
+    fn only_header_present_leaves_library_none() {
+        let dir = TempDir::new().unwrap();
+        write_fixture_file(&dir.path().join("10600").join(HEADER_FLAT_FILENAME));
+
+        let entry = find_entry(dir.path(), 10600).unwrap();
+        assert!(entry.library.is_none());
+        assert!(entry.header.is_some());
+    }
+
+    #[test]
+    fn ignores_non_hash_shaped_subfolders() {
+        let dir = TempDir::new().unwrap();
+        // A stray non-hash directory (e.g. some other Steam-internal folder shape) should never
+        // be mistaken for an asset-slot subfolder.
+        write_fixture_file(&dir.path().join("55").join("not-a-hash").join(LIBRARY_FILENAME));
+        assert_eq!(find_entry(dir.path(), 55), None);
+    }
+
+    #[test]
+    fn rejects_traversal_in_relative_path() {
+        let err = read_local_library_art_bytes(440, "../../../etc/passwd".to_string()).unwrap_err();
+        assert!(err.contains("rejected"));
+    }
+
+    /// Real-machine check - `#[ignore]`d by default. Discovers the Steam root at test time
+    /// rather than hardcoding a path, and only asserts on games that are actually present in a
+    /// local `find_local_library_art` result rather than any specific appid.
+    #[test]
+    #[ignore]
+    fn reads_real_library_art_on_this_machine() {
+        let steam_root = super::super::paths::find_steam_root().expect("expected a Steam install on this dev machine");
+        let base = librarycache_dir(&steam_root);
+        let entries: Vec<u32> = fs::read_dir(&base)
+            .expect("expected a readable librarycache dir")
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.file_name().to_str()?.parse::<u32>().ok())
+            .collect();
+        assert!(!entries.is_empty(), "expected at least one cached appid on this machine");
+
+        let found = find_local_library_art(entries.clone()).expect("expected a successful scan");
+        assert!(!found.is_empty(), "expected at least one appid with a library or header slot");
+
+        let with_library: usize = found.iter().filter(|e| e.library.is_some()).count();
+        let with_header: usize = found.iter().filter(|e| e.header.is_some()).count();
+        println!(
+            "Scanned {} appids: {} had a library slot, {} had a header slot",
+            entries.len(), with_library, with_header
+        );
+
+        let first_with_library = found.iter().find(|e| e.library.is_some()).expect("expected at least one library slot");
+        let slot = first_with_library.library.as_ref().unwrap();
+        let bytes = read_local_library_art_bytes(first_with_library.appid, slot.relative_path.clone())
+            .expect("expected to read the first discovered library art's bytes");
+        assert!(!bytes.is_empty());
+        // JPEG magic bytes - every library_600x900.jpg observed on this machine was a .jpg.
+        assert_eq!(&bytes[0..2], &[0xFF, 0xD8], "expected a JPEG file");
+        println!("Read {} bytes for appid {}", bytes.len(), first_with_library.appid);
+    }
+}

--- a/desktop/tauri-app/src/steam/librarycache.rs
+++ b/desktop/tauri-app/src/steam/librarycache.rs
@@ -116,14 +116,24 @@ fn is_hash_dirname(name: &str) -> bool {
 /// relative to `appcache/librarycache/<appid>/`) - rejects any path containing `..` so this
 /// command can't be used to escape that folder, same guard `read_local_screenshot_bytes` uses for
 /// the same reason.
+///
+/// Returns a raw `tauri::ipc::Response`, not `Vec<u8>` directly - a plain `Vec<u8>` return goes
+/// over Tauri's default JSON IPC as an array of numbers (confirmed as a real, measured bottleneck:
+/// this command runs on a genuinely hot path, up to one call per placed game box per session, and
+/// JSON-encoding/decoding a ~50-90KB JPEG as a comma-separated number array is dramatically more
+/// expensive than the disk read itself - see docs/plans/startup-artwork-resolution-plan.md).
+/// `Response` sends the bytes as a raw ArrayBuffer instead, same idiom LocalScreenshotReader.ts's
+/// own doc comment already flagged this concern for (screenshots stayed on JSON IPC deliberately -
+/// small N, loaded once - this command doesn't have that luxury).
 #[tauri::command]
-pub fn read_local_library_art_bytes(appid: u32, relative_path: String) -> Result<Vec<u8>, String> {
+pub fn read_local_library_art_bytes(appid: u32, relative_path: String) -> Result<tauri::ipc::Response, String> {
     if relative_path.contains("..") {
         return Err(format!("rejected suspicious library art path: {relative_path}"));
     }
     let steam_root = super::paths::find_steam_root().ok_or("Steam install not found")?;
     let path = librarycache_dir(&steam_root).join(appid.to_string()).join(&relative_path);
-    fs::read(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))
+    let bytes = fs::read(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    Ok(tauri::ipc::Response::new(bytes))
 }
 
 #[cfg(test)]
@@ -217,8 +227,11 @@ mod tests {
 
     #[test]
     fn rejects_traversal_in_relative_path() {
-        let err = read_local_library_art_bytes(440, "../../../etc/passwd".to_string()).unwrap_err();
-        assert!(err.contains("rejected"));
+        // Not unwrap_err() - tauri::ipc::Response (the Ok side) doesn't implement Debug.
+        match read_local_library_art_bytes(440, "../../../etc/passwd".to_string()) {
+            Err(err) => assert!(err.contains("rejected")),
+            Ok(_) => panic!("expected the traversal attempt to be rejected"),
+        }
     }
 
     /// Real-machine check - `#[ignore]`d by default. Discovers the Steam root at test time
@@ -248,8 +261,13 @@ mod tests {
 
         let first_with_library = found.iter().find(|e| e.library.is_some()).expect("expected at least one library slot");
         let slot = first_with_library.library.as_ref().unwrap();
-        let bytes = read_local_library_art_bytes(first_with_library.appid, slot.relative_path.clone())
+        let response = read_local_library_art_bytes(first_with_library.appid, slot.relative_path.clone())
             .expect("expected to read the first discovered library art's bytes");
+        let body = tauri::ipc::IpcResponse::body(response).expect("expected a readable response body");
+        let bytes = match body {
+            tauri::ipc::InvokeResponseBody::Raw(bytes) => bytes,
+            tauri::ipc::InvokeResponseBody::Json(_) => panic!("expected a raw byte response, got JSON"),
+        };
         assert!(!bytes.is_empty());
         // JPEG magic bytes - every library_600x900.jpg observed on this machine was a .jpg.
         assert_eq!(&bytes[0..2], &[0xFF, 0xD8], "expected a JPEG file");

--- a/desktop/tauri-app/src/steam/mod.rs
+++ b/desktop/tauri-app/src/steam/mod.rs
@@ -2,6 +2,7 @@ pub mod appinfo;
 pub mod collections;
 pub mod identity;
 pub mod keyvalues;
+pub mod librarycache;
 pub mod localization;
 pub mod paths;
 pub mod playtime;

--- a/docs/plans/release-pipeline-plan.md
+++ b/docs/plans/release-pipeline-plan.md
@@ -2,7 +2,7 @@
 
 **Parent features**: [Static Hosting](../features/static-hosting.md) · [Native Desktop App](../features/desktop-app.md)
 **Act**: 2
-**Status**: 🟢 Steps 1-2 and 2.5 implemented and run end-to-end. `scripts/release.sh` (`fetch_s3_cache` → `scripts/repack-steam-cache.sh`) pulls raw S3 objects and repacks them into one client-ready bundle: `app-details.json.gz` (1361 games, ~3.4 MiB), via single-corpus compression + tier dedup. Client-side consumption (`BakedCacheLoader`) implemented and wired into `SteamApiClient`. Step 2.5 (`bake_f2p_artwork` → `scripts/bake-f2p-artwork.sh`) filters `is_free == true` from that bundle itself, bakes F2P artwork, and writes an `undesirable_for_demo` flag back onto any appid whose artwork 404'd — see [F2P Artwork Bake](f2p-artwork-bake-plan.md). (2026-07-12: the earlier F2P/rest bundle split was removed — see "Split" section below, superseded.) Steps 3-5 (build/pack) still stubbed. **Step 2.4 proposed 2026-07-29, design decided, not yet implemented** — folding desktop-discovered dead-artwork-URLs and local-librarycache-derived real URLs back into the baked bundle (runs before Step 2.5, which now prefers a folded-in real URL over its own guess), developer-workflow scope for now: dev-build-only (`#[cfg(debug_assertions)]` + `import.meta.env.DEV`, absent entirely from release builds), triggered manually from a settings-menu action rather than running automatically. See section below.
+**Status**: 🟢 Steps 1-2 and 2.5 implemented and run end-to-end. `scripts/release.sh` (`fetch_s3_cache` → `scripts/repack-steam-cache.sh`) pulls raw S3 objects and repacks them into one client-ready bundle: `app-details.json.gz` (1361 games, ~3.4 MiB), via single-corpus compression + tier dedup. Client-side consumption (`BakedCacheLoader`) implemented and wired into `SteamApiClient`. Step 2.5 (`bake_f2p_artwork` → `scripts/bake-f2p-artwork.sh`) filters `is_free == true` from that bundle itself, bakes F2P artwork, and writes an `undesirable_for_demo` flag back onto any appid whose artwork 404'd — see [F2P Artwork Bake](f2p-artwork-bake-plan.md). (2026-07-12: the earlier F2P/rest bundle split was removed — see "Split" section below, superseded.) Steps 3-5 (build/pack) still stubbed. **Step 2.4 proposed 2026-07-29, design decided, not yet implemented** — folding desktop-discovered dead-artwork-URLs and local-librarycache-derived real URLs back into the baked bundle (runs before Step 2.5, which now prefers a folded-in real URL over its own guess), developer-workflow scope for now: present in every desktop build (dev and release alike, gated on `isTauri()` so it doesn't render on web, not on build mode), triggered manually from a settings-menu action rather than running automatically. See section below.
 
 ## Why this exists (the actual goal)
 
@@ -101,27 +101,29 @@ over a guess, full stop. `bake-f2p-artwork.sh`'s per-appid loop needs a correspo
 `.data.artwork.library` first, only fall back to the existing guess-and-download behavior when
 that's absent.
 
-### Dev-only, manually triggered — not automatic, not present in release builds (decided 2026-07-29)
+### Manually triggered, in every desktop build — gated on Tauri presence, not dev/release (revised 2026-07-29)
 
-This whole mechanism only exists for the developer gathering data ahead of a release — never for
-an end user's shipped copy of the app. Two gates, not one, so a release build simply has nothing
-to accidentally run:
+**Reversed from the original "dev-build-only" decision** (same day): both files are safe to
+produce in a release build too — the dead-paths file is a pure local IndexedDB read (no network at
+all), and the library-URL export is already rate-limited and only ever runs when the user
+deliberately clicks it, so there's nothing "release builds need protecting from" the way there
+would be for something that ran automatically. No `#[cfg(debug_assertions)]`, no
+`import.meta.env.DEV` — the command exists and the settings-menu entry can render in every desktop
+build.
 
-- **Rust side**: the write/validate command(s) are `#[cfg(debug_assertions)]`-gated (same idiom
-  `main.rs` already uses for the Windows console subsystem) — the capability doesn't exist in the
-  compiled release binary at all, not just "exists but is hidden."
-- **TS side**: the settings-menu entry that triggers it is gated behind `import.meta.env.DEV`
-  (Vite's build-mode flag — already the established convention, see `AppSettings.ts`'s
-  `getDefaultSettings()`, chosen there specifically so prod/dev behavior is "tied to the build, not
-  a runtime hostname check").
+**Still needs a real gate, just a different one**: the settings-menu action only makes sense on the
+desktop (Tauri) build at all — the web build has no `invoke()`, no local Steam install to read, and
+no filesystem to write a contribution file to. A button that's visible but does nothing (or throws)
+on web would be worse than no button. Gated on **`isTauri()`** — the exact idiom
+`LocalSteamLibraryLoader.ts`/`LocalSteamDataWriter.ts` already use for "can this process actually
+make Tauri calls," not a build-mode flag — so the entry **doesn't render at all** on web, present
+on both dev and release desktop builds. Reuses an existing pattern rather than inventing a new one.
 
-Runs **on demand from a settings-menu action**, not automatically on every local-scan — the
-earlier design (queue validation checks the moment `find_local_library_art` discovers a new
-candidate, every session) would mean network calls firing passively just from normal use, which is
-exactly the "not blast a bunch of requests" concern this is trying to avoid, not just at any single
-moment but as standing background behavior. A manual trigger means the developer decides when to
-spend that budget, and there's no automatic code path left for a release build to need disabling in
-the first place — belt and suspenders with the two gates above.
+Still runs **on demand from a settings-menu action**, not automatically on every local-scan — the
+earlier automatic-queue design would mean network calls firing passively just from normal use,
+which is exactly the "not blast a bunch of requests" concern this is trying to avoid as standing
+background behavior, not a one-time cost. A manual trigger means whoever's using the desktop build
+decides when to spend that budget.
 
 ### Two separate contribution files, both exported on demand (decided 2026-07-29)
 
@@ -192,11 +194,11 @@ Resolved via Tauri's own `app_handle.path().app_data_dir()` (Tauri v2's official
 path API), the same spirit as `paths.rs`'s existing "resolve, don't hardcode" approach to finding
 *Steam's* install — except here it's our own app's data dir, which Tauri already knows how to
 locate on any OS without any manual path construction. No in-app affordance to reveal the path
-(considered, rejected) — this is a development-time concern for whoever is running the dev build,
-not something an end user (who won't have this feature at all — see release-build gating above)
-ever needs surfaced. First command in `desktop/tauri-app/src/steam/` that needs an `AppHandle`
-parameter — every existing command is a plain argument-less-or-appid-only function; worth noting
-as a small new pattern for this module, not just "another command."
+(considered, rejected) — whoever clicks the settings-menu action to gather contribution data
+already knows this is a desktop-app-data-dir concept and can find it the normal way for their OS;
+doesn't need it surfaced inside the app. First command in `desktop/tauri-app/src/steam/` that needs
+an `AppHandle` parameter — every existing command is a plain argument-less-or-appid-only function;
+worth noting as a small new pattern for this module, not just "another command."
 
 ### Bake-time fold-in
 

--- a/docs/plans/startup-artwork-resolution-plan.md
+++ b/docs/plans/startup-artwork-resolution-plan.md
@@ -309,9 +309,10 @@ all — never written as a trusted `artwork.library`/`artwork.header` value on s
 [Release Pipeline Step 2.4](release-pipeline-plan.md#step-24-proposed-2026-07-29-folding-in-desktop-discovered-contributions)
 for the validation queue design (rate-limited, skips hashes already validated, writes the merge on
 success and a normal `markArtworkPathDead` entry on failure) — that section owns this mechanism
-now, since it's shared with the contribution-file write. Dev-build-only, triggered manually from a
-settings-menu action rather than running automatically as part of the local scan — not something
-that fires just from normal app usage. This is also the concrete mechanism for
+now, since it's shared with the contribution-file write. Triggered manually from a settings-menu
+action (present in every desktop build, gated on `isTauri()` so it doesn't render on web) rather
+than running automatically as part of the local scan — not something that fires just from normal
+app usage. This is also the concrete mechanism for
 the earlier "how do we get real artwork paths into the baked/S3 cache" question — a validated
 merge into `AppDetailsCache` benefits this session immediately, and the same discovery, written to
 `data/contributions/library-art-urls.ndjson`, is what Step 2.4's bake-time fold-in picks up for

--- a/docs/plans/startup-artwork-resolution-plan.md
+++ b/docs/plans/startup-artwork-resolution-plan.md
@@ -11,10 +11,21 @@ public contract for debug-logging purposes alone — this happened twice in one 
 (`PixelDataCache.logStatsSummary`, then `AppDetailsCache.getDeadArtworkPathStats`), both reverted.
 Use ephemeral/inline code for one-off diagnostics, or the existing console-command idiom
 (`registerConsoleCommands()` in `LodArtworkOrchestratorDebug.ts`) if something needs to be
-repeatable; don't grow the cache class's API surface for it. Local `librarycache` disk read
-(Problem 2's actual fix, not a stopgap) has a build plan proposed 2026-07-29, awaiting sign-off
-(see new section under Root Cause D, below) — not yet implemented. Concurrency cap not started.
-Iterate on this doc as each piece resolves.
+repeatable; don't grow the cache class's API surface for it. **Local `librarycache` disk read
+implemented and field-confirmed 2026-07-31** (Problem 2's actual fix, not a stopgap) — PR #149,
+scoped deliberately to just the disk read (`find_local_library_art`/`read_local_library_art_bytes`,
+wired into `GameArtworkProvider`/`GameArtworkRequest`, registered from `SteamIntegration.applyLibrary()`
+so it runs regardless of which startup-waterfall source supplies the library). Two bugs caught and
+fixed against real sessions during that same pass: the registration call originally lived where the
+common cache-hit path never reached it (fixed in `91d31d85`), and the bytes command initially
+returned `Vec<u8>` over Tauri's default JSON IPC, which measurably dominated startup time once it
+ran per placed game box - fixed by switching to a raw `tauri::ipc::Response` (`d7cf5945`). Dead-path
+skip separately reconfirmed against the same session: 56/56 failed resolutions fully skipped via
+the known-dead cache, zero wasted network attempts. **Concurrency cap is real, not yet started** -
+see Root Cause B and Open Question 4, below, both updated 2026-07-31 with a concrete finding
+(`GameArtworkProvider` funnels every decode, local or network, through a single shared
+`TextureWorker` with no pool) and a new requirement (distance-to-player priority). Deliberately the
+next PR, not bundled into this one. Iterate on this doc as each piece resolves.
 **Related**: [`cors-blocked-local-scan-artwork`](../tech-debt.md#id-cors-blocked-local-scan-artwork)
 (the tech-debt entry this plan supersedes/absorbs), [Image/Texture Pipeline](../architecture/image-texture-pipeline.md),
 [Desktop Offline-First Plan](desktop-offline-first-plan.md), [Multi-Layer Caching](../features/multi-layer-caching.md)
@@ -127,6 +138,29 @@ each of which checks `PixelDataCache` then, on miss, round-trips through the sin
 `TextureWorker`. The 972-peak-concurrency, 592ms-median-for-successes numbers above are the direct
 result — even a disk-cache-eligible fetch is competing in the same unthrottled scrum as everything
 else, including guesses that are about to burn a real (if fast) failed round trip.
+
+**Confirmed 2026-07-31, after local-disk read landed (PR #149) and a real session still showed a
+~35s stall between placement and completion**: `GameArtworkProvider` holds exactly one
+`TextureWorker`, which wraps exactly one `Worker` (`ManagedWorker` has no pooling - checked its
+source directly). Every image decode - local disk *or* network, doesn't matter which - funnels
+through that single worker's serial message queue, processed one at a time. This is the actual
+mechanism behind "stall then accelerate," a better match than network concurrency for the
+"starved thread pool" symptom this whole investigation started from: hundreds of requests fire at
+once (per the no-cap behavior above), but they all queue up behind one thread's `onmessage` loop
+regardless of how fast the underlying bytes arrived. Local-disk reads made the *bytes* fast; they
+didn't touch the *decode* bottleneck at all.
+
+Also noted in the same pass: `PixelDataCache` keys lookups by exact size (`@{width}x{height}`), so
+a MID-tier request and a later HIGH-tier request for the same source image never share a decode -
+each pays its own full read + JPEG-decode + canvas-readback, even though decoding once at native
+resolution and resizing down for the smaller tier would be cheaper. Pre-existing pattern (present
+in the network path already; the local-disk path just inherited it), not introduced by PR #149,
+but worth fixing alongside the worker pool since both live in the same code path.
+
+**New requirement, 2026-07-31**: whatever replaces the no-cap/no-priority behavior above must
+prioritize games nearest the player - those should be scheduled first, not just whichever games
+happen to iterate first in `prefetchBatch()`'s loop. Distinct axis from the disk-vs-network
+priority split already noted in Open Question 4 below; both apply.
 
 ### C. `PixelDataCache`'s actual purpose, and real numbers on its startup role (Problem 3) — measured 2026-07-25, root cause identified, not yet fixed
 
@@ -437,12 +471,10 @@ existing AppDetailsCache TTL gap, not duplicated here.)
 `findMissingArtwork()` requires both a fetchable URL to exist *and* the entry to lack
 `artwork_network_checked`, per the note left here during review.
 
-1. **Tauri-side read for the local `librarycache` folder — the priority to circle back to soon.**
-   **Build plan proposed 2026-07-29** — see the new section under Root Cause D, above. Awaiting
-   sign-off before implementation. Explicitly the fix that matters most: field observation from
-   this pass is that a real share of titles either have no artwork at all, or don't have it at the
-   paths we predict — this is the one piece that replaces guessing with a deterministic answer
-   instead of managing guesses better, and is what everything else in this doc is a stopgap around.
+1. ~~Tauri-side read for the local `librarycache` folder~~ **Resolved 2026-07-31** — implemented,
+   field-tested, and confirmed against real sessions (PR #149): 999/1845 cached appids on the test
+   machine have a library slot; local reads verifiably engage (native 600×900 decode signature);
+   the JSON-IPC transport bug that briefly made things *slower* than before this landed is fixed.
 2. ~~URL-key normalization for `PixelDataCache` / `artwork_dead_paths`~~ **Resolved 2026-07-29** —
    `UrlUtils.stripQueryParam(url, 't')`, applied at both `PixelDataCache`'s cache-key construction
    (`GameArtworkProvider.fetchPixels`/`isPixelsCached`) and `artwork_dead_paths`'
@@ -456,10 +488,20 @@ existing AppDetailsCache TTL gap, not duplicated here.)
    folded-in real URL over its own guess) — developer-workflow scope for now (a developer copies
    the files in manually before a release), not a live end-user submission pipeline. Answers this
    session's earlier "how do we get real artwork paths into the baked cache" question concretely.
-4. **Concurrency cap shape**: a semaphore-style limit on `ArtworkPrefetchCoordinator.prefetchBatch`,
-   a priority split (disk-cache-eligible games placed before any network-bound ones queue), or
-   both. Deliberately not designed yet — item 1 (local disk read) changes what "cache-eligible"
-   even means on desktop, so this should follow that, not precede it.
+4. **Concurrency cap shape — now the actual priority, explicitly the next PR/changeset, not
+   bundled into #149.** Local disk read landing changed what "cache-eligible" means on desktop
+   (item 1, resolved) and surfaced the real bottleneck underneath it (see Root Cause B's
+   2026-07-31 update): a single shared `TextureWorker` serializing every decode, local or network,
+   with no pool. Scope for that next pass:
+   - A small worker pool (not just one `TextureWorker`) so decode work actually parallelizes
+     across cores instead of queueing on one thread.
+   - A semaphore-style concurrency cap in front of `ArtworkPrefetchCoordinator.prefetchBatch`.
+   - **Priority order, two axes**: disk-cache-eligible games ahead of network-bound ones (already
+     noted), *and*, new 2026-07-31, games nearest the player scheduled first within whatever tier
+     they fall into - not just iteration order.
+   - Fix `PixelDataCache`'s per-exact-size keying so a MID request doesn't force its own full
+     decode when a HIGH decode of the same source either already happened or will (Root Cause B's
+     2026-07-31 note).
 ~~`artwork_dead_paths` baked-bundle half~~ **Resolved by the 2026-07-25 rework** — living on
 `AppDetailsData` means the bake/repack scripts pick it up automatically, the same way they already
 pick up every other field on that type. No separate mechanism needed.
@@ -489,11 +531,13 @@ dimensions, rather than any image over 300px wide).
 - [x] Field-test the dead-path mechanism against a real session — confirmed working, ephemeral
       logging reverted afterward (see Decisions, above)
 - [x] Normalize the `PixelDataCache`/`artwork_dead_paths` cache key (strip `?t=`) — Root cause C
-- [ ] Get sign-off on, then implement, the Tauri local `librarycache` read + CDN URL discovery
-      build plan (Root cause D) — the actual priority; everything else here is a stopgap around
-      not having this yet
-- [ ] Scope the concurrency cap / priority split for `ArtworkPrefetchCoordinator`, after the local
-      disk read above changes the baseline
+- [x] Implement the Tauri local `librarycache` read (Root cause D) — PR #149, field-confirmed
+      2026-07-31 (999/1845 appids have a library slot; dead-path skip separately reconfirmed at
+      56/56 in the same session). CDN URL discovery/validation (Deliverable 2 of the build plan)
+      not included in #149 — still open, not yet scheduled.
+- [ ] **Next PR/changeset**: worker pool + concurrency cap + priority queue for
+      `ArtworkPrefetchCoordinator` (see Root Cause B and Open Question 4, both updated 2026-07-31).
+      Must prioritize by distance to player, not just iteration order.
 - [ ] Scope the one-time bake-time backfill avenue (now simpler — dead paths discovered live
       already land somewhere the bake pipeline can read back); partly overlaps the local
       librarycache plan's out-of-scope shared-cache-push item — scope together


### PR DESCRIPTION
## Summary

Steam's own client already renders and caches `library_600x900.jpg`/`header.jpg` for every
game it's shown in the Library grid, at `appcache/librarycache/<appid>/...` (both a legacy
flat layout and a newer hash-per-asset-slot layout). This PR reads that cache directly on
the desktop build, ahead of any network guess or hint-based fetch — zero network cost for
any game Steam has already cached, and a deterministic answer instead of a guessed CDN path
for `library` art, which the Steam Store API has no field for at all.

- **Rust**: `find_local_library_art` (batched discovery, one directory-listing pass) and
  `read_local_library_art_bytes` (lazy, `..`-guarded) in a new `librarycache.rs`, following
  `screenshots.rs`'s established two-command shape. Returns bytes via `tauri::ipc::Response`
  (raw `ArrayBuffer`), not JSON — a plain `Vec<u8>` return measurably dominated startup time
  once this ran per placed game box (fixed after catching it against a real session).
- **Client**: `GameArtworkProvider` gets a local-scan-populated index and
  `fetchPixelsFromLocalDisk`, checked by `GameArtworkRequest` ahead of the cached-selection
  and URL-strategy paths. Registration happens from `SteamIntegration.applyLibrary()` — the
  one call site every startup-waterfall source (persisted cache, fresh local scan, online)
  funnels through — after an earlier version that only ran on a fresh local scan silently
  never fired for a returning user's much more common cache-hit path.
- **Field-confirmed against real desktop sessions**, not just unit tests: 999/1845 cached
  appids on the test machine have a `library` slot, local reads verifiably engage (native
  600×900 decode signature vs. the CDN's 300×450), and the existing dead-path skip mechanism
  was reconfirmed at 56/56 (100%) known-dead resolutions fully skipped with zero live network
  attempts.
- Also includes some adjacent work from the same investigation: `UrlUtils.stripQueryParam`
  fixing a `PixelDataCache`/`artwork_dead_paths` cache-key instability bug (Steam's hint URLs
  carry a rotating `?t=` timestamp), a narrower "High-res CDN image" debug check + log
  aggregation, and the release-pipeline plan for folding future desktop-discovered
  contributions (dead paths, validated local-art URLs) back into the baked bundle.

## Explicitly out of scope for this PR

Investigating the still-slow startup after this landed surfaced the *next* bottleneck:
`GameArtworkProvider` funnels every texture decode — local or network — through one shared
`TextureWorker` with no pool, and `ArtworkPrefetchCoordinator` fires every game's prefetch
with no concurrency cap or priority order. That's real, but scoped as its own follow-up PR
(worker pool + concurrency cap + priority-by-distance-to-player), not bundled in here. See
`docs/plans/startup-artwork-resolution-plan.md` (Root Cause B) for the write-up.

## Test plan

- [x] `cargo test --lib` (Rust, including the `#[ignore]`'d real-machine test against this
      dev machine's actual Steam install)
- [x] `yarn tsc` clean
- [x] `yarn vitest run test/unit` — full suite green
- [x] Verified against two real desktop sessions (logs reviewed for local-disk-read
      engagement, dead-path skip rate, and startup timing)