### PR TITLE
Remove dead fetchSingle(); note circuit-breaker gap in Lambda outboun…

### DIFF
--- a/client/src/steam/batch/BatchAppDetailsClient.ts
+++ b/client/src/steam/batch/BatchAppDetailsClient.ts
@@ -302,28 +302,4 @@ export class BatchAppDetailsClient {
             clearTimeout(timeoutId);
         }
     }
-
-    /**
-     * Fetch details for a single app (fallback to individual endpoint)
-     */
-    async fetchSingle(appid: number): Promise<AppDetailsResponse | null> {
-        try {
-            const response = await fetch(`${this.apiBaseUrl}/appdetails/${appid}`, {
-                method: 'GET',
-                headers: {
-                    'Accept': 'application/json'
-                }
-            });
-
-            if (!response.ok) {
-                BatchAppDetailsClient.logger.warn(`Single fetch failed for ${appid}: ${response.status}`)
-                return null;
-            }
-
-            return await response.json();
-        } catch (error) {
-            BatchAppDetailsClient.logger.error(`Error fetching appid ${appid}: ${String(error)}`)
-            return null;
-        }
-    }
 }

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -250,6 +250,22 @@ approach extend cleanly to meshes, or do meshes need a different policy shape th
 
 > No active trigger — explicitly deferred, conditional on something else landing first, or indefinite. Revisit when the stated condition is met, not on a schedule.
 
+## id: lambda-outbound-api-circuit-breaker
+**Priority**: Low
+**Effort**: ~1-2 hours (cockatiel is already a proven pattern here — see `client/src/steam/batch/BatchAppDetailsClient.ts` — just needs the Node/Lambda-side equivalent)
+**Context**: `BatchAppDetailsClient.ts` replaced its hand-rolled circuit breaker with cockatiel (2026-07-30) to stop hammering our own Lambda during an outage. A codebase-wide sweep for the same shape of problem while reviewing that change found it on the server side too, one hop closer to the actual flaky third party:
+- `getAppDetails()` in `external-tool/infrastructure/lambda-src/services/steam-api.js` calls the real Steam Store API per-appid (up to 5 concurrent), with hand-rolled retry that only backs off on HTTP 429 — a 5xx, timeout, or connection reset gets no backoff and no shared "stop trying" signal across the batch.
+- `fetchSteamSpyData()` in `external-tool/infrastructure/lambda-hydrator-src/index.js` has the same shape against the SteamSpy API.
+
+**Decision (for now)**: track it, don't fix. Neither Lambda has shown symptoms of this in practice; not worth the churn until one does.
+
+**Done when**:
+- Both functions share a per-process circuit breaker (cockatiel) around their outbound call, opening on any hard failure (not just 429) and skipping remaining concurrent/batch work once open, same shape as `BatchAppDetailsClient`'s fix
+
+**Related files**:
+- `external-tool/infrastructure/lambda-src/services/steam-api.js`
+- `external-tool/infrastructure/lambda-hydrator-src/index.js`
+
 ## id: personal-data-in-git-history
 **Priority**: High (privacy exposure on a public repo, but no active harm — it's the author's own account, not a third party's)
 **Effort**: Not yet scoped — needs its own careful pass (history rewrite tooling: `git filter-repo` or BFG, plus a force-push and coordinating anyone else with a clone)

--- a/external-tool/infrastructure/lambda-hydrator-src/index.js
+++ b/external-tool/infrastructure/lambda-hydrator-src/index.js
@@ -21,6 +21,7 @@ async function streamToBuffer(stream) {
 
 const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 
+// TD: lambda-outbound-api-circuit-breaker
 async function fetchSteamSpyData(appid, retryCount = 0, maxRetries = 3) {
   try {
     const url = `https://steamspy.com/api.php?request=appdetails&appid=${appid}`;

--- a/external-tool/infrastructure/lambda-src/services/steam-api.js
+++ b/external-tool/infrastructure/lambda-src/services/steam-api.js
@@ -9,12 +9,13 @@ const rateLimiter = new RateLimiter(5, 200); // Max 5 concurrent, 200ms between 
 
 /**
  * Get app details from Steam Store API with caching and retry logic
- * 
+ *
  * @param {string|number} appid - Steam application ID
  * @param {number} retryCount - Current retry attempt (internal use)
  * @param {number} maxRetries - Maximum retry attempts
  * @returns {Promise<Object>} Game details object
  */
+// TD: lambda-outbound-api-circuit-breaker
 async function getAppDetails(appid, retryCount = 0, maxRetries = 3) {
   if (!appid) {
     throw new Error('App ID is required');


### PR DESCRIPTION
…d calls

BatchAppDetailsClient.fetchSingle() duplicated fetchSingleBatch's raw fetch with no caller anywhere in src or tests - dead code, and it bypassed the circuit breaker other methods on this class now use.

Found while sweeping for other spots that could use the same cockatiel circuit breaker BatchAppDetailsClient just adopted. The Lambda-side outbound calls (steam-api.js's getAppDetails, the hydrator's fetchSteamSpyData) have the same shape of gap - hand-rolled retry-on-429-only, no shared "stop trying" state across a batch - but neither has shown symptoms in practice, so just tracked as tech debt (see docs/tech-debt.md) rather than fixed now.