### PR TITLE
Replace hand-rolled batch-fetch circuit breaker with cockatiel

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "cockatiel": "^4.0.0",
     "n8ao": "^1.10.2",
     "postprocessing": "^6.39.1",
     "three": "^0.183.2"

--- a/client/src/steam/batch/BatchAppDetailsClient.ts
+++ b/client/src/steam/batch/BatchAppDetailsClient.ts
@@ -105,15 +105,52 @@ export interface BatchAppDetailsResult {
 
 import { Logger } from '../../utils/Logger'
 import { PerformanceMonitor, ASYNC_CONTEXT } from '../../utils/PerformanceMonitor'
+import { circuitBreaker, CircuitState, ConsecutiveBreaker, ExponentialBackoff, handleAll, isBrokenCircuitError, type CircuitBreakerPolicy } from 'cockatiel'
+
+/**
+ * A single 503 from our own Lambda (each failure here already costs a real ~30s round trip -
+ * see fetchSingleBatch's timeout comment) is a clear enough "the backend is unhealthy right now"
+ * signal on its own - no need to pay for a second confirming failure before we stop hammering it.
+ */
+const CIRCUIT_BREAKER_CONSECUTIVE_FAILURES_TO_OPEN = 1;
+/** First retry probe 10s after opening; doubles each further consecutive break, capped at 5min. */
+const CIRCUIT_BREAKER_INITIAL_HALF_OPEN_DELAY_MS = 10_000;
+const CIRCUIT_BREAKER_MAX_HALF_OPEN_DELAY_MS = 5 * 60_000;
 
 export class BatchAppDetailsClient {
     private static readonly logger = Logger.createLogFunctions(BatchAppDetailsClient.name)
     private apiBaseUrl: string;
     private eventManager: EventManager;
+    /**
+     * Shared across every fetchBatch() call on this instance (per cockatiel's own guidance - a
+     * circuit breaker only works if it's reused, not recreated per call) so that once this
+     * backend is known to be unhealthy, later calls in the same session (a manual library
+     * reload, another game's gap-fill) skip straight to failing fast instead of re-discovering
+     * the same outage at full latency cost.
+     */
+    private readonly circuitBreaker: CircuitBreakerPolicy;
 
     constructor(apiBaseUrl: string = 'https://steam-api-dev.wehrly.com', eventManager?: EventManager) {
         this.apiBaseUrl = apiBaseUrl;
         this.eventManager = eventManager || EventManager.getInstance();
+
+        this.circuitBreaker = circuitBreaker(handleAll, {
+            breaker: new ConsecutiveBreaker(CIRCUIT_BREAKER_CONSECUTIVE_FAILURES_TO_OPEN),
+            halfOpenAfter: new ExponentialBackoff({
+                initialDelay: CIRCUIT_BREAKER_INITIAL_HALF_OPEN_DELAY_MS,
+                maxDelay: CIRCUIT_BREAKER_MAX_HALF_OPEN_DELAY_MS,
+            }),
+        });
+        this.circuitBreaker.onBreak(reason => {
+            const detail = 'error' in reason ? String(reason.error) : `isolated`;
+            BatchAppDetailsClient.logger.warn(`Circuit OPEN for ${this.apiBaseUrl} - backend appears unhealthy (${detail}), skipping further requests until it self-heals`);
+        });
+        this.circuitBreaker.onHalfOpen(() => {
+            BatchAppDetailsClient.logger.info(`Circuit HALF-OPEN for ${this.apiBaseUrl} - probing whether the backend has recovered`);
+        });
+        this.circuitBreaker.onReset(() => {
+            BatchAppDetailsClient.logger.info(`Circuit CLOSED for ${this.apiBaseUrl} - backend has recovered, resuming normal requests`);
+        });
     }
 
     /**
@@ -146,19 +183,20 @@ export class BatchAppDetailsClient {
         }
 
         let totalFetched = 0;
-        let consecutiveFailures = 0;
         let lastBatchDuration: number; // Track response time for adaptive delays
-        const MAX_CONSECUTIVE_FAILURES = 3; // Circuit breaker threshold
         const FAST_RESPONSE_THRESHOLD = 2000; // If batch returns in <2s, it's mostly cached
 
         // Process batches sequentially to respect rate limits
         for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
-            // Circuit breaker: stop if too many consecutive failures
-            if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
-                console.error(`🚨 [BatchAppDetails] Circuit breaker triggered after ${consecutiveFailures} consecutive failures. Stopping batch processing.`);
+            // Check before announcing/attempting a batch, not just in the catch block below - an
+            // already-open circuit (this call's own earlier failure, or a still-open break from a
+            // prior fetchBatch() call on this instance) means every remaining batch is doomed;
+            // don't log "Starting batch N" for one we already know we won't attempt.
+            if (this.circuitBreaker.state === CircuitState.Open || this.circuitBreaker.state === CircuitState.Isolated) {
+                BatchAppDetailsClient.logger.warn(`Skipping ${batches.length - batchIndex} remaining batch(es) - circuit is open for ${this.apiBaseUrl}`);
                 break;
             }
-            
+
             const batch = batches[batchIndex];
             const batchMonitor = PerformanceMonitor.start('network-batch', BatchAppDetailsClient.logger, ASYNC_CONTEXT)
             
@@ -172,7 +210,7 @@ export class BatchAppDetailsClient {
             });
             
             try {
-                const batchResult = await this.fetchSingleBatch(batch);
+                const batchResult = await this.circuitBreaker.execute(() => this.fetchSingleBatch(batch));
                 lastBatchDuration = batchMonitor.getElapsed();
                 
                 // Process successful results
@@ -210,29 +248,23 @@ export class BatchAppDetailsClient {
                     BatchAppDetailsClient.logger.warn(`Batch ${batchIndex + 1} had ${batchResult.failed.length} failures: ${batchResult.failed.map(f => `${f.appid}: ${f.error}`).join(', ')}`)
                 }
 
-                consecutiveFailures = 0; // Reset on success
-
                 // Adaptive delay: skip delay if responses are fast (cached), add delay if slow (uncached)
                 if (batchIndex < batches.length - 1) {
-                    if (lastBatchDuration < FAST_RESPONSE_THRESHOLD) {
-                        // Fast response = mostly cached, minimal delay needed
-                        await new Promise(resolve => setTimeout(resolve, 50));
-                    } else {
-                        // Slow response = uncached API calls, add backoff delay
-                        const baseDelay = 200;
-                        const backoffDelay = Math.min(baseDelay * Math.pow(1.5, consecutiveFailures), 2000);
-                        await new Promise(resolve => setTimeout(resolve, backoffDelay));
-                    }
+                    const delay = lastBatchDuration < FAST_RESPONSE_THRESHOLD ? 50 : 200;
+                    await new Promise(resolve => setTimeout(resolve, delay));
                 }
 
             } catch (error) {
-                consecutiveFailures++;
+                if (isBrokenCircuitError(error)) {
+                    // The breaker already opened from an earlier failure (this run or a prior
+                    // one on this same client instance) - don't burn another ~30s round trip on
+                    // a request we already know the backend will fail. Whatever's left in
+                    // `appids` stays unresolved this call; the breaker's own half-open probe
+                    // (see constructor) is what retries later, not this loop.
+                    BatchAppDetailsClient.logger.warn(`Stopping batch processing - circuit is open for ${this.apiBaseUrl}, ${batches.length - batchIndex} batch(es) skipped`);
+                    break;
+                }
                 BatchAppDetailsClient.logger.error(`Batch ${batchIndex + 1} failed: ${String(error)}`)
-                
-                // Exponential backoff on failure (max 5 seconds)
-                const backoffDelay = Math.min(1000 * Math.pow(2, consecutiveFailures - 1), 5000);
-                BatchAppDetailsClient.logger.debug(`Waiting ${backoffDelay}ms before next batch due to failure...`)
-                await new Promise(resolve => setTimeout(resolve, backoffDelay));
             }
         }
 

--- a/client/test/unit/steam/batch/BatchAppDetailsClient.test.ts
+++ b/client/test/unit/steam/batch/BatchAppDetailsClient.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setupFetchMock } from '../../../utils/test-helpers'
+import { BatchAppDetailsClient, type BatchAppDetailsResult } from '../../../../src/steam/batch/BatchAppDetailsClient'
+import { EventManager } from '../../../../src/core/EventManager'
+
+const NO_ARTWORK = { header: null, capsule: null, capsule_v5: null, background: null, background_raw: null }
+
+function jsonResponse(body: BatchAppDetailsResult | undefined, ok = true, status = 200) {
+    return {
+        ok,
+        status,
+        statusText: ok ? 'OK' : 'Service Unavailable',
+        json: async () => body,
+    }
+}
+
+function makeBatchResult(appids: number[]): BatchAppDetailsResult {
+    return {
+        success: true,
+        total_requested: appids.length,
+        total_successful: appids.length,
+        total_failed: 0,
+        results: appids.map(appid => ({
+            success: true,
+            appid,
+            retrieved_at: '2026-01-01T00:00:00Z',
+            data: { name: `Game ${appid}`, type: 'game', is_free: false, artwork: NO_ARTWORK },
+        })),
+        timestamp: '2026-01-01T00:00:00Z',
+    }
+}
+
+describe('BatchAppDetailsClient', () => {
+    let fetchMock: ReturnType<typeof setupFetchMock>
+    let client: BatchAppDetailsClient
+
+    beforeEach(() => {
+        fetchMock = setupFetchMock()
+        // A fresh instance per test - the circuit breaker is shared per-instance by design (see
+        // its own doc comment), so "does an open circuit persist across calls" needs one instance
+        // reused across multiple fetchBatch() calls, while every other test needs a clean breaker.
+        client = new BatchAppDetailsClient('https://steam-api-dev.example.com', EventManager.getInstance())
+    })
+
+    it('fetches every batch and merges results when all succeed', async () => {
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse(makeBatchResult([1, 2])))
+            .mockResolvedValueOnce(jsonResponse(makeBatchResult([3, 4])))
+
+        const result = await client.fetchBatch([1, 2, 3, 4], { batchSize: 2 })
+
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        expect(result.size).toBe(4)
+        expect(result.get(3)?.data?.name).toBe('Game 3')
+    })
+
+    it('opens the circuit on the first hard failure and skips remaining batches without further requests', async () => {
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse(undefined, false, 503))
+            // Would succeed if called - proves the breaker, not luck, is what stops the loop.
+            .mockResolvedValueOnce(jsonResponse(makeBatchResult([3, 4])))
+            .mockResolvedValueOnce(jsonResponse(makeBatchResult([5, 6])))
+
+        const result = await client.fetchBatch([1, 2, 3, 4, 5, 6], { batchSize: 2 })
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(result.size).toBe(0)
+    })
+
+    it('keeps failing fast on a later call while the circuit is still open, without hitting the network again', async () => {
+        fetchMock.mockResolvedValueOnce(jsonResponse(undefined, false, 503))
+
+        const first = await client.fetchBatch([1, 2], { batchSize: 2 })
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(first.size).toBe(0)
+
+        fetchMock.mockClear()
+        const second = await client.fetchBatch([9, 10], { batchSize: 2 })
+
+        expect(fetchMock).not.toHaveBeenCalled()
+        expect(second.size).toBe(0)
+    })
+
+    it('still fetches successfully when the circuit is closed and every batch succeeds, even with several batches', async () => {
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse(makeBatchResult([1])))
+            .mockResolvedValueOnce(jsonResponse(makeBatchResult([2])))
+            .mockResolvedValueOnce(jsonResponse(makeBatchResult([3])))
+
+        const result = await client.fetchBatch([1, 2, 3], { batchSize: 1 })
+
+        expect(fetchMock).toHaveBeenCalledTimes(3)
+        expect(result.size).toBe(3)
+    })
+})

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -614,6 +614,11 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+cockatiel@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cockatiel/-/cockatiel-4.0.0.tgz#037b17beb3fc32e2825eb89eff71d7359bf651c0"
+  integrity sha512-XpUZJnogsd03BGB19T9sv7Xb8SwvD8JddZV2Tlp0LNspopZ6Idv24ZwCl8vAGJ6JwODZ0zLRYVj3NWvmRcUDqA==
+
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"


### PR DESCRIPTION
The old circuit breaker required 3 full-latency consecutive failures (each ~30s, since these are real 503 responses from a slow Lambda, not client timeouts) before opening, and forgot everything once fetchBatch() returned - worst case ~123s of pure waiting per startup, observed blocking the whole game-box placement behind it.

Now uses a real circuit breaker (cockatiel), shared per BatchAppDetailsClient instance so it persists across calls in the same session:
- Opens after the first hard failure - a 503 from our own Lambda is already an unambiguous signal, no reason to pay for two more.
- Skips remaining batches immediately once open (checked before even announcing the next batch), instead of attempting and paying for each one.
- Self-heals via exponential backoff (10s initial, capped at 5min) so a later call in the same session automatically retries once the backend recovers, rather than staying broken until an app restart.
- Logs onBreak/onHalfOpen/onReset so circuit state transitions are visible.